### PR TITLE
实现编辑器批次：发帖 7a-7c、回复 6d/C4、图片队列 C5、表情面板 C6

### DIFF
--- a/app/src/main/java/io/github/nsreader/Navigation.kt
+++ b/app/src/main/java/io/github/nsreader/Navigation.kt
@@ -26,6 +26,7 @@ import io.github.nsreader.core.NodeSeekSite
 import io.github.nsreader.di.AppContainer
 import io.github.nsreader.ui.composer.PostComposerRoute
 import io.github.nsreader.ui.composer.PostComposerViewModel
+import io.github.nsreader.ui.composer.ReplyComposerViewModel
 import io.github.nsreader.ui.login.WebViewGoal
 import io.github.nsreader.ui.login.WebViewRoute
 import io.github.nsreader.ui.navigation.NodeSeekNavigationItems
@@ -214,8 +215,16 @@ fun MainNavigation(container: AppContainer) {
                             key = "post-${key.postId}",
                             factory = PostDetailViewModel.factory(container, key.postId),
                         )
+                    // Its own ViewModel, keyed the same way: an unsent reply belongs to one thread
+                    // and has to outlive the sheet that shows it.
+                    val replyViewModel: ReplyComposerViewModel =
+                        viewModel(
+                            key = "reply-${key.postId}",
+                            factory = ReplyComposerViewModel.factory(container, key.postId),
+                        )
                     PostDetailRoute(
                         viewModel = viewModel,
+                        replyViewModel = replyViewModel,
                         initialFloor = key.floor,
                         onBack = { backStack.removeLastOrNull() },
                         onOpenBrowser = openExternalUrl,

--- a/app/src/main/java/io/github/nsreader/data/composer/CommentComposerRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/composer/CommentComposerRepository.kt
@@ -1,0 +1,98 @@
+package io.github.nsreader.data.composer
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import io.github.nsreader.core.AppClock
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private val Context.commentComposerDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "comment-composer",
+)
+
+/**
+ * An unsent reply.
+ *
+ * [quotedFloor]/[quotedText] survive the round trip so reopening the sheet restores the quote chip
+ * along with the text — a reply written against a quote reads as a non sequitur without it.
+ */
+@Serializable
+data class CommentDraft(
+    val body: String = "",
+    val quotedFloor: Int? = null,
+    val quotedAuthor: String? = null,
+    val quotedText: String? = null,
+    val savedAtMillis: Long = 0L,
+) {
+    val hasContent: Boolean get() = body.isNotBlank()
+}
+
+data class CommentSubmission(
+    val postId: Long,
+    val body: String,
+    val quotedFloor: Int? = null,
+)
+
+interface CommentComposerRepository {
+    fun draft(postId: Long): Flow<CommentDraft?>
+
+    suspend fun saveDraft(postId: Long, draft: CommentDraft)
+
+    suspend fun deleteDraft(postId: Long)
+
+    /** @return the new floor number when the site reports one. */
+    suspend fun publish(submission: CommentSubmission): Int?
+}
+
+/**
+ * Drafts are real and local; publishing is not wired up yet.
+ *
+ * NodeSeek's comment endpoint has not been captured from a signed-in session, and this sandbox
+ * cannot reach the site to find out — every request comes back as a Cloudflare challenge. Rather
+ * than post to a guessed URL (which would fail in a way indistinguishable from an expired session,
+ * or worse, half-succeed), [publish] fails with a message that says what is actually missing. The
+ * editor's failure path is the same one a network error takes, so wiring the real request in later
+ * changes this class and nothing above it.
+ */
+class LocalCommentComposerRepository(
+    context: Context,
+    private val clock: AppClock,
+) : CommentComposerRepository {
+    private val dataStore = context.applicationContext.commentComposerDataStore
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun draft(postId: Long): Flow<CommentDraft?> = dataStore.data.map { preferences ->
+        preferences[key(postId)]?.let { encoded ->
+            runCatching { json.decodeFromString<CommentDraft>(encoded) }.getOrNull()
+        }
+    }
+
+    override suspend fun saveDraft(postId: Long, draft: CommentDraft) {
+        dataStore.edit { preferences ->
+            preferences[key(postId)] = json.encodeToString(draft.copy(savedAtMillis = clock.nowMillis()))
+        }
+    }
+
+    override suspend fun deleteDraft(postId: Long) {
+        dataStore.edit { preferences -> preferences.remove(key(postId)) }
+    }
+
+    override suspend fun publish(submission: CommentSubmission): Int? = throw NodeSeekException(
+        error = NodeSeekError.Unknown,
+        detail = UNAVAILABLE_DETAIL,
+    )
+
+    private fun key(postId: Long) = stringPreferencesKey("draft-$postId")
+
+    companion object {
+        const val UNAVAILABLE_DETAIL = "评论发布接口尚未接入"
+    }
+}

--- a/app/src/main/java/io/github/nsreader/data/composer/ImageUploadQueue.kt
+++ b/app/src/main/java/io/github/nsreader/data/composer/ImageUploadQueue.kt
@@ -1,0 +1,131 @@
+package io.github.nsreader.data.composer
+
+import io.github.nsreader.core.runCatchingExceptCancellation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/** An image the picker handed back, before the queue has given it an identity. */
+data class PickedImage(val source: String, val name: String)
+
+/**
+ * The attachment tray behind board C5, shared by the post editor and the reply editor.
+ *
+ * Uploads run **one at a time**. That is not a throttle for the server's benefit — it is what makes
+ * the four states in the design real rather than decorative: with a single worker there is always
+ * at most one "上传中" cell and the rest genuinely are "等待中". Uploading everything at once would
+ * leave the waiting state unreachable and the progress rings racing each other for attention.
+ *
+ * Removal is allowed at any point, including mid-upload. The worker therefore re-checks that a cell
+ * still exists before writing its result back, otherwise a finished upload would resurrect a row the
+ * user has already dismissed.
+ */
+class ImageUploadQueue(
+    private val scope: CoroutineScope,
+    private val uploader: ImageUploader,
+    private val newId: () -> String = { UUID.randomUUID().toString() },
+) {
+    private val _attachments = MutableStateFlow<List<ImageAttachment>>(emptyList())
+    val attachments: StateFlow<List<ImageAttachment>> = _attachments.asStateFlow()
+
+    /**
+     * Emits each attachment as it lands, so the editor can insert the Markdown at that moment
+     * rather than polling the list for new URLs.
+     */
+    private val _uploaded = MutableSharedFlow<ImageAttachment>(extraBufferCapacity = 16)
+    val uploaded: SharedFlow<ImageAttachment> = _uploaded.asSharedFlow()
+
+    private var worker: Job? = null
+
+    fun enqueue(images: List<PickedImage>) {
+        if (images.isEmpty()) return
+        _attachments.update { current ->
+            current + images.map { picked ->
+                ImageAttachment(id = newId(), source = picked.source, name = picked.name)
+            }
+        }
+        pump()
+    }
+
+    /** @return the removed attachment, so a caller can strip its Markdown out of the body. */
+    fun remove(id: String): ImageAttachment? {
+        val removed = _attachments.value.firstOrNull { it.id == id } ?: return null
+        _attachments.update { current -> current.filterNot { it.id == id } }
+        return removed
+    }
+
+    fun retry(id: String) {
+        _attachments.update { current ->
+            current.map { attachment ->
+                if (attachment.id == id && attachment.status == UploadStatus.FAILED) {
+                    attachment.copy(status = UploadStatus.WAITING, progress = 0f)
+                } else {
+                    attachment
+                }
+            }
+        }
+        pump()
+    }
+
+    fun retryFailed() {
+        _attachments.update { current ->
+            current.map { attachment ->
+                if (attachment.status == UploadStatus.FAILED) {
+                    attachment.copy(status = UploadStatus.WAITING, progress = 0f)
+                } else {
+                    attachment
+                }
+            }
+        }
+        pump()
+    }
+
+    fun clear() {
+        worker?.cancel()
+        worker = null
+        _attachments.value = emptyList()
+    }
+
+    private fun pump() {
+        if (worker?.isActive == true) return
+        worker = scope.launch {
+            while (true) {
+                val next = _attachments.value.firstOrNull { it.status == UploadStatus.WAITING } ?: break
+                mutate(next.id) { it.copy(status = UploadStatus.UPLOADING, progress = 0f) }
+                val result = runCatchingExceptCancellation {
+                    uploader.upload(next) { progress ->
+                        mutate(next.id) { it.copy(progress = progress.coerceIn(0f, 1f)) }
+                    }
+                }
+                // Dismissed while it was in flight: neither outcome belongs on screen any more.
+                if (_attachments.value.none { it.id == next.id }) continue
+                result
+                    .onSuccess { url ->
+                        mutate(next.id) {
+                            it.copy(status = UploadStatus.UPLOADED, progress = 1f, remoteUrl = url)
+                        }
+                        _attachments.value.firstOrNull { it.id == next.id }?.let { _uploaded.emit(it) }
+                    }.onFailure {
+                        mutate(next.id) { it.copy(status = UploadStatus.FAILED) }
+                    }
+            }
+        }
+    }
+
+    private fun mutate(
+        id: String,
+        transform: (ImageAttachment) -> ImageAttachment,
+    ) {
+        _attachments.update { current ->
+            current.map { attachment -> if (attachment.id == id) transform(attachment) else attachment }
+        }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/data/composer/ImageUploader.kt
+++ b/app/src/main/java/io/github/nsreader/data/composer/ImageUploader.kt
@@ -1,0 +1,70 @@
+package io.github.nsreader.data.composer
+
+import androidx.compose.runtime.Immutable
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+
+/** Where an attachment is in its trip to the image host. Board C5 draws one cell per value. */
+enum class UploadStatus { WAITING, UPLOADING, UPLOADED, FAILED }
+
+/**
+ * One picked image on its way into the body.
+ *
+ * [source] is the content URI the picker handed us and stays put for the retry path; [remoteUrl] is
+ * only non-null once the host has answered, and is what gets written into the Markdown.
+ */
+@Immutable
+data class ImageAttachment(
+    val id: String,
+    val source: String,
+    val name: String,
+    val status: UploadStatus = UploadStatus.WAITING,
+    /** 0f–1f, meaningful only while [status] is [UploadStatus.UPLOADING]. */
+    val progress: Float = 0f,
+    val remoteUrl: String? = null,
+) {
+    /** What gets inserted into the body — and, on removal, deleted from it again. */
+    val markdown: String? get() = remoteUrl?.let { "![$name]($it)" }
+}
+
+/**
+ * Uploads one image and reports progress.
+ *
+ * An interface rather than a concrete class because the host is the one part of the editor we have
+ * not been able to observe: NodeSeek's editor says "NodeImage已就绪" and inline images come back as
+ * `https://cdn.nodeimage.com/i/<id>.webp`, but the upload request itself has never been captured
+ * from a signed-in session, and this sandbox cannot reach the site to find out (every request is
+ * answered by Cloudflare). See [NodeImageUploader].
+ */
+fun interface ImageUploader {
+    /**
+     * @param onProgress called with 0f–1f as bytes go out; the queue turns this into the ring in C5.
+     * @throws NodeSeekException when the upload cannot be completed.
+     */
+    suspend fun upload(
+        attachment: ImageAttachment,
+        onProgress: (Float) -> Unit,
+    ): String
+}
+
+/**
+ * The placeholder that keeps the failure honest.
+ *
+ * Every upload fails with a message saying the endpoint is not wired up, which is exactly what the
+ * user sees: the queue moves the cell to [UploadStatus.FAILED] and offers a retry, the same path a
+ * real network failure takes. Swapping in the real request is a one-class change once the
+ * multipart shape has been captured on a device — nothing above this interface has to move.
+ */
+class NodeImageUploader : ImageUploader {
+    override suspend fun upload(
+        attachment: ImageAttachment,
+        onProgress: (Float) -> Unit,
+    ): String = throw NodeSeekException(
+        error = NodeSeekError.Unknown,
+        detail = UNAVAILABLE_DETAIL,
+    )
+
+    companion object {
+        const val UNAVAILABLE_DETAIL = "NodeImage 上传接口尚未接入"
+    }
+}

--- a/app/src/main/java/io/github/nsreader/data/composer/ImageUploader.kt
+++ b/app/src/main/java/io/github/nsreader/data/composer/ImageUploader.kt
@@ -23,8 +23,19 @@ data class ImageAttachment(
     val progress: Float = 0f,
     val remoteUrl: String? = null,
 ) {
-    /** What gets inserted into the body — and, on removal, deleted from it again. */
-    val markdown: String? get() = remoteUrl?.let { "![$name]($it)" }
+    /**
+     * What gets inserted into the body — and, on removal, deleted from it again.
+     *
+     * The display name comes from a content provider, which is allowed to answer with anything;
+     * a `]` or `(` in it would end the alt text early and leave broken syntax the removal path
+     * could no longer find.
+     */
+    val markdown: String?
+        get() = remoteUrl?.let { url -> "![${name.replace(ALT_UNSAFE, " ").trim()}]($url)" }
+
+    private companion object {
+        val ALT_UNSAFE = Regex("""[\[\]()]""")
+    }
 }
 
 /**

--- a/app/src/main/java/io/github/nsreader/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nsreader/di/AppContainer.kt
@@ -21,7 +21,11 @@ import io.github.nsreader.data.OfflineFirstPostRepository
 import io.github.nsreader.data.PostRepository
 import io.github.nsreader.data.ProfileRepository
 import io.github.nsreader.data.SearchRepository
+import io.github.nsreader.data.composer.CommentComposerRepository
 import io.github.nsreader.data.composer.DefaultPostComposerRepository
+import io.github.nsreader.data.composer.ImageUploader
+import io.github.nsreader.data.composer.LocalCommentComposerRepository
+import io.github.nsreader.data.composer.NodeImageUploader
 import io.github.nsreader.data.composer.PostComposerRepository
 import io.github.nsreader.data.local.NodeSeekDatabase
 import io.github.nsreader.data.session.SessionRepository
@@ -50,6 +54,8 @@ interface AppContainer {
     val profileRepository: ProfileRepository
     val searchRepository: SearchRepository
     val postComposerRepository: PostComposerRepository
+    val commentComposerRepository: CommentComposerRepository
+    val imageUploader: ImageUploader
     val sessionRepository: SessionRepository
 
     /**
@@ -131,6 +137,12 @@ class DefaultAppContainer(
     override val postComposerRepository: PostComposerRepository by lazy {
         DefaultPostComposerRepository(appContext, okHttpClient, dispatchers, clock)
     }
+
+    override val commentComposerRepository: CommentComposerRepository by lazy {
+        LocalCommentComposerRepository(appContext, clock)
+    }
+
+    override val imageUploader: ImageUploader by lazy { NodeImageUploader() }
 
     /**
      * Shares the cookie jar rather than owning a store of its own: the cookies OkHttp sends and the

--- a/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.graphics.vector.addPathNodes
 import androidx.compose.ui.unit.dp
 
 /**
- * The four Material Symbols the design uses that `material-icons-core` does not ship.
+ * The Material Symbols the design uses that `material-icons-core` does not ship.
  *
  * Declared here rather than pulling in `material-icons-extended`, which would add roughly two
  * thousand unused vectors — and, more to the point, a dependency-graph change that this project's
@@ -111,6 +111,140 @@ object NodeSeekIcons {
             "M15,3H6c-0.8,0 -1.5,0.5 -1.8,1.2L1.1,11.3C0.6,12.6 1.5,14 3,14h5.7" +
                 "l-1,4.6C7.5,19.4 8.1,20 8.8,20h0.4c0.4,0 0.8,-0.2 1.1,-0.5L16,13.8V5" +
                 "c0,-1.1 -0.9,-2 -2,-2zM18,3v11h4V3z",
+        )
+    }
+
+    // --- Editor toolbar (boards 6d / 7a / c5 / c6) ---------------------------
+
+    val FormatBold: ImageVector by lazy {
+        materialIcon(
+            name = "FormatBold",
+            pathData =
+            "M15.6,10.79c0.97,-0.67 1.65,-1.77 1.65,-2.79c0,-2.26 -1.75,-4 -4,-4H7v14h7.04" +
+                "c2.09,0 3.71,-1.7 3.71,-3.79c0,-1.52 -0.86,-2.82 -2.15,-3.42z" +
+                "M10,6.5h3c0.83,0 1.5,0.67 1.5,1.5s-0.67,1.5 -1.5,1.5h-3V6.5z" +
+                "M13.5,15.5H10v-3h3.5c0.83,0 1.5,0.67 1.5,1.5s-0.67,1.5 -1.5,1.5z",
+        )
+    }
+
+    /** Heading. Material's `title` glyph rather than `format_h2`, which is text rendered as a path. */
+    val Title: ImageVector by lazy {
+        materialIcon(name = "Title", pathData = "M5,4v3h5.5v12h3V7H19V4z")
+    }
+
+    val Code: ImageVector by lazy {
+        materialIcon(
+            name = "Code",
+            pathData =
+            "M9.4,16.6L4.8,12l4.6,-4.6L8,6l-6,6 6,6 1.4,-1.4z" +
+                "M14.6,16.6l4.6,-4.6 -4.6,-4.6L16,6l6,6 -6,6 -1.4,-1.4z",
+        )
+    }
+
+    val FormatQuote: ImageVector by lazy {
+        materialIcon(
+            name = "FormatQuote",
+            pathData = "M6,17h3l2,-4V7H5v6h3zM14,17h3l2,-4V7h-6v6h3z",
+        )
+    }
+
+    val FormatListBulleted: ImageVector by lazy {
+        materialIcon(
+            name = "FormatListBulleted",
+            pathData =
+            "M4,10.5c-0.83,0 -1.5,0.67 -1.5,1.5s0.67,1.5 1.5,1.5 1.5,-0.67 1.5,-1.5 -0.67,-1.5 -1.5,-1.5z" +
+                "M4,4.5c-0.83,0 -1.5,0.67 -1.5,1.5S3.17,7.5 4,7.5 5.5,6.83 5.5,6 4.83,4.5 4,4.5z" +
+                "M4,16.5c-0.83,0 -1.5,0.68 -1.5,1.5s0.68,1.5 1.5,1.5 1.5,-0.68 1.5,-1.5 -0.67,-1.5 -1.5,-1.5z" +
+                "M7,19h14v-2H7v2zM7,13h14v-2H7v2zM7,5v2h14V5H7z",
+        )
+    }
+
+    val Link: ImageVector by lazy {
+        materialIcon(
+            name = "Link",
+            pathData =
+            "M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4V7H7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9H7" +
+                "c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2H8v2zM17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1" +
+                "s-1.39,3.1 -3.1,3.1h-4V17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z",
+        )
+    }
+
+    val Image: ImageVector by lazy {
+        materialIcon(
+            name = "Image",
+            pathData =
+            "M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2z" +
+                "M8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z",
+        )
+    }
+
+    /** The emoji panel's entry point. */
+    val Mood: ImageVector by lazy {
+        materialIcon(
+            name = "Mood",
+            pathData =
+            "M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2z" +
+                "M12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z" +
+                "M15.5,11c0.83,0 1.5,-0.67 1.5,-1.5S16.33,8 15.5,8 14,8.67 14,9.5s0.67,1.5 1.5,1.5z" +
+                "M8.5,11c0.83,0 1.5,-0.67 1.5,-1.5S9.33,8 8.5,8 7,8.67 7,9.5 7.67,11 8.5,11z" +
+                "M12,17.5c2.33,0 4.31,-1.46 5.11,-3.5H6.89c0.8,2.04 2.78,3.5 5.11,3.5z",
+        )
+    }
+
+    /** Mentions another member; the reply editor's `@`. */
+    val AlternateEmail: ImageVector by lazy {
+        materialIcon(
+            name = "AlternateEmail",
+            pathData =
+            "M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10h5v-2h-5c-4.34,0 -8,-3.66 -8,-8s3.66,-8 8,-8 8,3.66 8,8" +
+                "v1.43c0,0.79 -0.71,1.57 -1.5,1.57s-1.5,-0.78 -1.5,-1.57V12c0,-2.76 -2.24,-5 -5,-5s-5,2.24 -5,5" +
+                " 2.24,5 5,5c1.38,0 2.64,-0.56 3.54,-1.47 0.65,0.89 1.77,1.47 2.96,1.47 1.97,0 3.5,-1.6 3.5,-3.57" +
+                "V12c0,-5.52 -4.48,-10 -10,-10zM12,15c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3z",
+        )
+    }
+
+    /** The emoji panel's delete key. */
+    val Backspace: ImageVector by lazy {
+        materialIcon(
+            name = "Backspace",
+            pathData =
+            "M22,3H7c-0.69,0 -1.23,0.35 -1.59,0.88L0,12l5.41,8.11c0.36,0.53 0.9,0.89 1.59,0.89h15" +
+                "c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2zM19,15.59L17.59,17 14,13.41 10.41,17 9,15.59 12.59,12" +
+                " 9,8.41 10.41,7 14,10.59 17.59,7 19,8.41 15.41,12 19,15.59z",
+        )
+    }
+
+    /** The forum rules card on the publish preview. */
+    val Campaign: ImageVector by lazy {
+        materialIcon(
+            name = "Campaign",
+            pathData =
+            "M18,11v2h4v-2h-4zM16,17.61c0.96,0.71 2.21,1.65 3.2,2.39 0.4,-0.53 0.8,-1.07 1.2,-1.6" +
+                " -0.99,-0.74 -2.24,-1.68 -3.2,-2.4 -0.4,0.54 -0.8,1.08 -1.2,1.61z" +
+                "M20.4,5.6c-0.4,-0.53 -0.8,-1.07 -1.2,-1.6 -0.99,0.74 -2.24,1.68 -3.2,2.4 0.4,0.53 0.8,1.07 1.2,1.6" +
+                " 0.96,-0.72 2.21,-1.65 3.2,-2.4zM4,9c-1.1,0 -2,0.9 -2,2v2c0,1.1 0.9,2 2,2h1v4h2v-4h1l5,3V6L8,9H4z" +
+                "M15.5,12c0,-1.33 -0.58,-2.53 -1.5,-3.35v6.69c0.92,-0.81 1.5,-2.01 1.5,-3.34z",
+        )
+    }
+
+    /** Draft recovery. */
+    val Drafts: ImageVector by lazy {
+        materialIcon(
+            name = "Drafts",
+            pathData =
+            "M21.99,8c0,-0.72 -0.37,-1.35 -0.94,-1.7L12,1 2.95,6.3C2.38,6.65 2,7.28 2,8v10c0,1.1 0.9,2 2,2h16" +
+                "c1.1,0 2,-0.9 2,-2l-0.01,-10zM12,13L3.74,7.84 12,3l8.26,4.84L12,13z",
+        )
+    }
+
+    /** An attachment that has not started uploading yet. */
+    val Schedule: ImageVector by lazy {
+        materialIcon(
+            name = "Schedule",
+            pathData =
+            "M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2z" +
+                "M12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z" +
+                "M12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z",
         )
     }
 }

--- a/app/src/main/java/io/github/nsreader/ui/composer/AttachmentTray.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/AttachmentTray.kt
@@ -1,0 +1,225 @@
+package io.github.nsreader.ui.composer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import io.github.nsreader.R
+import io.github.nsreader.data.composer.ImageAttachment
+import io.github.nsreader.data.composer.UploadStatus
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.theme.Spacing
+import kotlin.math.roundToInt
+
+/**
+ * The attachment strip from C5, shared by both editors.
+ *
+ * All four states sit side by side on purpose: uploads run one at a time, so "等待中" is a real
+ * state a user with four screenshots will see, and showing it beats a spinner that implies
+ * everything is moving at once. A failed cell is itself the retry target — the label says so — and
+ * the batch retry lives on the Snackbar the caller shows.
+ */
+@Composable
+fun AttachmentTray(
+    attachments: List<ImageAttachment>,
+    onRemove: (ImageAttachment) -> Unit,
+    onRetry: (ImageAttachment) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (attachments.isEmpty()) return
+    Row(
+        modifier = modifier
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        attachments.forEach { attachment ->
+            AttachmentCell(
+                attachment = attachment,
+                onRemove = { onRemove(attachment) },
+                onRetry = { onRetry(attachment) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun AttachmentCell(
+    attachment: ImageAttachment,
+    onRemove: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    val failed = attachment.status == UploadStatus.FAILED
+    val retryDescription = stringResource(R.string.composer_image_retry_one, attachment.name)
+    // The dismiss badge hangs off the thumbnail's corner, so the cell reserves the overhang rather
+    // than letting the Row clip it.
+    Box(modifier = Modifier.padding(top = BADGE_OVERHANG, end = BADGE_OVERHANG)) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(
+                modifier = Modifier
+                    .size(THUMBNAIL)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(
+                        if (attachment.status == UploadStatus.WAITING) {
+                            MaterialTheme.colorScheme.surfaceContainerLow
+                        } else {
+                            MaterialTheme.colorScheme.surfaceContainer
+                        },
+                    ).then(
+                        if (failed) {
+                            Modifier.border(2.dp, MaterialTheme.colorScheme.error, RoundedCornerShape(12.dp))
+                        } else {
+                            Modifier
+                        },
+                    ).then(
+                        if (failed) Modifier.clickable(onClick = onRetry).semantics { contentDescription = retryDescription } else Modifier,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                when (attachment.status) {
+                    UploadStatus.UPLOADING -> {
+                        Thumbnail(attachment, dimmed = true)
+                        CircularProgressIndicator(
+                            progress = { attachment.progress },
+                            modifier = Modifier.size(34.dp),
+                            strokeWidth = 4.dp,
+                            trackColor = MaterialTheme.colorScheme.outlineVariant,
+                        )
+                    }
+
+                    UploadStatus.UPLOADED -> {
+                        Thumbnail(attachment, dimmed = false)
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(4.dp)
+                                .size(18.dp)
+                                .clip(CircleShape)
+                                .background(MaterialTheme.colorScheme.surfaceContainerLowest),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.CheckCircle,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    }
+
+                    UploadStatus.FAILED -> Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(26.dp),
+                    )
+
+                    UploadStatus.WAITING -> Icon(
+                        imageVector = NodeSeekIcons.Schedule,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
+            Text(
+                text = attachment.statusLabel(),
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 11.sp,
+                fontWeight = if (failed) FontWeight.SemiBold else FontWeight.Normal,
+                color = if (failed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = Spacing.xs).size(width = THUMBNAIL, height = 16.dp),
+            )
+        }
+        RemoveBadge(name = attachment.name, onClick = onRemove, modifier = Modifier.align(Alignment.TopEnd))
+    }
+}
+
+@Composable
+private fun Thumbnail(
+    attachment: ImageAttachment,
+    dimmed: Boolean,
+) {
+    AsyncImage(
+        model = attachment.source,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier.size(THUMBNAIL),
+    )
+    if (dimmed) {
+        Box(Modifier.size(THUMBNAIL).background(Color.Black.copy(alpha = SCRIM_ALPHA)))
+    }
+}
+
+@Composable
+private fun RemoveBadge(
+    name: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(R.string.composer_image_remove, name)
+    Box(
+        modifier = modifier
+            .size(20.dp)
+            .clip(CircleShape)
+            .background(Color.Black.copy(alpha = BADGE_ALPHA))
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(13.dp),
+        )
+    }
+}
+
+@Composable
+private fun ImageAttachment.statusLabel(): String = when (status) {
+    UploadStatus.UPLOADING -> stringResource(R.string.composer_image_uploading, (progress * 100).roundToInt())
+    UploadStatus.UPLOADED -> stringResource(R.string.composer_image_uploaded)
+    UploadStatus.FAILED -> stringResource(R.string.composer_image_failed)
+    UploadStatus.WAITING -> stringResource(R.string.composer_image_waiting)
+}
+
+private val THUMBNAIL = 68.dp
+private val BADGE_OVERHANG = 6.dp
+private const val BADGE_ALPHA = 0.55f
+private const val SCRIM_ALPHA = 0.35f

--- a/app/src/main/java/io/github/nsreader/ui/composer/ComposerPreview.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/ComposerPreview.kt
@@ -1,0 +1,132 @@
+package io.github.nsreader.ui.composer
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.R
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.richtext.RichContent
+import io.github.nsreader.ui.theme.PostBody
+import io.github.nsreader.ui.theme.Spacing
+
+/**
+ * The site's right-hand rules card, moved to the top of the publish preview.
+ *
+ * Global and permanent, not per-board and not dismissible — that was the correction in §0.8 of the
+ * requirements against the earlier drafts, which had it as a 技术-only notice with a close button.
+ */
+@Composable
+fun RuleReminderCard(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        shape = RoundedCornerShape(14.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = Spacing.md),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm + 2.dp),
+        ) {
+            Icon(NodeSeekIcons.Campaign, contentDescription = null, modifier = Modifier.size(20.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                    text = stringResource(R.string.composer_rule_title),
+                    style = MaterialTheme.typography.labelMedium,
+                )
+                Text(
+                    text = stringResource(R.string.composer_rule_body),
+                    style = MaterialTheme.typography.labelSmall,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Renders draft Markdown with the reading screen's own typography.
+ *
+ * The point of a preview is to be wrong in none of the ways that matter, so it goes through the
+ * same [RichContent] the detail screen uses rather than a lighter-weight renderer — a code block
+ * that wraps differently here than after publishing is a preview that cannot be trusted.
+ */
+@Composable
+fun MarkdownPreviewBody(
+    markdown: String,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = PostBody,
+) {
+    val uriHandler = LocalUriHandler.current
+    val nodes = remember(markdown) { parseMarkdown(markdown) }
+    if (nodes.isEmpty()) {
+        Text(
+            text = stringResource(R.string.composer_preview_empty),
+            style = textStyle,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier,
+        )
+        return
+    }
+    val openExternally: (String) -> Unit = { url ->
+        if (NodeSeekSite.isExternalWebUrl(url)) runCatching { uriHandler.openUri(url) }
+    }
+    RichContent(
+        nodes = nodes,
+        onLinkClick = openExternally,
+        onImageClick = openExternally,
+        textStyle = textStyle,
+        modifier = modifier,
+    )
+}
+
+/** The board chip + author + "刚刚" line under the preview title (7b). */
+@Composable
+fun PreviewByline(
+    boardTitle: String?,
+    authorName: String?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm + 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        boardTitle?.let {
+            Surface(
+                color = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                shape = RoundedCornerShape(8.dp),
+            ) {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(horizontal = 9.dp, vertical = 2.dp),
+                )
+            }
+        }
+        authorName?.let {
+            Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Text(
+            text = stringResource(R.string.composer_just_now),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/composer/EditorToolbar.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/EditorToolbar.kt
@@ -167,7 +167,10 @@ fun <T> ViewModeSwitch(
         ) {
             options.forEach { option ->
                 val isSelected = option == selected
+                // The selectable overload, so TalkBack announces which of the three views is
+                // active — colour is the only visual cue and reads as nothing.
                 Surface(
+                    selected = isSelected,
                     onClick = { onSelect(option) },
                     shape = MaterialTheme.shapes.extraLarge,
                     color = if (isSelected) {

--- a/app/src/main/java/io/github/nsreader/ui/composer/EditorToolbar.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/EditorToolbar.kt
@@ -1,0 +1,195 @@
+package io.github.nsreader.ui.composer
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.nsreader.R
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.theme.Spacing
+
+/**
+ * The formatting strip that sits on the keyboard's top edge.
+ *
+ * Shared by the post editor (7a/C5) and the reply sheet (6d/C6) — same component, different action
+ * list and different trailing control.
+ *
+ * The trailing control is pinned and the keys scroll under it. Measured on a 360dp phone, seven
+ * 32dp keys and a 发布 button fit with a few dp to spare — which means they stop fitting the moment
+ * the system font scale goes up, and of the two, a key you have to scroll to is far less costly
+ * than a publish button you cannot see.
+ *
+ * [active] is what marks the toggled-open panels — the image and emoji keys stay lit while their
+ * sheet is showing, which is the only cue that tapping again closes it.
+ */
+@Composable
+fun EditorToolbar(
+    actions: List<EditorAction>,
+    onAction: (EditorAction) -> Unit,
+    modifier: Modifier = Modifier,
+    active: Set<EditorAction> = emptySet(),
+    showDivider: Boolean = true,
+    trailing: @Composable RowScope.() -> Unit = {},
+) {
+    Surface(color = MaterialTheme.colorScheme.surface, modifier = modifier) {
+        Box {
+            if (showDivider) {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    modifier = Modifier
+                        .weight(1f)
+                        .horizontalScroll(rememberScrollState()),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    actions.forEach { action ->
+                        ToolbarButton(
+                            action = action,
+                            selected = action in active,
+                            onClick = { onAction(action) },
+                        )
+                    }
+                }
+                trailing()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToolbarButton(
+    action: EditorAction,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        // 32dp box, 48dp touch target: `IconButton` keeps the minimum interactive size regardless
+        // of how small the drawn button is, which is what lets the strip match the board's density
+        // without dropping below the accessibility floor.
+        modifier = Modifier.size(32.dp),
+        colors = if (selected) {
+            IconButtonDefaults.iconButtonColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                contentColor = MaterialTheme.colorScheme.primary,
+            )
+        } else {
+            IconButtonDefaults.iconButtonColors(
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Icon(
+            imageVector = action.icon,
+            contentDescription = stringResource(action.labelRes),
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+private val EditorAction.icon: ImageVector
+    get() = when (this) {
+        EditorAction.BOLD -> NodeSeekIcons.FormatBold
+        EditorAction.HEADING -> NodeSeekIcons.Title
+        EditorAction.CODE -> NodeSeekIcons.Code
+        EditorAction.QUOTE -> NodeSeekIcons.FormatQuote
+        EditorAction.LIST -> NodeSeekIcons.FormatListBulleted
+        EditorAction.LINK -> NodeSeekIcons.Link
+        EditorAction.MENTION -> NodeSeekIcons.AlternateEmail
+        EditorAction.IMAGE -> NodeSeekIcons.Image
+        EditorAction.EMOJI -> NodeSeekIcons.Mood
+        EditorAction.PREVIEW -> NodeSeekIcons.Visibility
+    }
+
+private val EditorAction.labelRes: Int
+    get() = when (this) {
+        EditorAction.BOLD -> R.string.composer_format_bold
+        EditorAction.HEADING -> R.string.composer_format_heading
+        EditorAction.CODE -> R.string.composer_format_code
+        EditorAction.QUOTE -> R.string.composer_format_quote
+        EditorAction.LIST -> R.string.composer_format_list
+        EditorAction.LINK -> R.string.composer_format_link
+        EditorAction.MENTION -> R.string.composer_format_mention
+        EditorAction.IMAGE -> R.string.composer_format_image
+        EditorAction.EMOJI -> R.string.composer_format_emoji
+        EditorAction.PREVIEW -> R.string.action_preview
+    }
+
+/**
+ * The 内容 / 预览 / 对照 switch from 7a.
+ *
+ * A hand-built pill rather than `SingleChoiceSegmentedButtonRow`: the segmented button's own 40dp
+ * height and check-mark affordance push the toolbar past the point where the keyboard fits, and the
+ * three options here are views of one thing rather than a choice being made.
+ */
+@Composable
+fun <T> ViewModeSwitch(
+    options: List<T>,
+    selected: T,
+    label: @Composable (T) -> String,
+    onSelect: (T) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Row(
+            modifier = Modifier.padding(2.dp),
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            options.forEach { option ->
+                val isSelected = option == selected
+                Surface(
+                    onClick = { onSelect(option) },
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = if (isSelected) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    },
+                    contentColor = if (isSelected) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                ) {
+                    Text(
+                        text = label(option),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = Spacing.sm),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/composer/EmojiPanel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/EmojiPanel.kt
@@ -1,0 +1,277 @@
+package io.github.nsreader.ui.composer
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.nsreader.R
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.theme.Spacing
+
+/**
+ * One of the five groups NodeSeek's own editor offers.
+ *
+ * The first three are image stickers hosted by the site. Their asset URLs have never been captured
+ * — the sandbox cannot reach nodeseek.com — and inserting a guessed URL would publish a broken
+ * image into a real thread, so those groups carry no entries and say so. Filling them in is a change
+ * to this list alone: give the group its [EmojiEntry.Sticker] items and the panel starts working.
+ */
+data class EmojiGroup(
+    @param:StringRes val titleRes: Int,
+    val entries: List<EmojiEntry>,
+)
+
+sealed interface EmojiEntry {
+    /** Inserted as-is. Fluent and App are plain Unicode, which is why they work today. */
+    data class Unicode(val character: String) : EmojiEntry
+
+    /** Inserted as a Markdown image, the way the site stores stickers. */
+    data class Sticker(val name: String, val url: String) : EmojiEntry
+}
+
+val EmojiEntry.insertion: String
+    get() = when (this) {
+        is EmojiEntry.Unicode -> character
+        is EmojiEntry.Sticker -> "![$name]($url)"
+    }
+
+val NodeSeekEmojiGroups = listOf(
+    EmojiGroup(R.string.composer_emoji_group_acn, emptyList()),
+    EmojiGroup(R.string.composer_emoji_group_onion, emptyList()),
+    EmojiGroup(R.string.composer_emoji_group_chick, emptyList()),
+    EmojiGroup(
+        R.string.composer_emoji_group_fluent,
+        listOf(
+            "😀", "😄", "😅", "🤣", "🙂", "😉",
+            "😍", "😘", "🤔", "😐", "😴", "😭",
+            "😡", "👍", "👎", "🎉", "❤️", "🔥",
+        ).map(EmojiEntry::Unicode),
+    ),
+    EmojiGroup(
+        R.string.composer_emoji_group_app,
+        listOf(
+            "🍗", "✨", "🐧", "💻", "🌐", "🚀",
+            "📦", "🔧", "🐛", "📈", "💰", "🛒",
+            "🎯", "⚡", "🧪", "📌", "🔒", "🧵",
+        ).map(EmojiEntry::Unicode),
+    ),
+)
+
+/**
+ * The emoji panel from C6, shared by the post editor and the reply sheet.
+ *
+ * It replaces the keyboard rather than stacking on top of it — the board is explicit about this
+ * ("面板与键盘同高切换，不叠加"), and on a 360×800 screen a panel that stacks leaves two lines of
+ * the reply visible. The caller is responsible for dismissing the IME before showing it.
+ *
+ * Recently used emoji live in [rememberSaveable] rather than a repository: the list is worth
+ * keeping across a rotation or a process death, not worth a schema.
+ */
+@Composable
+fun EmojiPanel(
+    onInsert: (String) -> Unit,
+    onBackspace: () -> Unit,
+    modifier: Modifier = Modifier,
+    groups: List<EmojiGroup> = NodeSeekEmojiGroups,
+) {
+    // Opens on the first group that has anything in it, so the panel is useful the moment it shows.
+    var selectedIndex by rememberSaveable { mutableStateOf(groups.indexOfFirst { it.entries.isNotEmpty() }.coerceAtLeast(0)) }
+    var recent by rememberSaveable { mutableStateOf(listOf<String>()) }
+    val group = groups.getOrNull(selectedIndex) ?: groups.first()
+
+    fun insert(text: String) {
+        onInsert(text)
+        recent = (listOf(text) + recent.filterNot { it == text }).take(RECENT_LIMIT)
+    }
+
+    Surface(color = MaterialTheme.colorScheme.surfaceContainer, modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.xs + 2.dp)) {
+                groups.forEachIndexed { index, candidate ->
+                    GroupPill(
+                        title = stringResource(candidate.titleRes),
+                        selected = index == selectedIndex,
+                        onClick = { selectedIndex = index },
+                    )
+                }
+            }
+            Box(Modifier.fillMaxWidth().heightIn(min = GRID_MIN_HEIGHT)) {
+                if (group.entries.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.composer_emoji_stickers_pending),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.align(Alignment.Center).padding(horizontal = Spacing.xl),
+                    )
+                } else {
+                    EmojiGrid(entries = group.entries, onSelect = { insert(it.insertion) })
+                }
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RecentRow(recent = recent, onSelect = ::insert, modifier = Modifier.weight(1f))
+                BackspaceKey(onClick = onBackspace)
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupPill(
+    title: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(16.dp),
+        color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
+        )
+    }
+}
+
+@Composable
+private fun EmojiGrid(
+    entries: List<EmojiEntry>,
+    onSelect: (EmojiEntry) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        entries.chunked(COLUMNS).forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm), modifier = Modifier.fillMaxWidth()) {
+                row.forEach { entry ->
+                    EmojiCell(entry = entry, onClick = { onSelect(entry) }, modifier = Modifier.weight(1f))
+                }
+                // Keeps the last, partly filled row aligned with the ones above it.
+                repeat(COLUMNS - row.size) { Box(Modifier.weight(1f)) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmojiCell(
+    entry: EmojiEntry,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = when (entry) {
+        is EmojiEntry.Unicode -> entry.character
+        is EmojiEntry.Sticker -> entry.name
+    }
+    Box(
+        modifier = modifier
+            .height(46.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        when (entry) {
+            is EmojiEntry.Unicode -> Text(entry.character, fontSize = 24.sp)
+
+            is EmojiEntry.Sticker -> Text(
+                text = entry.name,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecentRow(
+    recent: List<String>,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            imageVector = NodeSeekIcons.History,
+            contentDescription = null,
+            modifier = Modifier.size(15.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = stringResource(R.string.composer_emoji_recent),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = Spacing.xs, end = Spacing.sm),
+        )
+        recent.forEach { entry ->
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable { onSelect(entry) },
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(entry, fontSize = 18.sp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun BackspaceKey(onClick: () -> Unit) {
+    val description = stringResource(R.string.composer_emoji_backspace)
+    Box(
+        modifier = Modifier
+            .width(56.dp)
+            .height(40.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = description },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = NodeSeekIcons.Backspace,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private const val COLUMNS = 6
+private const val RECENT_LIMIT = 6
+private val GRID_MIN_HEIGHT = 162.dp

--- a/app/src/main/java/io/github/nsreader/ui/composer/EmojiPanel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/EmojiPanel.kt
@@ -92,24 +92,26 @@ val NodeSeekEmojiGroups = listOf(
  * ("面板与键盘同高切换，不叠加"), and on a 360×800 screen a panel that stacks leaves two lines of
  * the reply visible. The caller is responsible for dismissing the IME before showing it.
  *
- * Recently used emoji live in [rememberSaveable] rather than a repository: the list is worth
- * keeping across a rotation or a process death, not worth a schema.
+ * [recent] is hoisted rather than remembered here: the panel is conditionally composed, so any
+ * state it held itself would be thrown away every time the panel closes — which is exactly when
+ * the recents were just used and are worth keeping.
  */
 @Composable
 fun EmojiPanel(
     onInsert: (String) -> Unit,
     onBackspace: () -> Unit,
+    recent: List<String>,
+    onRecentChange: (List<String>) -> Unit,
     modifier: Modifier = Modifier,
     groups: List<EmojiGroup> = NodeSeekEmojiGroups,
 ) {
     // Opens on the first group that has anything in it, so the panel is useful the moment it shows.
     var selectedIndex by rememberSaveable { mutableStateOf(groups.indexOfFirst { it.entries.isNotEmpty() }.coerceAtLeast(0)) }
-    var recent by rememberSaveable { mutableStateOf(listOf<String>()) }
     val group = groups.getOrNull(selectedIndex) ?: groups.first()
 
     fun insert(text: String) {
         onInsert(text)
-        recent = (listOf(text) + recent.filterNot { it == text }).take(RECENT_LIMIT)
+        onRecentChange((listOf(text) + recent.filterNot { it == text }).take(RECENT_LIMIT))
     }
 
     Surface(color = MaterialTheme.colorScheme.surfaceContainer, modifier = modifier) {
@@ -155,7 +157,9 @@ private fun GroupPill(
     selected: Boolean,
     onClick: () -> Unit,
 ) {
+    // The selectable overload, so a screen reader hears which group is open.
     Surface(
+        selected = selected,
         onClick = onClick,
         shape = RoundedCornerShape(16.dp),
         color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerLow,

--- a/app/src/main/java/io/github/nsreader/ui/composer/MarkdownEditing.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/MarkdownEditing.kt
@@ -1,0 +1,125 @@
+package io.github.nsreader.ui.composer
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+
+/**
+ * Everything the editor toolbar can do.
+ *
+ * The site's own editor carries fifteen keys (§1.6). A phone toolbar that tried to match it would
+ * either scroll — hiding the actions people actually use behind a swipe — or shrink below the 48dp
+ * target, so the boards pick six or seven per surface and this enum is the union of those picks.
+ * [IMAGE], [EMOJI] and [PREVIEW] open something rather than rewriting text; the screen handles them.
+ */
+enum class EditorAction { BOLD, HEADING, CODE, QUOTE, LIST, LINK, MENTION, IMAGE, EMOJI, PREVIEW }
+
+/** True when the action rewrites the body itself, which is what [applyMarkdown] can act on. */
+val EditorAction.isTextTransform: Boolean
+    get() = this !in setOf(EditorAction.IMAGE, EditorAction.EMOJI, EditorAction.PREVIEW)
+
+/**
+ * Applies one toolbar action to the current selection.
+ *
+ * Two shapes, both operating on [TextFieldValue] rather than a plain string so the caret lands
+ * somewhere useful afterwards — an editor that formats correctly but drops the caret at the end of
+ * the document makes people stop using the toolbar:
+ *
+ * - **Wrapping** (bold, inline code, links) surrounds the selection, or inserts a placeholder and
+ *   selects it so the next keystroke replaces it.
+ * - **Line prefixes** (heading, quote, list) toggle at the start of the caret's line, so tapping
+ *   the same key twice undoes it instead of stacking `>> `.
+ */
+fun applyMarkdown(
+    value: TextFieldValue,
+    action: EditorAction,
+): TextFieldValue = when (action) {
+    EditorAction.BOLD -> value.wrap("**", "**", "加粗文字")
+    EditorAction.CODE -> value.wrap("`", "`", "code")
+    EditorAction.LINK -> value.link()
+    EditorAction.MENTION -> value.insert("@")
+    EditorAction.HEADING -> value.togglePrefix("## ")
+    EditorAction.QUOTE -> value.togglePrefix("> ")
+    EditorAction.LIST -> value.togglePrefix("- ")
+    EditorAction.IMAGE, EditorAction.EMOJI, EditorAction.PREVIEW -> value
+}
+
+/** Drops [text] in at the caret, replacing the selection. Used by the emoji panel. */
+fun insertText(
+    value: TextFieldValue,
+    text: String,
+): TextFieldValue = value.insert(text)
+
+/**
+ * Appends an uploaded image on a line of its own.
+ *
+ * Not inserted at the caret: uploads finish while typing continues, and dropping `![…](…)` into the
+ * middle of the sentence being written is both surprising and hard to undo. A block image also has
+ * to start its own line to render as one.
+ */
+fun appendBlock(
+    body: String,
+    block: String,
+): String = when {
+    body.isBlank() -> block
+    body.endsWith("\n\n") -> body + block
+    body.endsWith("\n") -> body + "\n" + block
+    else -> body + "\n\n" + block
+}
+
+/** Removes an attachment's Markdown again when its cell is dismissed. */
+fun removeBlock(
+    body: String,
+    block: String,
+): String = body
+    .replace("\n\n$block", "")
+    .replace("\n$block", "")
+    .replace(block, "")
+
+private fun TextFieldValue.wrap(
+    prefix: String,
+    suffix: String,
+    placeholder: String,
+): TextFieldValue {
+    val start = selection.min.coerceIn(0, text.length)
+    val end = selection.max.coerceIn(0, text.length)
+    val selected = text.substring(start, end)
+    val content = selected.ifEmpty { placeholder }
+    val replaced = text.replaceRange(start, end, prefix + content + suffix)
+    val contentStart = start + prefix.length
+    return TextFieldValue(replaced, TextRange(contentStart, contentStart + content.length))
+}
+
+private fun TextFieldValue.link(): TextFieldValue {
+    val start = selection.min.coerceIn(0, text.length)
+    val end = selection.max.coerceIn(0, text.length)
+    val label = text.substring(start, end).ifEmpty { "链接文字" }
+    val replaced = text.replaceRange(start, end, "[$label](https://)")
+    // Caret inside the empty URL: the label is the easy part, the address is what needs typing.
+    val cursor = start + label.length + 3 + URL_SCHEME.length
+    return TextFieldValue(replaced, TextRange(cursor.coerceIn(0, replaced.length)))
+}
+
+private fun TextFieldValue.insert(insertion: String): TextFieldValue {
+    val start = selection.min.coerceIn(0, text.length)
+    val end = selection.max.coerceIn(0, text.length)
+    val replaced = text.replaceRange(start, end, insertion)
+    val cursor = (start + insertion.length).coerceIn(0, replaced.length)
+    return TextFieldValue(replaced, TextRange(cursor))
+}
+
+private fun TextFieldValue.togglePrefix(prefix: String): TextFieldValue {
+    val caret = selection.min.coerceIn(0, text.length)
+    val lineStart = text.lastIndexOf('\n', (caret - 1).coerceAtLeast(0))
+        .let { if (it < 0 || text.isEmpty()) 0 else it + 1 }
+    val hasPrefix = text.startsWith(prefix, lineStart)
+    val replaced = if (hasPrefix) {
+        text.removeRange(lineStart, lineStart + prefix.length)
+    } else {
+        text.replaceRange(lineStart, lineStart, prefix)
+    }
+    val shift = if (hasPrefix) -prefix.length else prefix.length
+    val cursor = (caret + shift).coerceIn(lineStart.coerceAtMost(replaced.length), replaced.length)
+    return TextFieldValue(replaced, TextRange(cursor))
+}
+
+private const val URL_SCHEME = "https://"

--- a/app/src/main/java/io/github/nsreader/ui/composer/PickedImages.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/PickedImages.kt
@@ -1,0 +1,28 @@
+package io.github.nsreader.ui.composer
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import io.github.nsreader.R
+import io.github.nsreader.data.composer.PickedImage
+
+/**
+ * Turns what the photo picker returns into queue entries.
+ *
+ * The display name is worth the content-provider query: it is what the tray labels, what the
+ * failure message quotes back, and what ends up as the image's alt text in the published Markdown.
+ * Providers are allowed to answer with nothing, hence the two fallbacks.
+ */
+internal fun List<Uri>.toPickedImages(context: Context): List<PickedImage> =
+    map { uri -> PickedImage(source = uri.toString(), name = uri.displayName(context)) }
+
+private fun Uri.displayName(context: Context): String {
+    val fromProvider = runCatching {
+        context.contentResolver
+            .query(this, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+    }.getOrNull()
+    return fromProvider
+        ?: lastPathSegment?.substringAfterLast('/')
+        ?: context.getString(R.string.composer_image_default_name)
+}

--- a/app/src/main/java/io/github/nsreader/ui/composer/PostComposerScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/PostComposerScreen.kt
@@ -1,9 +1,10 @@
 package io.github.nsreader.ui.composer
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,20 +12,21 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.MailOutline
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -37,6 +39,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -54,23 +57,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nsreader.R
-import io.github.nsreader.core.NodeSeekSite
 import io.github.nsreader.core.net.NodeSeekError
 import io.github.nsreader.data.Board
+import io.github.nsreader.data.composer.ImageAttachment
 import io.github.nsreader.data.composer.PostDraft
 import io.github.nsreader.data.composer.PostPermission
 import io.github.nsreader.ui.common.NodeSeekIcons
-import io.github.nsreader.ui.richtext.RichContent
 import io.github.nsreader.ui.theme.PostBody
 import io.github.nsreader.ui.theme.Spacing
 import io.github.nsreader.ui.theme.readableWidth
@@ -87,9 +90,59 @@ fun PostComposerRoute(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
-    val errorMessage = state.publishError?.let { publishErrorMessage(it, state.publishErrorDetail) }
-    val errorActionLabel = state.publishError?.let { error ->
+
+    PublishErrorSnackbar(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onDismissed = viewModel::clearPublishError,
+        onSignIn = onSignIn,
+        onVerify = onVerify,
+        onRetry = { viewModel.publish(onPublished) },
+    )
+    UploadErrorSnackbar(
+        failedCount = state.failedUploadCount,
+        snackbarHostState = snackbarHostState,
+        onRetry = viewModel::retryFailedUploads,
+    )
+
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_PICK),
+    ) { uris -> viewModel.addImages(uris.toPickedImages(context)) }
+
+    PostComposerScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onClose = onClose,
+        onTitleChange = viewModel::updateTitle,
+        onBodyChange = viewModel::updateBody,
+        onBoardSelect = viewModel::selectBoard,
+        onPermissionSelect = viewModel::selectPermission,
+        onViewModeChange = viewModel::setViewMode,
+        onPickImages = {
+            picker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        },
+        onRemoveAttachment = viewModel::removeAttachment,
+        onRetryAttachment = viewModel::retryUpload,
+        onPublish = { if (state.isSignedIn) viewModel.publish(onPublished) else onSignIn() },
+        onContinueDraft = viewModel::continueDraft,
+        onDiscardDraft = viewModel::discardDraft,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun PublishErrorSnackbar(
+    state: PostComposerUiState,
+    snackbarHostState: SnackbarHostState,
+    onDismissed: () -> Unit,
+    onSignIn: () -> Unit,
+    onVerify: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    val message = state.publishError?.let { publishErrorMessage(it, state.publishErrorDetail) }
+    val actionLabel = state.publishError?.let { error ->
         stringResource(
             when (error) {
                 NodeSeekError.LoginRequired -> R.string.action_sign_in
@@ -98,107 +151,101 @@ fun PostComposerRoute(
             },
         )
     }
-
-    LaunchedEffect(state.publishError, errorMessage, errorActionLabel) {
+    LaunchedEffect(state.publishError, message, actionLabel) {
         val error = state.publishError ?: return@LaunchedEffect
         val result = snackbarHostState.showSnackbar(
-            message = errorMessage ?: return@LaunchedEffect,
-            actionLabel = errorActionLabel,
+            message = message ?: return@LaunchedEffect,
+            actionLabel = actionLabel,
             duration = SnackbarDuration.Indefinite,
         )
-        viewModel.clearPublishError()
-        if (result == androidx.compose.material3.SnackbarResult.ActionPerformed) {
+        onDismissed()
+        if (result == SnackbarResult.ActionPerformed) {
             when (error) {
                 NodeSeekError.LoginRequired -> onSignIn()
                 NodeSeekError.Cloudflare -> onVerify()
-                else -> viewModel.publish(onPublished)
+                else -> onRetry()
             }
         }
     }
-
-    PostComposerScreen(
-        state = state,
-        snackbarHostState = snackbarHostState,
-        onClose = onClose,
-        onBackToEditor = viewModel::showEditor,
-        onTitleChange = viewModel::updateTitle,
-        onBodyChange = viewModel::updateBody,
-        onBoardSelect = viewModel::selectBoard,
-        onPermissionSelect = viewModel::selectPermission,
-        onPreview = viewModel::showPreview,
-        onPublish = {
-            if (state.isSignedIn) viewModel.publish(onPublished) else onSignIn()
-        },
-        onDismissRule = viewModel::dismissRuleReminder,
-        onContinueDraft = viewModel::continueDraft,
-        onDiscardDraft = viewModel::discardDraft,
-        modifier = modifier,
-    )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UploadErrorSnackbar(
+    failedCount: Int,
+    snackbarHostState: SnackbarHostState,
+    onRetry: () -> Unit,
+) {
+    val message = stringResource(R.string.composer_image_failed_count, failedCount)
+    val retry = stringResource(R.string.action_retry)
+    LaunchedEffect(failedCount) {
+        if (failedCount == 0) return@LaunchedEffect
+        val result = snackbarHostState.showSnackbar(
+            message = message,
+            actionLabel = retry,
+            duration = SnackbarDuration.Long,
+        )
+        if (result == SnackbarResult.ActionPerformed) onRetry()
+    }
+}
+
 @Composable
 fun PostComposerScreen(
     state: PostComposerUiState,
     snackbarHostState: SnackbarHostState,
     onClose: () -> Unit,
-    onBackToEditor: () -> Unit,
     onTitleChange: (String) -> Unit,
     onBodyChange: (String) -> Unit,
     onBoardSelect: (Board) -> Unit,
     onPermissionSelect: (PostPermission) -> Unit,
-    onPreview: () -> Unit,
+    onViewModeChange: (ComposerViewMode) -> Unit,
+    onPickImages: () -> Unit,
+    onRemoveAttachment: (ImageAttachment) -> Unit,
+    onRetryAttachment: (ImageAttachment) -> Unit,
     onPublish: () -> Unit,
-    onDismissRule: () -> Unit,
     onContinueDraft: () -> Unit,
     onDiscardDraft: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // While a publish is in flight the request may already have created the topic; leaving now would
     // cancel the ViewModel, keep the draft, and set up a duplicate post on the next attempt. Preview
-    // mode reuses the same handler so system back mirrors the top bar's "‹" instead of closing.
-    BackHandler(enabled = state.isPublishing || state.mode == ComposerMode.PREVIEW) {
-        if (!state.isPublishing) onBackToEditor()
+    // reuses the same handler so system back mirrors the top bar's arrow instead of closing.
+    BackHandler(enabled = state.isPublishing || state.viewMode == ComposerViewMode.PREVIEW) {
+        if (!state.isPublishing) onViewModeChange(ComposerViewMode.CONTENT)
     }
     Scaffold(
         modifier = modifier.fillMaxSize(),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             ComposerTopBar(
-                preview = state.mode == ComposerMode.PREVIEW,
+                preview = state.viewMode == ComposerViewMode.PREVIEW,
                 isPublishing = state.isPublishing,
                 canPublish = state.canPublish,
                 onClose = onClose,
-                onBack = onBackToEditor,
+                onBack = { onViewModeChange(ComposerViewMode.CONTENT) },
                 onPublish = onPublish,
             )
         },
     ) { padding ->
-        if (state.mode == ComposerMode.EDIT) {
+        if (state.viewMode == ComposerViewMode.PREVIEW) {
+            PreviewContent(state = state, modifier = Modifier.padding(padding))
+        } else {
             EditorContent(
                 state = state,
                 onTitleChange = onTitleChange,
                 onBodyChange = onBodyChange,
                 onBoardSelect = onBoardSelect,
                 onPermissionSelect = onPermissionSelect,
-                onPreview = onPreview,
-                modifier = Modifier.padding(padding),
-            )
-        } else {
-            PreviewContent(
-                state = state,
-                onDismissRule = onDismissRule,
+                onViewModeChange = onViewModeChange,
+                onPickImages = onPickImages,
+                onRemoveAttachment = onRemoveAttachment,
+                onRetryAttachment = onRetryAttachment,
                 modifier = Modifier.padding(padding),
             )
         }
     }
 
     state.pendingDraft?.let { draft ->
-        DraftRecoveryDialog(
-            draft = draft,
-            onContinue = onContinueDraft,
-            onDiscard = onDiscardDraft,
-        )
+        DraftRecoveryDialog(draft = draft, onContinue = onContinueDraft, onDiscard = onDiscardDraft)
     }
 }
 
@@ -216,40 +263,65 @@ private fun ComposerTopBar(
         title = {
             Text(
                 text = stringResource(if (preview) R.string.composer_preview_title else R.string.composer_title),
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleSmall,
+                fontSize = 16.sp,
             )
         },
         navigationIcon = {
-            if (preview) {
-                TextButton(onClick = onBack, contentPadding = PaddingValues(horizontal = Spacing.md)) {
-                    Text("‹", style = MaterialTheme.typography.headlineMedium)
-                }
-            } else {
-                IconButton(onClick = onClose, enabled = !isPublishing) {
-                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.action_cancel))
-                }
+            IconButton(onClick = if (preview) onBack else onClose, enabled = !isPublishing) {
+                Icon(
+                    imageVector = if (preview) Icons.AutoMirrored.Filled.ArrowBack else Icons.Default.Close,
+                    contentDescription = stringResource(if (preview) R.string.action_back else R.string.action_cancel),
+                )
             }
         },
-        actions = {
-            Button(
-                onClick = onPublish,
-                enabled = canPublish,
-                contentPadding = PaddingValues(horizontal = Spacing.lg),
-            ) {
-                if (isPublishing) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(16.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                    Text("  ${stringResource(R.string.action_publish)}")
-                } else {
-                    Text(stringResource(R.string.action_publish))
-                }
-            }
-        },
+        actions = { PublishButton(isPublishing = isPublishing, enabled = canPublish, onClick = onPublish) },
         colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
     )
+}
+
+/**
+ * "发布" and its in-flight twin from 7c.
+ *
+ * The tonal, spinner-carrying variant replaces the filled button rather than showing a spinner
+ * inside it: the difference has to survive being glanced at, because the one thing a user must not
+ * do here is tap again.
+ */
+@Composable
+private fun PublishButton(
+    isPublishing: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled && !isPublishing,
+        contentPadding = PaddingValues(horizontal = 18.dp),
+        colors = if (isPublishing) {
+            ButtonDefaults.buttonColors(
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            ButtonDefaults.buttonColors()
+        },
+        modifier = Modifier.padding(end = Spacing.sm).height(40.dp),
+    ) {
+        if (isPublishing) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(14.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = stringResource(R.string.composer_publishing),
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(start = Spacing.sm),
+            )
+        } else {
+            Text(stringResource(R.string.action_publish), style = MaterialTheme.typography.labelLarge)
+        }
+    }
 }
 
 @Composable
@@ -259,101 +331,185 @@ private fun EditorContent(
     onBodyChange: (String) -> Unit,
     onBoardSelect: (Board) -> Unit,
     onPermissionSelect: (PostPermission) -> Unit,
-    onPreview: () -> Unit,
+    onViewModeChange: (ComposerViewMode) -> Unit,
+    onPickImages: () -> Unit,
+    onRemoveAttachment: (ImageAttachment) -> Unit,
+    onRetryAttachment: (ImageAttachment) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var bodyValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(state.body, TextRange(state.body.length)))
     }
+    var emojiOpen by rememberSaveable { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
+    val keyboard = LocalSoftwareKeyboardController.current
     LaunchedEffect(state.body) {
         if (state.body != bodyValue.text) {
             bodyValue = TextFieldValue(state.body, TextRange(state.body.length))
         }
     }
+    fun edit(next: TextFieldValue) {
+        bodyValue = next
+        onBodyChange(next.text)
+    }
 
     Column(modifier = modifier.fillMaxSize().imePadding()) {
-        ComposerOptions(
+        ComposerOptions(state = state, onBoardSelect = onBoardSelect, onPermissionSelect = onPermissionSelect)
+        TitleField(title = state.title, onTitleChange = onTitleChange)
+        BodyArea(
             state = state,
-            onBoardSelect = onBoardSelect,
-            onPermissionSelect = onPermissionSelect,
+            bodyValue = bodyValue,
+            onEdit = ::edit,
+            focusRequester = focusRequester,
+            modifier = Modifier.weight(1f),
         )
-        BasicTextField(
-            value = state.title,
-            onValueChange = onTitleChange,
-            singleLine = true,
-            textStyle = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.onSurface),
-            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        AttachmentTray(
+            attachments = state.attachments,
+            onRemove = onRemoveAttachment,
+            onRetry = onRetryAttachment,
+        )
+        EditorToolbar(
+            actions = POST_ACTIONS,
+            active = if (emojiOpen) setOf(EditorAction.EMOJI) else emptySet(),
+            onAction = { action ->
+                when (action) {
+                    EditorAction.IMAGE -> onPickImages()
+
+                    EditorAction.EMOJI -> {
+                        emojiOpen = !emojiOpen
+                        if (emojiOpen) keyboard?.hide()
+                    }
+
+                    else -> {
+                        emojiOpen = false
+                        edit(applyMarkdown(bodyValue, action))
+                        focusRequester.requestFocus()
+                    }
+                }
+            },
+            trailing = {
+                ViewModeSwitch(
+                    options = ComposerViewMode.entries,
+                    selected = state.viewMode,
+                    label = { mode -> stringResource(mode.labelRes) },
+                    onSelect = onViewModeChange,
+                )
+            },
+        )
+        if (emojiOpen) {
+            EmojiPanel(
+                onInsert = { text -> edit(insertText(bodyValue, text)) },
+                onBackspace = { edit(bodyValue.deleteBackwards()) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BodyArea(
+    state: PostComposerUiState,
+    bodyValue: TextFieldValue,
+    onEdit: (TextFieldValue) -> Unit,
+    focusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    if (state.viewMode != ComposerViewMode.COMPARE) {
+        BodyField(bodyValue, onEdit, focusRequester, modifier)
+        return
+    }
+    // 对照: the site puts the two side by side, which needs a width a phone does not have. Stacked
+    // keeps the pairing — edit above, result below — without shrinking either to an unreadable column.
+    Column(modifier = modifier) {
+        BodyField(bodyValue, onEdit, focusRequester, Modifier.weight(1f))
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        MarkdownPreviewBody(
+            markdown = state.body,
             modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
                 .readableWidth()
-                .padding(horizontal = Spacing.lg)
-                .background(MaterialTheme.colorScheme.surface)
-                .padding(vertical = Spacing.sm),
-            decorationBox = { inner ->
-                Column {
-                    Box(Modifier.fillMaxWidth()) {
-                        if (state.title.isEmpty()) {
+                .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        )
+    }
+}
+
+@Composable
+private fun BodyField(
+    bodyValue: TextFieldValue,
+    onEdit: (TextFieldValue) -> Unit,
+    focusRequester: FocusRequester,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = bodyValue,
+        onValueChange = onEdit,
+        textStyle = PostBody.copy(color = MaterialTheme.colorScheme.onSurface),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        modifier = modifier
+            .readableWidth()
+            .focusRequester(focusRequester)
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        decorationBox = { inner ->
+            Box(Modifier.fillMaxSize()) {
+                if (bodyValue.text.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.composer_body_hint),
+                        style = PostBody,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                inner()
+            }
+        },
+    )
+}
+
+@Composable
+private fun TitleField(
+    title: String,
+    onTitleChange: (String) -> Unit,
+) {
+    BasicTextField(
+        value = title,
+        onValueChange = onTitleChange,
+        singleLine = true,
+        textStyle = MaterialTheme.typography.titleMedium.copy(
+            fontSize = 19.sp,
+            lineHeight = 26.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        ),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        modifier = Modifier.readableWidth().padding(horizontal = Spacing.lg),
+        decorationBox = { inner ->
+            Column {
+                Row(verticalAlignment = Alignment.Bottom) {
+                    Box(Modifier.weight(1f).padding(bottom = Spacing.sm)) {
+                        if (title.isEmpty()) {
                             Text(
-                                stringResource(R.string.composer_title_hint),
-                                style = MaterialTheme.typography.titleLarge,
+                                text = stringResource(R.string.composer_title_hint),
+                                style = MaterialTheme.typography.titleMedium.copy(fontSize = 19.sp),
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
                         inner()
                     }
-                    HorizontalDivider(
-                        modifier = Modifier.padding(top = Spacing.sm),
-                        thickness = 2.dp,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
                     Text(
                         text = stringResource(
                             R.string.composer_title_count,
-                            state.title.length,
+                            title.length,
                             PostComposerViewModel.MAX_TITLE_LENGTH,
                         ),
                         style = MaterialTheme.typography.labelSmall,
+                        fontSize = 11.sp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.align(Alignment.End).padding(top = Spacing.xs),
+                        modifier = Modifier.padding(start = Spacing.sm, bottom = Spacing.md),
                     )
                 }
-            },
-        )
-        BasicTextField(
-            value = bodyValue,
-            onValueChange = {
-                bodyValue = it
-                onBodyChange(it.text)
-            },
-            textStyle = PostBody.copy(color = MaterialTheme.colorScheme.onSurface),
-            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-            modifier = Modifier
-                .readableWidth()
-                .weight(1f)
-                .focusRequester(focusRequester)
-                .padding(horizontal = Spacing.lg, vertical = Spacing.md),
-            decorationBox = { inner ->
-                Box(Modifier.fillMaxSize()) {
-                    if (bodyValue.text.isEmpty()) {
-                        Text(
-                            stringResource(R.string.composer_body_hint),
-                            style = PostBody,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    inner()
-                }
-            },
-        )
-        MarkdownToolbar(
-            onFormat = { format ->
-                bodyValue = applyFormat(bodyValue, format)
-                onBodyChange(bodyValue.text)
-                focusRequester.requestFocus()
-            },
-            onPreview = onPreview,
-        )
-    }
+                HorizontalDivider(thickness = 2.dp, color = MaterialTheme.colorScheme.primary)
+            }
+        },
+    )
 }
 
 @Composable
@@ -364,26 +520,23 @@ private fun ComposerOptions(
 ) {
     var boardMenuOpen by remember { mutableStateOf(false) }
     var permissionMenuOpen by remember { mutableStateOf(false) }
-    val boardRequired = state.boardSlug == null && state.hasContent
+    // The board is the one required field with no default, so it is called out only once there is
+    // something to publish — an error outline on an untouched form is just noise.
+    val boardMissing = state.boardSlug == null && state.hasContent
 
     Row(
         modifier = Modifier
             .readableWidth()
-            .horizontalScroll(rememberScrollState())
             .padding(horizontal = Spacing.lg, vertical = Spacing.xs),
         horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box {
-            AssistChip(
+            ComposerChip(
+                label = state.boardTitle ?: stringResource(R.string.composer_select_board),
+                filled = state.boardTitle != null,
+                error = boardMissing,
                 onClick = { boardMenuOpen = true },
-                label = { Text(state.boardTitle ?: stringResource(R.string.composer_select_board)) },
-                trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, null, Modifier.size(18.dp)) },
-                modifier = if (boardRequired) {
-                    Modifier.border(1.dp, MaterialTheme.colorScheme.error, RoundedCornerShape(8.dp))
-                } else {
-                    Modifier
-                },
             )
             DropdownMenu(expanded = boardMenuOpen, onDismissRequest = { boardMenuOpen = false }) {
                 state.boards.forEach { board ->
@@ -398,20 +551,12 @@ private fun ComposerOptions(
             }
         }
         Box {
-            AssistChip(
+            ComposerChip(
+                label = permissionLabel(state.permission),
+                filled = false,
+                error = false,
+                leading = NodeSeekIcons.Visibility,
                 onClick = { permissionMenuOpen = true },
-                label = {
-                    Text(
-                        stringResource(
-                            R.string.composer_permission,
-                            permissionLabel(state.permission),
-                        ),
-                    )
-                },
-                leadingIcon = {
-                    Icon(NodeSeekIcons.Visibility, null, Modifier.size(17.dp))
-                },
-                trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, null, Modifier.size(18.dp)) },
             )
             DropdownMenu(expanded = permissionMenuOpen, onDismissRequest = { permissionMenuOpen = false }) {
                 PostPermission.entries.forEach { permission ->
@@ -425,10 +570,12 @@ private fun ComposerOptions(
                 }
             }
         }
+        Box(Modifier.weight(1f))
         Text(
             text = state.savedAtMillis?.let { stringResource(R.string.composer_draft_saved, formatTime(it)) }
                 ?: stringResource(R.string.composer_draft_saving),
             style = MaterialTheme.typography.labelSmall,
+            fontSize = 11.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
         )
@@ -436,136 +583,76 @@ private fun ComposerOptions(
 }
 
 @Composable
-private fun MarkdownToolbar(
-    onFormat: (MarkdownFormat) -> Unit,
-    onPreview: () -> Unit,
-) {
-    Surface(tonalElevation = 2.dp, color = MaterialTheme.colorScheme.surfaceContainer) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            FormatButton("B", R.string.composer_format_bold) { onFormat(MarkdownFormat.BOLD) }
-            FormatButton("H2", R.string.composer_format_heading) { onFormat(MarkdownFormat.HEADING) }
-            FormatButton("</>", R.string.composer_format_code) { onFormat(MarkdownFormat.CODE) }
-            FormatButton("•", R.string.composer_format_list) { onFormat(MarkdownFormat.LIST) }
-            FormatButton("↗", R.string.composer_format_link) { onFormat(MarkdownFormat.LINK) }
-            FormatButton("▧", R.string.composer_format_image) { onFormat(MarkdownFormat.IMAGE) }
-            FormatButton("☺", R.string.composer_format_emoji) { onFormat(MarkdownFormat.EMOJI) }
-            TextButton(onClick = onPreview) {
-                Icon(NodeSeekIcons.Visibility, null, Modifier.size(18.dp))
-                Text("  ${stringResource(R.string.action_preview)}")
-            }
-        }
-    }
-}
-
-@Composable
-private fun FormatButton(
+private fun ComposerChip(
     label: String,
-    descriptionRes: Int,
+    filled: Boolean,
+    error: Boolean,
     onClick: () -> Unit,
+    leading: ImageVector? = null,
 ) {
-    val description = stringResource(descriptionRes)
-    IconButton(
+    val shape = RoundedCornerShape(8.dp)
+    Surface(
         onClick = onClick,
-        modifier = Modifier.semantics { contentDescription = description },
+        shape = shape,
+        color = if (filled) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surface,
+        contentColor = if (filled) {
+            MaterialTheme.colorScheme.onSecondaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        border = BorderStroke(
+            width = 1.dp,
+            color = if (error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.outlineVariant,
+        ),
+        modifier = Modifier.height(32.dp),
     ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelLarge,
-        )
+        Row(
+            modifier = Modifier.padding(start = Spacing.md, end = Spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            leading?.let { Icon(it, contentDescription = null, modifier = Modifier.size(16.dp)) }
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = if (filled) FontWeight.SemiBold else FontWeight.Medium,
+            )
+            Icon(Icons.Default.KeyboardArrowDown, contentDescription = null, modifier = Modifier.size(18.dp))
+        }
     }
 }
 
 @Composable
 private fun PreviewContent(
     state: PostComposerUiState,
-    onDismissRule: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val uriHandler = LocalUriHandler.current
-    val nodes = remember(state.body) { parseMarkdown(state.body) }
-    androidx.compose.foundation.lazy.LazyColumn(
-        modifier = modifier.fillMaxSize().readableWidth(),
-        contentPadding = PaddingValues(horizontal = Spacing.xl, vertical = Spacing.sm),
-        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .readableWidth(),
     ) {
-        if (state.showRuleReminder) {
-            item(key = "rule-reminder") {
-                RuleReminder(onDismissRule)
-            }
-        }
-        item(key = "title") {
+        RuleReminderCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.lg)
+                .padding(bottom = Spacing.sm + 2.dp),
+        )
+        Column(modifier = Modifier.padding(horizontal = Spacing.xl, vertical = Spacing.sm)) {
             Text(
                 text = state.title,
-                style = MaterialTheme.typography.headlineSmall,
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleLarge.copy(fontSize = 22.sp, lineHeight = 31.sp),
             )
-        }
-        item(key = "meta") {
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                Surface(
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                    shape = RoundedCornerShape(8.dp),
-                ) {
-                    Text(
-                        state.boardTitle.orEmpty(),
-                        style = MaterialTheme.typography.labelSmall,
-                        modifier = Modifier.padding(horizontal = Spacing.sm, vertical = Spacing.xs),
-                    )
-                }
-                Text(
-                    stringResource(R.string.composer_just_now),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-        item(key = "body") {
-            if (nodes.isEmpty()) {
-                Text(
-                    stringResource(R.string.composer_preview_empty),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            } else {
-                RichContent(
-                    nodes = nodes,
-                    onLinkClick = { url ->
-                        if (NodeSeekSite.isExternalWebUrl(url)) runCatching { uriHandler.openUri(url) }
-                    },
-                    onImageClick = { url ->
-                        if (NodeSeekSite.isExternalWebUrl(url)) runCatching { uriHandler.openUri(url) }
-                    },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun RuleReminder(onDismiss: () -> Unit) {
-    Surface(
-        color = MaterialTheme.colorScheme.tertiaryContainer,
-        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-        shape = RoundedCornerShape(14.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(start = Spacing.md, top = Spacing.md, bottom = Spacing.md),
-            verticalAlignment = Alignment.Top,
-        ) {
-            Icon(Icons.Default.Info, null, Modifier.size(20.dp))
-            Column(Modifier.weight(1f).padding(horizontal = Spacing.sm)) {
-                Text(stringResource(R.string.composer_rule_title), style = MaterialTheme.typography.labelLarge)
-                Text(stringResource(R.string.composer_rule_body), style = MaterialTheme.typography.bodySmall)
-            }
-            IconButton(onClick = onDismiss) {
-                Icon(Icons.Default.Close, stringResource(R.string.composer_rule_dismiss))
-            }
+            PreviewByline(
+                boardTitle = state.boardTitle,
+                authorName = state.authorName,
+                modifier = Modifier.padding(top = Spacing.sm + 2.dp),
+            )
+            MarkdownPreviewBody(
+                markdown = state.body,
+                modifier = Modifier.padding(top = 14.dp, bottom = Spacing.xl),
+            )
         }
     }
 }
@@ -576,26 +663,30 @@ private fun DraftRecoveryDialog(
     onContinue: () -> Unit,
     onDiscard: () -> Unit,
 ) {
+    val imageCount = remember(draft.body) { countImages(draft.body) }
+    val board = draft.boardTitle ?: stringResource(R.string.composer_select_board)
+    val title = draft.title.ifBlank { stringResource(R.string.composer_title_hint) }
     AlertDialog(
         onDismissRequest = {},
-        icon = { Icon(Icons.Default.MailOutline, null) },
+        icon = { Icon(NodeSeekIcons.Drafts, contentDescription = null, tint = MaterialTheme.colorScheme.primary) },
         title = { Text(stringResource(R.string.composer_restore_title)) },
         text = {
             Text(
-                stringResource(
-                    R.string.composer_restore_body,
-                    formatTime(draft.savedAtMillis),
-                    draft.boardTitle ?: stringResource(R.string.composer_select_board),
-                    draft.title.ifBlank { stringResource(R.string.composer_title_hint) },
-                ),
+                text = if (imageCount > 0) {
+                    stringResource(
+                        R.string.composer_restore_body_images,
+                        formatTime(draft.savedAtMillis),
+                        board,
+                        title,
+                        imageCount,
+                    )
+                } else {
+                    stringResource(R.string.composer_restore_body, formatTime(draft.savedAtMillis), board, title)
+                },
             )
         },
-        confirmButton = {
-            Button(onClick = onContinue) { Text(stringResource(R.string.composer_restore_continue)) }
-        },
-        dismissButton = {
-            TextButton(onClick = onDiscard) { Text(stringResource(R.string.composer_restore_discard)) }
-        },
+        confirmButton = { Button(onClick = onContinue) { Text(stringResource(R.string.composer_restore_continue)) } },
+        dismissButton = { TextButton(onClick = onDiscard) { Text(stringResource(R.string.composer_restore_discard)) } },
     )
 }
 
@@ -618,29 +709,6 @@ private fun publishErrorMessage(error: NodeSeekError, detail: String?): String {
     return stringResource(R.string.composer_publish_failed, reason)
 }
 
-private enum class MarkdownFormat { BOLD, HEADING, CODE, LIST, LINK, IMAGE, EMOJI }
-
-private fun applyFormat(value: TextFieldValue, format: MarkdownFormat): TextFieldValue {
-    val start = value.selection.min.coerceIn(0, value.text.length)
-    val end = value.selection.max.coerceIn(0, value.text.length)
-    val selected = value.text.substring(start, end)
-    val (replacement, cursorOffset) = when (format) {
-        MarkdownFormat.BOLD -> "**${selected.ifEmpty { "加粗文字" }}**" to if (selected.isEmpty()) 2 else selected.length + 4
-        MarkdownFormat.HEADING -> "## ${selected.ifEmpty { "标题" }}" to if (selected.isEmpty()) 3 else selected.length + 3
-        MarkdownFormat.CODE -> "`${selected.ifEmpty { "code" }}`" to if (selected.isEmpty()) 1 else selected.length + 2
-        MarkdownFormat.LIST -> "- ${selected.ifEmpty { "列表项" }}" to if (selected.isEmpty()) 2 else selected.length + 2
-        MarkdownFormat.LINK -> "[${selected.ifEmpty { "链接文字" }}](https://)" to if (selected.isEmpty()) 1 else selected.length + 3
-        MarkdownFormat.IMAGE -> "![${selected.ifEmpty { "图片说明" }}](https://)" to if (selected.isEmpty()) 2 else selected.length + 4
-        MarkdownFormat.EMOJI -> "$selected🙂" to selected.length + 2
-    }
-    val text = value.text.replaceRange(start, end, replacement)
-    val cursor = (start + cursorOffset).coerceIn(0, text.length)
-    return TextFieldValue(text, TextRange(cursor))
-}
-
-private fun formatTime(timestamp: Long): String =
-    DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(timestamp))
-
 @Composable
 private fun permissionLabel(permission: PostPermission): String =
     stringResource(
@@ -650,3 +718,41 @@ private fun permissionLabel(permission: PostPermission): String =
             PostPermission.PRIVATE -> R.string.composer_permission_private
         },
     )
+
+private val ComposerViewMode.labelRes: Int
+    get() = when (this) {
+        ComposerViewMode.CONTENT -> R.string.composer_view_content
+        ComposerViewMode.PREVIEW -> R.string.composer_view_preview
+        ComposerViewMode.COMPARE -> R.string.composer_view_compare
+    }
+
+/** Deletes one character before the caret — the emoji panel's own backspace key. */
+internal fun TextFieldValue.deleteBackwards(): TextFieldValue {
+    val start = selection.min.coerceIn(0, text.length)
+    val end = selection.max.coerceIn(0, text.length)
+    if (start != end) {
+        return TextFieldValue(text.removeRange(start, end), TextRange(start))
+    }
+    if (start == 0) return this
+    // Step by code point so a single tap removes a whole emoji rather than half a surrogate pair.
+    val previous = text.offsetByCodePoints(start, -1)
+    return TextFieldValue(text.removeRange(previous, start), TextRange(previous))
+}
+
+private fun countImages(markdown: String): Int = IMAGE_MARKDOWN.findAll(markdown).count()
+
+private fun formatTime(timestamp: Long): String =
+    DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(timestamp))
+
+private val IMAGE_MARKDOWN = Regex("""!\[[^]]*]\([^)]+\)""")
+
+private val POST_ACTIONS = listOf(
+    EditorAction.BOLD,
+    EditorAction.CODE,
+    EditorAction.LIST,
+    EditorAction.LINK,
+    EditorAction.IMAGE,
+    EditorAction.EMOJI,
+)
+
+private const val MAX_IMAGES_PER_PICK = 9

--- a/app/src/main/java/io/github/nsreader/ui/composer/PostComposerScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/PostComposerScreen.kt
@@ -77,6 +77,7 @@ import io.github.nsreader.ui.common.NodeSeekIcons
 import io.github.nsreader.ui.theme.PostBody
 import io.github.nsreader.ui.theme.Spacing
 import io.github.nsreader.ui.theme.readableWidth
+import java.text.BreakIterator
 import java.text.DateFormat
 import java.util.Date
 
@@ -341,6 +342,8 @@ private fun EditorContent(
         mutableStateOf(TextFieldValue(state.body, TextRange(state.body.length)))
     }
     var emojiOpen by rememberSaveable { mutableStateOf(false) }
+    // Held here, not in the panel: the panel leaves the composition whenever it closes.
+    var recentEmoji by rememberSaveable { mutableStateOf(listOf<String>()) }
     val focusRequester = remember { FocusRequester() }
     val keyboard = LocalSoftwareKeyboardController.current
     LaunchedEffect(state.body) {
@@ -400,6 +403,8 @@ private fun EditorContent(
             EmojiPanel(
                 onInsert = { text -> edit(insertText(bodyValue, text)) },
                 onBackspace = { edit(bodyValue.deleteBackwards()) },
+                recent = recentEmoji,
+                onRecentChange = { recentEmoji = it },
             )
         }
     }
@@ -734,8 +739,11 @@ internal fun TextFieldValue.deleteBackwards(): TextFieldValue {
         return TextFieldValue(text.removeRange(start, end), TextRange(start))
     }
     if (start == 0) return this
-    // Step by code point so a single tap removes a whole emoji rather than half a surrogate pair.
-    val previous = text.offsetByCodePoints(start, -1)
+    // Step back one grapheme cluster, not one code point: the panel's own ❤️ is base + variation
+    // selector, and a code-point step would strip the selector and leave a black text-style heart.
+    val iterator = BreakIterator.getCharacterInstance()
+    iterator.setText(text)
+    val previous = iterator.preceding(start).let { if (it == BreakIterator.DONE) 0 else it }
     return TextFieldValue(text.removeRange(previous, start), TextRange(previous))
 }
 

--- a/app/src/main/java/io/github/nsreader/ui/composer/PostComposerViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/PostComposerViewModel.kt
@@ -10,10 +10,16 @@ import io.github.nsreader.core.net.NodeSeekError
 import io.github.nsreader.core.net.NodeSeekException
 import io.github.nsreader.core.runCatchingExceptCancellation
 import io.github.nsreader.data.Board
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.composer.ImageAttachment
+import io.github.nsreader.data.composer.ImageUploadQueue
+import io.github.nsreader.data.composer.ImageUploader
+import io.github.nsreader.data.composer.PickedImage
 import io.github.nsreader.data.composer.PostComposerRepository
 import io.github.nsreader.data.composer.PostDraft
 import io.github.nsreader.data.composer.PostPermission
 import io.github.nsreader.data.composer.PostSubmission
+import io.github.nsreader.data.composer.UploadStatus
 import io.github.nsreader.data.session.SessionState
 import io.github.nsreader.di.AppContainer
 import kotlinx.coroutines.Job
@@ -33,12 +39,17 @@ class PostComposerViewModel(
     boards: Flow<List<Board>>,
     session: StateFlow<SessionState>,
     private val clock: AppClock,
+    uploader: ImageUploader,
+    private val profileRepository: ProfileRepository? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PostComposerUiState())
     val uiState: StateFlow<PostComposerUiState> = _uiState.asStateFlow()
 
+    private val uploads = ImageUploadQueue(viewModelScope, uploader)
+
     private var saveJob: Job? = null
     private var publishJob: Job? = null
+    private var authorJob: Job? = null
 
     init {
         boards
@@ -50,6 +61,16 @@ class PostComposerViewModel(
         session
             .onEach { session -> _uiState.update { it.copy(isSignedIn = session.isSignedIn) } }
             .launchIn(viewModelScope)
+        uploads.attachments
+            .onEach { attachments -> _uiState.update { it.copy(attachments = attachments) } }
+            .launchIn(viewModelScope)
+        // An upload lands while typing continues, so its Markdown goes to the end of the body
+        // rather than wherever the caret happens to be sitting.
+        uploads.uploaded
+            .onEach { attachment ->
+                val markdown = attachment.markdown ?: return@onEach
+                mutate { it.copy(body = appendBlock(it.body, markdown)) }
+            }.launchIn(viewModelScope)
 
         viewModelScope.launch {
             val draft = repository.draft.first()
@@ -70,26 +91,13 @@ class PostComposerViewModel(
 
     fun updateBody(body: String) = mutate { it.copy(body = body) }
 
-    fun selectBoard(board: Board) = mutate {
-        it.copy(
-            boardSlug = board.slug,
-            boardTitle = board.title,
-            showRuleReminder = board.slug == TECH_BOARD && !it.ruleReminderDismissed,
-        )
-    }
+    fun selectBoard(board: Board) = mutate { it.copy(boardSlug = board.slug, boardTitle = board.title) }
 
     fun selectPermission(permission: PostPermission) = mutate { it.copy(permission = permission) }
 
-    fun showPreview() {
-        _uiState.update { it.copy(mode = ComposerMode.PREVIEW) }
-    }
-
-    fun showEditor() {
-        _uiState.update { it.copy(mode = ComposerMode.EDIT) }
-    }
-
-    fun dismissRuleReminder() {
-        _uiState.update { it.copy(showRuleReminder = false, ruleReminderDismissed = true) }
+    fun setViewMode(mode: ComposerViewMode) {
+        _uiState.update { it.copy(viewMode = mode) }
+        if (mode != ComposerViewMode.CONTENT) loadAuthorName()
     }
 
     fun continueDraft() {
@@ -104,7 +112,6 @@ class PostComposerViewModel(
                 savedAtMillis = draft.savedAtMillis,
                 pendingDraft = null,
                 draftDecisionMade = true,
-                showRuleReminder = draft.boardSlug == TECH_BOARD,
             )
         }
     }
@@ -113,6 +120,23 @@ class PostComposerViewModel(
         viewModelScope.launch { repository.deleteDraft() }
         _uiState.update { it.copy(pendingDraft = null, draftDecisionMade = true) }
     }
+
+    // --- Attachments --------------------------------------------------------
+
+    fun addImages(images: List<PickedImage>) = uploads.enqueue(images)
+
+    fun retryUpload(attachment: ImageAttachment) = uploads.retry(attachment.id)
+
+    fun retryFailedUploads() = uploads.retryFailed()
+
+    /** Dismissing a finished upload also takes its Markdown out of the body it was written into. */
+    fun removeAttachment(attachment: ImageAttachment) {
+        val removed = uploads.remove(attachment.id) ?: return
+        val markdown = removed.markdown ?: return
+        mutate { it.copy(body = removeBlock(it.body, markdown)) }
+    }
+
+    // --- Publishing ---------------------------------------------------------
 
     fun publish(onPublished: (Long?) -> Unit) {
         val state = _uiState.value
@@ -149,6 +173,20 @@ class PostComposerViewModel(
         _uiState.update { it.copy(publishError = null, publishErrorDetail = null) }
     }
 
+    /**
+     * The preview's byline needs a name, and nothing else in the composer does — so it is fetched
+     * the first time a preview is opened rather than on entry, and a failure just leaves the byline
+     * one field shorter.
+     */
+    private fun loadAuthorName() {
+        val repository = profileRepository ?: return
+        if (_uiState.value.authorName != null || authorJob?.isActive == true) return
+        authorJob = viewModelScope.launch {
+            runCatchingExceptCancellation { repository.profile() }
+                .onSuccess { profile -> _uiState.update { it.copy(authorName = profile.name) } }
+        }
+    }
+
     private fun mutate(transform: (PostComposerUiState) -> PostComposerUiState) {
         _uiState.update { transform(it).copy(draftDecisionMade = true, pendingDraft = null) }
         scheduleSave()
@@ -173,7 +211,6 @@ class PostComposerViewModel(
 
     companion object {
         const val MAX_TITLE_LENGTH = 60
-        private const val TECH_BOARD = "tech"
         private const val AUTOSAVE_DELAY_MILLIS = 750L
 
         fun factory(container: AppContainer): ViewModelProvider.Factory = viewModelFactory {
@@ -183,13 +220,16 @@ class PostComposerViewModel(
                     boards = container.categoryRepository.boards,
                     session = container.sessionRepository.state,
                     clock = container.clock,
+                    uploader = container.imageUploader,
+                    profileRepository = container.profileRepository,
                 )
             }
         }
     }
 }
 
-enum class ComposerMode { EDIT, PREVIEW }
+/** The site's three editor views (§1.8). 对照 stacks them, which is the only way it fits a phone. */
+enum class ComposerViewMode { CONTENT, PREVIEW, COMPARE }
 
 data class PostComposerUiState(
     val isSignedIn: Boolean = false,
@@ -199,19 +239,30 @@ data class PostComposerUiState(
     val boardSlug: String? = null,
     val boardTitle: String? = null,
     val permission: PostPermission = PostPermission.PUBLIC,
-    val mode: ComposerMode = ComposerMode.EDIT,
+    val viewMode: ComposerViewMode = ComposerViewMode.CONTENT,
     val isPublishing: Boolean = false,
     val publishError: NodeSeekError? = null,
     val publishErrorDetail: String? = null,
     val savedAtMillis: Long? = null,
     val pendingDraft: PostDraft? = null,
     val draftDecisionMade: Boolean = false,
-    val showRuleReminder: Boolean = false,
-    val ruleReminderDismissed: Boolean = false,
+    val attachments: List<ImageAttachment> = emptyList(),
+    val authorName: String? = null,
 ) {
     val hasContent: Boolean get() = title.isNotBlank() || body.isNotBlank()
+
+    val failedUploadCount: Int get() = attachments.count { it.status == UploadStatus.FAILED }
+
+    /**
+     * Publishing is blocked while an upload is still moving: the Markdown for a pending image is
+     * written only when it lands, so posting early silently drops the picture from the thread.
+     */
     val canPublish: Boolean
-        get() = title.isNotBlank() && body.isNotBlank() && boardSlug != null && !isPublishing
+        get() = title.isNotBlank() &&
+            body.isNotBlank() &&
+            boardSlug != null &&
+            !isPublishing &&
+            attachments.none { it.status == UploadStatus.UPLOADING || it.status == UploadStatus.WAITING }
 }
 
 private fun PostComposerUiState.toDraft() = PostDraft(

--- a/app/src/main/java/io/github/nsreader/ui/composer/ReplyComposer.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/ReplyComposer.kt
@@ -101,6 +101,9 @@ fun ReplyComposerHost(
     onClearError: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // Above the early return on purpose: the host stays composed while the sheet is closed, so
+    // this is the one place the recents survive both the emoji panel and the sheet being dismissed.
+    var recentEmoji by rememberSaveable { mutableStateOf(listOf<String>()) }
     if (!state.visible) return
     val context = LocalContext.current
     val picker = rememberLauncherForActivityResult(
@@ -141,6 +144,8 @@ fun ReplyComposerHost(
             onRetryFailedUploads = onRetryFailedUploads,
             onPublish = onPublish,
             onClearError = onClearError,
+            recentEmoji = recentEmoji,
+            onRecentEmojiChange = { recentEmoji = it },
         )
     }
 }
@@ -159,6 +164,8 @@ private fun ReplyEditorSheet(
     onRetryFailedUploads: () -> Unit,
     onPublish: () -> Unit,
     onClearError: () -> Unit,
+    recentEmoji: List<String>,
+    onRecentEmojiChange: (List<String>) -> Unit,
 ) {
     var bodyValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(state.body, TextRange(state.body.length)))
@@ -176,7 +183,9 @@ private fun ReplyEditorSheet(
     }
 
     ModalBottomSheet(
-        onDismissRequest = onDismiss,
+        // Guarded like the close button and the BackHandler: while a publish is in flight, a swipe
+        // or scrim tap must not be the one dismiss path that still works.
+        onDismissRequest = { if (!state.isPublishing) onDismiss() },
         sheetState = rememberBottomSheetState(
             initialValue = SheetValue.Hidden,
             enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
@@ -299,6 +308,8 @@ private fun ReplyEditorSheet(
                 EmojiPanel(
                     onInsert = { text -> edit(insertText(bodyValue, text)) },
                     onBackspace = { edit(bodyValue.deleteBackwards()) },
+                    recent = recentEmoji,
+                    onRecentChange = onRecentEmojiChange,
                 )
             }
         }

--- a/app/src/main/java/io/github/nsreader/ui/composer/ReplyComposer.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/ReplyComposer.kt
@@ -1,0 +1,555 @@
+package io.github.nsreader.ui.composer
+
+import android.content.Context
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.nsreader.R
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.composer.ImageAttachment
+import io.github.nsreader.data.composer.PickedImage
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.theme.CommentBody
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+import java.text.DateFormat
+import java.util.Date
+
+/**
+ * The reply editor: a modal sheet (6d) that expands to a full-screen preview (C4).
+ *
+ * Hosted as a sibling of the thread rather than inside it, because both halves cover the screen —
+ * the sheet in its own window, the preview over everything — and neither belongs in the thread's
+ * own layout. The two are mutually exclusive: the preview replaces the sheet rather than stacking
+ * on it, which is what the shared-axis transition in the board describes.
+ */
+@Composable
+fun ReplyComposerHost(
+    state: ReplyComposerUiState,
+    onDismiss: () -> Unit,
+    onBodyChange: (String) -> Unit,
+    onClearQuote: () -> Unit,
+    onPreviewChange: (Boolean) -> Unit,
+    onPickImages: (List<PickedImage>) -> Unit,
+    onRemoveAttachment: (ImageAttachment) -> Unit,
+    onRetryAttachment: (ImageAttachment) -> Unit,
+    onRetryFailedUploads: () -> Unit,
+    onPublish: () -> Unit,
+    onClearError: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!state.visible) return
+    val context = LocalContext.current
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_PICK),
+    ) { uris -> onPickImages(uris.toPickedImages(context)) }
+    val launchPicker = {
+        picker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    }
+
+    Box(modifier.fillMaxSize()) {
+        AnimatedVisibility(
+            visible = state.previewing,
+            // Shared axis Y: the preview rises out of the sheet and sinks back into it, so the two
+            // read as one surface changing state rather than two screens swapping.
+            enter = fadeIn(spring(stiffness = SPRING_STIFFNESS)) +
+                slideInVertically(spring(stiffness = SPRING_STIFFNESS)) { it / SLIDE_FRACTION },
+            exit = fadeOut() + slideOutVertically { it / SLIDE_FRACTION },
+        ) {
+            ReplyPreviewScreen(
+                state = state,
+                onBack = { onPreviewChange(false) },
+                onPublish = onPublish,
+                onClearError = onClearError,
+            )
+        }
+    }
+
+    if (!state.previewing) {
+        ReplyEditorSheet(
+            state = state,
+            onDismiss = onDismiss,
+            onBodyChange = onBodyChange,
+            onClearQuote = onClearQuote,
+            onPreview = { onPreviewChange(true) },
+            onPickImages = launchPicker,
+            onRemoveAttachment = onRemoveAttachment,
+            onRetryAttachment = onRetryAttachment,
+            onRetryFailedUploads = onRetryFailedUploads,
+            onPublish = onPublish,
+            onClearError = onClearError,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReplyEditorSheet(
+    state: ReplyComposerUiState,
+    onDismiss: () -> Unit,
+    onBodyChange: (String) -> Unit,
+    onClearQuote: () -> Unit,
+    onPreview: () -> Unit,
+    onPickImages: () -> Unit,
+    onRemoveAttachment: (ImageAttachment) -> Unit,
+    onRetryAttachment: (ImageAttachment) -> Unit,
+    onRetryFailedUploads: () -> Unit,
+    onPublish: () -> Unit,
+    onClearError: () -> Unit,
+) {
+    var bodyValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(state.body, TextRange(state.body.length)))
+    }
+    var emojiOpen by rememberSaveable { mutableStateOf(false) }
+    val keyboard = LocalSoftwareKeyboardController.current
+    LaunchedEffect(state.body) {
+        if (state.body != bodyValue.text) {
+            bodyValue = TextFieldValue(state.body, TextRange(state.body.length))
+        }
+    }
+    fun edit(next: TextFieldValue) {
+        bodyValue = next
+        onBodyChange(next.text)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        ),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().imePadding()) {
+            Row(
+                modifier = Modifier.padding(start = Spacing.xl, end = Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = state.quote?.let {
+                        stringResource(R.string.post_reply_editor_title_floor, it.floor, it.author)
+                    } ?: stringResource(R.string.post_reply_editor_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                state.savedAtMillis?.let {
+                    Text(
+                        text = stringResource(R.string.post_reply_draft_saved, formatTime(it)),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = onDismiss, enabled = !state.isPublishing) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.action_close),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            state.quote?.let { quote ->
+                QuoteChip(
+                    excerpt = quote.excerpt,
+                    onClear = onClearQuote,
+                    modifier = Modifier.padding(start = Spacing.xl, end = Spacing.xl, top = Spacing.xs),
+                )
+            }
+            BasicTextField(
+                value = bodyValue,
+                onValueChange = ::edit,
+                textStyle = CommentBody.copy(
+                    fontSize = 16.sp,
+                    lineHeight = 26.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                ),
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                modifier = Modifier
+                    .readableWidth()
+                    .heightIn(min = MIN_EDITOR_HEIGHT, max = MAX_EDITOR_HEIGHT)
+                    .padding(horizontal = Spacing.xl, vertical = Spacing.sm),
+                decorationBox = { inner ->
+                    // Fills the width it was given: `readableWidth` centres what it wraps, so a
+                    // decoration that measures to its content would centre a half-typed reply.
+                    Box(Modifier.fillMaxWidth()) {
+                        if (bodyValue.text.isEmpty()) {
+                            Text(
+                                text = stringResource(R.string.post_reply_editor_hint),
+                                style = CommentBody.copy(fontSize = 16.sp, lineHeight = 26.sp),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        inner()
+                    }
+                },
+            )
+            AttachmentTray(
+                attachments = state.attachments,
+                onRemove = onRemoveAttachment,
+                onRetry = onRetryAttachment,
+            )
+            ComposerErrorStrip(
+                error = state.publishError,
+                detail = state.publishErrorDetail,
+                failedUploads = state.failedUploadCount,
+                onRetryPublish = onPublish,
+                onRetryUploads = onRetryFailedUploads,
+                onDismiss = onClearError,
+                modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.xs),
+            )
+            EditorToolbar(
+                actions = REPLY_ACTIONS,
+                active = if (emojiOpen) setOf(EditorAction.EMOJI) else emptySet(),
+                showDivider = false,
+                onAction = { action ->
+                    when (action) {
+                        EditorAction.IMAGE -> onPickImages()
+
+                        EditorAction.PREVIEW -> {
+                            keyboard?.hide()
+                            onPreview()
+                        }
+
+                        EditorAction.EMOJI -> {
+                            emojiOpen = !emojiOpen
+                            if (emojiOpen) keyboard?.hide()
+                        }
+
+                        else -> {
+                            emojiOpen = false
+                            edit(applyMarkdown(bodyValue, action))
+                        }
+                    }
+                },
+                trailing = {
+                    PublishReplyButton(
+                        isPublishing = state.isPublishing,
+                        enabled = state.canPublish,
+                        onClick = onPublish,
+                    )
+                },
+            )
+            if (emojiOpen) {
+                EmojiPanel(
+                    onInsert = { text -> edit(insertText(bodyValue, text)) },
+                    onBackspace = { edit(bodyValue.deleteBackwards()) },
+                )
+            }
+        }
+    }
+}
+
+/** C4: the sheet's content, full screen, rendered exactly the way the thread will render it. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReplyPreviewScreen(
+    state: ReplyComposerUiState,
+    onBack: () -> Unit,
+    onPublish: () -> Unit,
+    onClearError: () -> Unit,
+) {
+    BackHandler(enabled = !state.isPublishing, onBack = onBack)
+    Surface(color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxSize()) {
+        Column {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = state.quote?.let {
+                            stringResource(R.string.post_reply_preview_title_floor, it.floor)
+                        } ?: stringResource(R.string.post_reply_preview_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontSize = 16.sp,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack, enabled = !state.isPublishing) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                actions = {
+                    PublishReplyButton(
+                        isPublishing = state.isPublishing,
+                        enabled = state.canPublish,
+                        onClick = onPublish,
+                        modifier = Modifier.padding(end = Spacing.sm),
+                    )
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surface),
+            )
+            ComposerErrorStrip(
+                error = state.publishError,
+                detail = state.publishErrorDetail,
+                failedUploads = 0,
+                onRetryPublish = onPublish,
+                onRetryUploads = {},
+                onDismiss = onClearError,
+                modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.xs),
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .readableWidth()
+                    .padding(horizontal = Spacing.xl, vertical = Spacing.sm),
+                verticalArrangement = Arrangement.spacedBy(Spacing.sm + 2.dp),
+            ) {
+                state.quote?.let { quote ->
+                    QuoteReference(floor = quote.floor, author = quote.author, excerpt = quote.excerpt)
+                }
+                MarkdownPreviewBody(markdown = state.body)
+            }
+        }
+    }
+}
+
+/** The dismissible quote context above the reply field (6d). */
+@Composable
+private fun QuoteChip(
+    excerpt: String,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    ) {
+        Row(
+            modifier = Modifier.padding(start = Spacing.md, end = Spacing.xs, top = Spacing.sm, bottom = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs + 2.dp),
+        ) {
+            Icon(NodeSeekIcons.FormatQuote, contentDescription = null, modifier = Modifier.size(15.dp))
+            Text(
+                text = excerpt,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onClear, modifier = Modifier.size(24.dp)) {
+                Icon(
+                    Icons.Default.Close,
+                    contentDescription = stringResource(R.string.post_reply_quote_remove),
+                    modifier = Modifier.size(15.dp),
+                )
+            }
+        }
+    }
+}
+
+/** How the quote reads once published: an addressed chip, then the quoted floor. */
+@Composable
+private fun QuoteReference(
+    floor: Int,
+    author: String,
+    excerpt: String,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        Surface(
+            shape = RoundedCornerShape(11.dp),
+            color = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        ) {
+            Text(
+                text = "@$author ${stringResource(R.string.post_quote_prefix, floor)}",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(horizontal = 9.dp, vertical = 3.dp),
+            )
+        }
+        Row {
+            Box(
+                Modifier
+                    .width(3.dp)
+                    .heightIn(min = 20.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(MaterialTheme.colorScheme.outlineVariant),
+            )
+            Text(
+                text = excerpt,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = Spacing.md),
+            )
+        }
+    }
+}
+
+/**
+ * Failures, inline.
+ *
+ * The post editor puts these on a Snackbar; the reply editor cannot, because its own sheet is a
+ * separate window that a Snackbar would appear behind. Inline also keeps the message on screen
+ * next to the text it is talking about, which for "草稿已保留" is the reassurance that matters.
+ */
+@Composable
+private fun ComposerErrorStrip(
+    error: NodeSeekError?,
+    detail: String?,
+    failedUploads: Int,
+    onRetryPublish: () -> Unit,
+    onRetryUploads: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val message = when {
+        error != null -> stringResource(R.string.post_reply_publish_failed, replyErrorReason(error, detail))
+        failedUploads > 0 -> stringResource(R.string.composer_image_failed_count, failedUploads)
+        else -> return
+    }
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(start = Spacing.md, end = Spacing.xs, top = Spacing.sm, bottom = Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = message, style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
+            TextButton(
+                onClick = {
+                    if (error != null) {
+                        onDismiss()
+                        onRetryPublish()
+                    } else {
+                        onRetryUploads()
+                    }
+                },
+                contentPadding = PaddingValues(horizontal = Spacing.md),
+            ) {
+                Text(stringResource(R.string.action_retry), color = MaterialTheme.colorScheme.onErrorContainer)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PublishReplyButton(
+    isPublishing: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled && !isPublishing,
+        contentPadding = PaddingValues(horizontal = 18.dp),
+        modifier = modifier.height(40.dp),
+    ) {
+        if (isPublishing) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(14.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onPrimary,
+            )
+        } else {
+            Icon(Icons.Default.Send, contentDescription = null, modifier = Modifier.size(18.dp))
+        }
+        Text(
+            text = stringResource(if (isPublishing) R.string.composer_publishing else R.string.action_publish),
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier.padding(start = Spacing.xs + 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun replyErrorReason(error: NodeSeekError, detail: String?): String = when (error) {
+    NodeSeekError.Network -> stringResource(R.string.composer_publish_network_failed)
+    NodeSeekError.LoginRequired -> stringResource(R.string.composer_publish_login_required)
+    NodeSeekError.Cloudflare -> stringResource(R.string.composer_publish_challenge)
+    is NodeSeekError.Http -> stringResource(R.string.composer_publish_http, error.statusCode)
+    else -> detail?.takeIf { it.isNotBlank() } ?: stringResource(R.string.post_reply_publish_unavailable)
+}
+
+private fun formatTime(timestamp: Long): String =
+    DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(timestamp))
+
+private val REPLY_ACTIONS = listOf(
+    EditorAction.BOLD,
+    EditorAction.CODE,
+    EditorAction.QUOTE,
+    EditorAction.MENTION,
+    EditorAction.IMAGE,
+    EditorAction.EMOJI,
+    EditorAction.PREVIEW,
+)
+
+private val MIN_EDITOR_HEIGHT = 96.dp
+private val MAX_EDITOR_HEIGHT = 260.dp
+private const val MAX_IMAGES_PER_PICK = 9
+private const val SLIDE_FRACTION = 6
+private const val SPRING_STIFFNESS = 400f

--- a/app/src/main/java/io/github/nsreader/ui/composer/ReplyComposerViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/ReplyComposerViewModel.kt
@@ -1,0 +1,235 @@
+package io.github.nsreader.ui.composer
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.AppClock
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.composer.CommentComposerRepository
+import io.github.nsreader.data.composer.CommentDraft
+import io.github.nsreader.data.composer.CommentSubmission
+import io.github.nsreader.data.composer.ImageAttachment
+import io.github.nsreader.data.composer.ImageUploadQueue
+import io.github.nsreader.data.composer.ImageUploader
+import io.github.nsreader.data.composer.PickedImage
+import io.github.nsreader.data.composer.UploadStatus
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/** Which floor a reply answers, and enough of it to keep the reply readable on its own. */
+data class ReplyQuote(
+    val floor: Int,
+    val author: String,
+    val excerpt: String,
+)
+
+/**
+ * The reply editor behind 6d and C4.
+ *
+ * Scoped to the thread rather than to the sheet: closing the sheet must not throw away what has
+ * been typed, and the draft is keyed by post id so two half-written replies in two threads do not
+ * overwrite each other.
+ */
+class ReplyComposerViewModel(
+    private val postId: Long,
+    private val repository: CommentComposerRepository,
+    private val clock: AppClock,
+    uploader: ImageUploader,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ReplyComposerUiState())
+    val uiState: StateFlow<ReplyComposerUiState> = _uiState.asStateFlow()
+
+    private val uploads = ImageUploadQueue(viewModelScope, uploader)
+
+    private var saveJob: Job? = null
+    private var publishJob: Job? = null
+
+    init {
+        uploads.attachments
+            .onEach { attachments -> _uiState.update { it.copy(attachments = attachments) } }
+            .launchIn(viewModelScope)
+        uploads.uploaded
+            .onEach { attachment ->
+                val markdown = attachment.markdown ?: return@onEach
+                mutate { it.copy(body = appendBlock(it.body, markdown)) }
+            }.launchIn(viewModelScope)
+    }
+
+    /**
+     * Opens the sheet, restoring whatever was left behind.
+     *
+     * A [quote] passed in wins over the stored one — tapping 回复 on a different floor is a new
+     * intent, and silently answering the previous floor would be worse than losing the old context.
+     */
+    fun open(quote: ReplyQuote? = null) {
+        viewModelScope.launch {
+            val stored = repository.draft(postId).first()
+            _uiState.update { current ->
+                val restored = if (current.body.isBlank() && stored != null) {
+                    current.copy(
+                        body = stored.body,
+                        savedAtMillis = stored.savedAtMillis.takeIf { it > 0 },
+                        quote = stored.toQuote(),
+                    )
+                } else {
+                    current
+                }
+                restored.copy(visible = true, previewing = false, quote = quote ?: restored.quote)
+            }
+        }
+    }
+
+    fun close() {
+        _uiState.update { it.copy(visible = false, previewing = false) }
+    }
+
+    fun updateBody(body: String) = mutate { it.copy(body = body) }
+
+    fun clearQuote() = mutate { it.copy(quote = null) }
+
+    fun setPreviewing(previewing: Boolean) {
+        _uiState.update { it.copy(previewing = previewing) }
+    }
+
+    fun addImages(images: List<PickedImage>) = uploads.enqueue(images)
+
+    fun retryUpload(attachment: ImageAttachment) = uploads.retry(attachment.id)
+
+    fun retryFailedUploads() = uploads.retryFailed()
+
+    fun removeAttachment(attachment: ImageAttachment) {
+        val removed = uploads.remove(attachment.id) ?: return
+        val markdown = removed.markdown ?: return
+        mutate { it.copy(body = removeBlock(it.body, markdown)) }
+    }
+
+    fun publish(onPublished: (Int?) -> Unit) {
+        val state = _uiState.value
+        if (!state.canPublish || publishJob?.isActive == true) return
+        publishJob = viewModelScope.launch {
+            _uiState.update { it.copy(isPublishing = true, publishError = null, publishErrorDetail = null) }
+            runCatchingExceptCancellation {
+                repository.publish(
+                    CommentSubmission(
+                        postId = postId,
+                        body = state.submissionBody,
+                        quotedFloor = state.quote?.floor,
+                    ),
+                )
+            }.onSuccess { floor ->
+                saveJob?.cancel()
+                repository.deleteDraft(postId)
+                _uiState.value = ReplyComposerUiState()
+                uploads.clear()
+                onPublished(floor)
+            }.onFailure { throwable ->
+                _uiState.update {
+                    it.copy(
+                        isPublishing = false,
+                        publishError = (throwable as? NodeSeekException)?.error ?: NodeSeekError.Unknown,
+                        publishErrorDetail = throwable.message,
+                    )
+                }
+            }
+        }
+    }
+
+    fun clearPublishError() {
+        _uiState.update { it.copy(publishError = null, publishErrorDetail = null) }
+    }
+
+    private fun mutate(transform: (ReplyComposerUiState) -> ReplyComposerUiState) {
+        _uiState.update(transform)
+        scheduleSave()
+    }
+
+    private fun scheduleSave() {
+        saveJob?.cancel()
+        saveJob = viewModelScope.launch {
+            delay(AUTOSAVE_DELAY_MILLIS)
+            val state = _uiState.value
+            if (state.body.isBlank()) {
+                repository.deleteDraft(postId)
+                _uiState.update { it.copy(savedAtMillis = null) }
+                return@launch
+            }
+            repository.saveDraft(postId, state.toDraft())
+            _uiState.update { it.copy(savedAtMillis = clock.nowMillis()) }
+        }
+    }
+
+    companion object {
+        private const val AUTOSAVE_DELAY_MILLIS = 750L
+
+        fun factory(container: AppContainer, postId: Long): ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                ReplyComposerViewModel(
+                    postId = postId,
+                    repository = container.commentComposerRepository,
+                    clock = container.clock,
+                    uploader = container.imageUploader,
+                )
+            }
+        }
+    }
+}
+
+data class ReplyComposerUiState(
+    val visible: Boolean = false,
+    val previewing: Boolean = false,
+    val body: String = "",
+    val quote: ReplyQuote? = null,
+    val savedAtMillis: Long? = null,
+    val isPublishing: Boolean = false,
+    val publishError: NodeSeekError? = null,
+    val publishErrorDetail: String? = null,
+    val attachments: List<ImageAttachment> = emptyList(),
+) {
+    val failedUploadCount: Int get() = attachments.count { it.status == UploadStatus.FAILED }
+
+    val canPublish: Boolean
+        get() = body.isNotBlank() &&
+            !isPublishing &&
+            attachments.none { it.status == UploadStatus.UPLOADING || it.status == UploadStatus.WAITING }
+
+    /**
+     * What actually gets sent: the quote is a chip in the editor but a Markdown blockquote on the
+     * wire, because that is how the site's own quote button leaves it in the comment source.
+     */
+    val submissionBody: String
+        get() = quote?.let { quote ->
+            buildString {
+                append("> ")
+                append(quote.excerpt.replace("\n", "\n> "))
+                append("\n\n@")
+                append(quote.author)
+                append(' ')
+            }
+        }.orEmpty() + body
+}
+
+private fun ReplyComposerUiState.toDraft() = CommentDraft(
+    body = body,
+    quotedFloor = quote?.floor,
+    quotedAuthor = quote?.author,
+    quotedText = quote?.excerpt,
+    savedAtMillis = savedAtMillis ?: 0L,
+)
+
+private fun CommentDraft.toQuote(): ReplyQuote? {
+    val floor = quotedFloor ?: return null
+    return ReplyQuote(floor = floor, author = quotedAuthor.orEmpty(), excerpt = quotedText.orEmpty())
+}

--- a/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailScreen.kt
@@ -87,6 +87,9 @@ import io.github.nsreader.ui.common.NodeSeekErrorState
 import io.github.nsreader.ui.common.NodeSeekIcons
 import io.github.nsreader.ui.common.UserAvatar
 import io.github.nsreader.ui.common.rememberClipboardCopy
+import io.github.nsreader.ui.composer.ReplyComposerHost
+import io.github.nsreader.ui.composer.ReplyComposerViewModel
+import io.github.nsreader.ui.composer.ReplyQuote
 import io.github.nsreader.ui.richtext.RichContent
 import io.github.nsreader.ui.theme.NodeSeekTheme
 import io.github.nsreader.ui.theme.PostTitle
@@ -99,6 +102,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun PostDetailRoute(
     viewModel: PostDetailViewModel,
+    replyViewModel: ReplyComposerViewModel,
     onBack: () -> Unit,
     onOpenBrowser: (String) -> Unit,
     onSignIn: () -> Unit,
@@ -108,6 +112,7 @@ fun PostDetailRoute(
     initialFloor: String? = null,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val replyState by replyViewModel.uiState.collectAsStateWithLifecycle()
     val postUrl = viewModel.postUrl()
     PostDetailScreen(
         state = state,
@@ -122,7 +127,25 @@ fun PostDetailRoute(
         onLoadMore = viewModel::loadNextPage,
         onLoadPage = viewModel::loadPage,
         onPageScrollHandled = viewModel::onPageScrollHandled,
+        // Replying needs an account; sending an anonymous reply into the void is the one outcome
+        // the editor must not produce, so the sign-in page comes first.
+        onReply = { quote -> if (state.isSignedIn) replyViewModel.open(quote) else onSignIn() },
+        replyOpen = replyState.visible,
         modifier = modifier,
+    )
+
+    ReplyComposerHost(
+        state = replyState,
+        onDismiss = replyViewModel::close,
+        onBodyChange = replyViewModel::updateBody,
+        onClearQuote = replyViewModel::clearQuote,
+        onPreviewChange = replyViewModel::setPreviewing,
+        onPickImages = replyViewModel::addImages,
+        onRemoveAttachment = replyViewModel::removeAttachment,
+        onRetryAttachment = replyViewModel::retryUpload,
+        onRetryFailedUploads = replyViewModel::retryFailedUploads,
+        onPublish = { replyViewModel.publish { viewModel.refresh() } },
+        onClearError = replyViewModel::clearPublishError,
     )
 }
 
@@ -144,13 +167,15 @@ fun PostDetailScreen(
     onSignIn: () -> Unit = { onOpenBrowser(postUrl) },
     /** Clears a Cloudflare challenge on this thread's own URL. */
     onVerify: () -> Unit = { onOpenBrowser(postUrl) },
+    /** `null` opens an empty reply; a quote answers one floor (6d). The editor itself is hosted by the route. */
+    onReply: (ReplyQuote?) -> Unit = {},
+    /** Hides the bottom toolbar while the editor covers it. */
+    replyOpen: Boolean = false,
 ) {
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var chickenTarget by remember { mutableStateOf<PostContent?>(null) }
     var showPageSheet by remember { mutableStateOf(false) }
-    var showReplySheet by remember { mutableStateOf(false) }
-    var replyDraft by rememberSaveable { mutableStateOf("") }
     var pageToolbarExpanded by rememberSaveable { mutableStateOf(true) }
     var hasJumpedToInitialFloor by remember(initialFloor) { mutableStateOf(false) }
     val collapsedTitleThreshold = with(LocalDensity.current) { 72.dp.roundToPx() }
@@ -267,6 +292,7 @@ fun PostDetailScreen(
                             if (index != null) scope.launch { listState.animateScrollToItem(index) }
                         },
                         onChickenClick = { chickenTarget = it },
+                        onReplyToFloor = onReply,
                         modifier =
                         Modifier.floatingToolbarVerticalNestedScroll(
                             expanded = toolbarExpanded,
@@ -276,7 +302,7 @@ fun PostDetailScreen(
                     )
             }
 
-            if (state.body != null && !showReplySheet) {
+            if (state.body != null && !replyOpen) {
                 DetailBottomActions(
                     toolbarExpanded = toolbarExpanded,
                     page = visiblePage,
@@ -287,7 +313,7 @@ fun PostDetailScreen(
                         if (next <= state.page) scrollToPage(next) else onLoadPage(next)
                     },
                     onPageClick = { showPageSheet = true },
-                    onReply = { showReplySheet = true },
+                    onReply = { onReply(null) },
                     modifier = Modifier.align(Alignment.BottomEnd),
                 )
             }
@@ -314,14 +340,6 @@ fun PostDetailScreen(
                 val clamped = target.coerceIn(1, state.totalPages.coerceAtLeast(1))
                 if (clamped <= state.page) scrollToPage(clamped) else onLoadPage(clamped)
             },
-        )
-    }
-
-    if (showReplySheet) {
-        ReplyEditorSheet(
-            draft = replyDraft,
-            onDraftChange = { replyDraft = it },
-            onDismiss = { showReplySheet = false },
         )
     }
 }
@@ -465,106 +483,6 @@ private fun PageJumpSheet(
     }
 }
 
-/**
- * The reply editor shell. Posting a reply is not implemented yet, so everything that would promise
- * otherwise is disabled: the publish button, and the formatting actions that have no handler. The
- * draft lives with the screen, not the sheet, so closing the sheet does not silently discard it.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ReplyEditorSheet(
-    draft: String,
-    onDraftChange: (String) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val boldDescription = stringResource(R.string.post_tool_bold)
-    val quoteDescription = stringResource(R.string.post_tool_quote)
-    val emojiDescription = stringResource(R.string.post_tool_emoji)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState =
-        rememberBottomSheetState(
-            initialValue = SheetValue.Hidden,
-            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
-        ),
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg).imePadding(),
-            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Column(Modifier.weight(1f)) {
-                    Text(stringResource(R.string.post_reply_editor_title), style = MaterialTheme.typography.titleLarge)
-                    Text(
-                        stringResource(R.string.post_reply_wip),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                IconButton(onClick = onDismiss) {
-                    Icon(Icons.Default.Close, contentDescription = stringResource(R.string.action_cancel))
-                }
-            }
-            BasicTextField(
-                value = draft,
-                onValueChange = onDraftChange,
-                modifier = Modifier.fillMaxWidth().heightIn(min = 120.dp).padding(vertical = Spacing.sm),
-                textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
-                decorationBox = { inner ->
-                    Box {
-                        if (draft.isEmpty()) {
-                            Text(
-                                stringResource(R.string.post_reply_editor_hint),
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        inner()
-                    }
-                },
-            )
-            HorizontalDivider()
-            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-                TextButton(
-                    onClick = {},
-                    enabled = false,
-                    modifier =
-                    Modifier.semantics {
-                        contentDescription = boldDescription
-                    },
-                ) {
-                    Text("B", fontWeight = FontWeight.Bold)
-                }
-                TextButton(
-                    onClick = {},
-                    enabled = false,
-                    modifier =
-                    Modifier.semantics {
-                        contentDescription = quoteDescription
-                    },
-                ) {
-                    Text(">_")
-                }
-                TextButton(onClick = {}, enabled = false) { Text(stringResource(R.string.post_tool_image)) }
-                TextButton(
-                    onClick = {},
-                    enabled = false,
-                    modifier =
-                    Modifier.semantics {
-                        contentDescription = emojiDescription
-                    },
-                ) {
-                    Text("🙂")
-                }
-                Box(Modifier.weight(1f))
-                Button(onClick = {}, enabled = false) {
-                    Text(stringResource(R.string.action_publish))
-                }
-            }
-            androidx.compose.foundation.layout.Spacer(Modifier.height(Spacing.lg))
-        }
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DetailTopBar(
@@ -657,6 +575,7 @@ private fun ThreadList(
     onImageClick: (String) -> Unit,
     onJumpToFloor: (String) -> Unit,
     onChickenClick: (PostContent) -> Unit,
+    onReplyToFloor: (ReplyQuote?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(
@@ -696,6 +615,7 @@ private fun ThreadList(
                 onImageClick = onImageClick,
                 onJumpToFloor = onJumpToFloor,
                 onChickenClick = { onChickenClick(comment) },
+                onReply = { onReplyToFloor(comment.toReplyQuote()) },
             )
         }
 
@@ -868,6 +788,7 @@ private fun CommentRow(
     onImageClick: (String) -> Unit,
     onJumpToFloor: (String) -> Unit,
     onChickenClick: () -> Unit,
+    onReply: () -> Unit,
 ) {
     Column(
         modifier = Modifier.padding(
@@ -909,7 +830,7 @@ private fun CommentRow(
             textStyle = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.padding(start = 36.dp, top = Spacing.sm),
         )
-        ReactionRow(onChickenClick = onChickenClick)
+        ReactionRow(onChickenClick = onChickenClick, onReply = onReply)
     }
 }
 
@@ -917,6 +838,7 @@ private fun CommentRow(
 private fun ReactionRow(
     onChickenClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onReply: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier.fillMaxWidth().padding(top = Spacing.sm),
@@ -931,6 +853,16 @@ private fun ReactionRow(
             onClick = onChickenClick,
         )
         QuietReaction(NodeSeekIcons.ThumbDown, R.string.post_reaction_dislike, "0")
+        // The one interaction on a floor that is actually wired up. It carries the floor into the
+        // editor as a quote, which is what 6d's "回复 #12 · nssk" header is showing.
+        onReply?.let {
+            QuietReaction(
+                icon = NodeSeekIcons.Reply,
+                label = R.string.post_reply_action,
+                count = "",
+                onClick = it,
+            )
+        }
     }
 }
 
@@ -943,11 +875,13 @@ private fun QuietReaction(
 ) {
     TextButton(onClick = onClick ?: {}, enabled = onClick != null) {
         Icon(icon, contentDescription = stringResource(label), modifier = Modifier.size(18.dp))
-        Text(
-            text = count,
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.padding(start = Spacing.xs),
-        )
+        if (count.isNotEmpty()) {
+            Text(
+                text = count,
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.padding(start = Spacing.xs),
+            )
+        }
     }
 }
 
@@ -994,6 +928,39 @@ private fun OriginalPosterBadge() {
             .padding(horizontal = 7.dp, vertical = 1.dp),
     )
 }
+
+/**
+ * The quote context the reply editor opens with.
+ *
+ * `null` for a floor with no number — a reply that says "回复 #" answers nothing, and the editor
+ * handles a missing quote perfectly well by opening empty.
+ */
+private fun PostContent.toReplyQuote(): ReplyQuote? {
+    val number = floor?.trimStart('#')?.toIntOrNull() ?: return null
+    return ReplyQuote(floor = number, author = authorName, excerpt = nodes.excerpt())
+}
+
+/** First readable line of a floor, short enough to sit on one line of the quote chip. */
+private fun List<RichNode>.excerpt(): String {
+    val text = firstNotNullOfOrNull { node ->
+        when (node) {
+            is RichNode.Paragraph -> node.inlines.plainText()
+            is RichNode.Heading -> node.inlines.plainText()
+            else -> null
+        }?.takeIf(String::isNotBlank)
+    }.orEmpty().trim()
+    return if (text.length > EXCERPT_LENGTH) text.take(EXCERPT_LENGTH).trimEnd() + "…" else text
+}
+
+private fun List<InlineNode>.plainText(): String = joinToString("") { inline ->
+    when (inline) {
+        is InlineNode.Text -> inline.text
+        is InlineNode.Link -> inline.text
+        else -> ""
+    }
+}
+
+private const val EXCERPT_LENGTH = 40
 
 /** Tabular figures so `#9` and `#127` sit on the same right edge as the list scrolls. */
 @Composable

--- a/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailScreen.kt
@@ -940,17 +940,21 @@ private fun PostContent.toReplyQuote(): ReplyQuote? {
     return ReplyQuote(floor = number, author = authorName, excerpt = nodes.excerpt())
 }
 
-/** First readable line of a floor, short enough to sit on one line of the quote chip. */
-private fun List<RichNode>.excerpt(): String {
-    val text = firstNotNullOfOrNull { node ->
-        when (node) {
-            is RichNode.Paragraph -> node.inlines.plainText()
-            is RichNode.Heading -> node.inlines.plainText()
-            else -> null
-        }?.takeIf(String::isNotBlank)
-    }.orEmpty().trim()
-    return if (text.length > EXCERPT_LENGTH) text.take(EXCERPT_LENGTH).trimEnd() + "…" else text
-}
+/**
+ * The floor's readable text, in full.
+ *
+ * Deliberately not truncated here: the same string is the chip's label, the preview's quote block
+ * *and* the blockquote that goes on the wire, and only the first of those wants to be short. The
+ * chip ellipsizes at render time; publishing a quote cut to 40 characters with a `…` would put a
+ * mangled quote into a real thread the moment the comment endpoint is wired up.
+ */
+private fun List<RichNode>.excerpt(): String = mapNotNull { node ->
+    when (node) {
+        is RichNode.Paragraph -> node.inlines.plainText()
+        is RichNode.Heading -> node.inlines.plainText()
+        else -> null
+    }?.trim()?.takeIf(String::isNotBlank)
+}.joinToString("\n")
 
 private fun List<InlineNode>.plainText(): String = joinToString("") { inline ->
     when (inline) {
@@ -959,8 +963,6 @@ private fun List<InlineNode>.plainText(): String = joinToString("") { inline ->
         else -> ""
     }
 }
-
-private const val EXCERPT_LENGTH = 40
 
 /** Tabular figures so `#9` and `#127` sit on the same right edge as the list scrolls. */
 @Composable

--- a/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailViewModel.kt
@@ -99,6 +99,12 @@ class PostDetailViewModel(
             }
         }
 
+        // The reply editor is the only thing here that needs an account, and it needs to know before
+        // it opens rather than after a failed publish.
+        session
+            .onEach { sessionState -> _uiState.update { it.copy(isSignedIn = sessionState.isSignedIn) } }
+            .launchIn(viewModelScope)
+
         // Coming back from the WebView signed in, or with a challenge cleared, is the one case where a
         // thread that was "fresh" a second ago is worth re-fetching: a locked thread has content now.
         // `drop(1)` skips the cookies we started with — a cold start is not a session change.
@@ -224,6 +230,7 @@ data class PostDetailUiState(
     val hasNextPage: Boolean = false,
     val isLoading: Boolean = false,
     val isAppending: Boolean = false,
+    val isSignedIn: Boolean = false,
     /** A page the screen should scroll to once its comments are in [comments]. */
     val pendingScrollPage: Int? = null,
     val error: NodeSeekError? = null,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,17 +43,18 @@
     <string name="composer_body_hint">写下正文，支持 Markdown…</string>
     <string name="composer_title_count">%1$d/%2$d</string>
     <string name="composer_select_board">选择版块</string>
-    <string name="composer_permission">阅读权限：%1$s</string>
     <string name="composer_permission_public">公开</string>
     <string name="composer_permission_level_one" tools:ignore="Typos">Lv1</string>
     <string name="composer_permission_private">私有</string>
     <string name="composer_draft_saved">草稿 %1$s</string>
     <string name="composer_draft_saving">草稿自动保存</string>
-    <string name="composer_rule_title">技术版发帖提醒</string>
-    <string name="composer_rule_body">请带上系统版本与可复现步骤；纯提问请优先发到「日常」。</string>
-    <string name="composer_rule_dismiss">关闭版规提醒</string>
+    <string name="composer_publishing">发布中</string>
+    <!-- The site's own right-hand rules card, verbatim in substance; shown on every board -->
+    <string name="composer_rule_title">重要提醒</string>
+    <string name="composer_rule_body">敏感话题请发内版 · 发卡站 / 大量出售必须发推广 · 禁止人身攻击 · 违规将受惩罚</string>
     <string name="composer_restore_title">继续上次的草稿？</string>
     <string name="composer_restore_body">保存于 %1$s · %2$s · 「%3$s」</string>
+    <string name="composer_restore_body_images">保存于 %1$s · %2$s · 「%3$s」，含 %4$d 张图片。</string>
     <string name="composer_restore_continue">继续编辑</string>
     <string name="composer_restore_discard">放弃草稿</string>
     <string name="composer_publish_failed">发布失败：%1$s，草稿已保留</string>
@@ -65,12 +66,37 @@
     <string name="composer_format_bold">加粗</string>
     <string name="composer_format_heading">二级标题</string>
     <string name="composer_format_code">行内代码</string>
+    <string name="composer_format_quote">引用</string>
     <string name="composer_format_list">无序列表</string>
     <string name="composer_format_link">链接</string>
+    <string name="composer_format_mention">提到某人</string>
     <string name="composer_format_image">图片</string>
     <string name="composer_format_emoji">表情</string>
     <string name="composer_preview_empty">正文预览会显示在这里</string>
     <string name="composer_just_now">刚刚</string>
+    <string name="composer_view_content">内容</string>
+    <string name="composer_view_preview">预览</string>
+    <string name="composer_view_compare">对照</string>
+
+    <!-- Image attachments: NodeImage is the site's own host -->
+    <string name="composer_image_uploading">上传中 %1$d%%</string>
+    <string name="composer_image_uploaded">已上传</string>
+    <string name="composer_image_failed">失败 · 重试</string>
+    <string name="composer_image_waiting">等待中</string>
+    <string name="composer_image_remove">移除 %1$s</string>
+    <string name="composer_image_retry_one">重试上传 %1$s</string>
+    <string name="composer_image_failed_count">%1$d 张图片上传失败</string>
+    <string name="composer_image_default_name">图片</string>
+
+    <!-- Emoji panel: five groups, matching the site's own editor -->
+    <string name="composer_emoji_group_acn">AC娘</string>
+    <string name="composer_emoji_group_onion">洋葱头</string>
+    <string name="composer_emoji_group_chick">小黄鸡</string>
+    <string name="composer_emoji_group_fluent">Fluent</string>
+    <string name="composer_emoji_group_app">App</string>
+    <string name="composer_emoji_recent">最近使用</string>
+    <string name="composer_emoji_backspace">删除</string>
+    <string name="composer_emoji_stickers_pending">站内贴图素材尚未接入，先用下面两组 emoji</string>
 
     <!-- Post detail -->
     <string name="post_comments_header">评论 · %1$d</string>
@@ -94,12 +120,15 @@
     <string name="post_last_page">最后一页</string>
     <string name="post_go_page">前往第 %1$s 页</string>
     <string name="post_reply_editor_title">回复</string>
-    <string name="post_reply_wip">回复功能开发中，暂不可发布</string>
+    <string name="post_reply_editor_title_floor">回复 #%1$d · %2$s</string>
     <string name="post_reply_editor_hint">写下你的回复…</string>
-    <string name="post_tool_bold">加粗</string>
-    <string name="post_tool_quote">引用</string>
-    <string name="post_tool_image">图片</string>
-    <string name="post_tool_emoji">表情</string>
+    <string name="post_reply_preview_title">预览 · 回复</string>
+    <string name="post_reply_preview_title_floor">预览 · 回复 #%1$d</string>
+    <string name="post_reply_draft_saved">草稿已保存 %1$s</string>
+    <string name="post_reply_quote_remove">移除引用</string>
+    <string name="post_reply_publish_failed">发布失败：%1$s，草稿已保留</string>
+    <string name="post_reply_publish_unavailable">评论发布接口尚未接入</string>
+    <string name="post_quote_prefix">#%1$d</string>
     <string name="post_reaction_like">点赞</string>
     <string name="post_reaction_chicken">投喂鸡腿</string>
     <string name="post_reaction_dislike">点踩</string>

--- a/app/src/test/java/io/github/nsreader/ui/composer/MarkdownEditingTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/composer/MarkdownEditingTest.kt
@@ -74,4 +74,14 @@ class MarkdownEditingTest {
 
         assertEquals("赞一个", result.text)
     }
+
+    @Test
+    fun `backspace removes a variation-selector emoji in one tap`() {
+        // ❤️ is U+2764 + U+FE0F; a code-point step would leave the black text-style heart behind.
+        val value = TextFieldValue("好❤️", TextRange("好❤️".length))
+
+        val result = value.deleteBackwards()
+
+        assertEquals("好", result.text)
+    }
 }

--- a/app/src/test/java/io/github/nsreader/ui/composer/MarkdownEditingTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/composer/MarkdownEditingTest.kt
@@ -1,0 +1,77 @@
+package io.github.nsreader.ui.composer
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** The toolbar's text transforms, including where the caret lands afterwards. */
+class MarkdownEditingTest {
+    @Test
+    fun `bold wraps the selection and keeps it selected`() {
+        val value = TextFieldValue("规则改名费用", TextRange(2, 4))
+
+        val result = applyMarkdown(value, EditorAction.BOLD)
+
+        assertEquals("规则**改名**费用", result.text)
+        assertEquals(TextRange(4, 6), result.selection)
+    }
+
+    @Test
+    fun `bold on an empty selection inserts a placeholder that the next keystroke replaces`() {
+        val result = applyMarkdown(TextFieldValue("", TextRange(0)), EditorAction.BOLD)
+
+        assertEquals("**加粗文字**", result.text)
+        assertEquals(TextRange(2, 6), result.selection)
+    }
+
+    @Test
+    fun `a link puts the caret in the empty address, not on the label`() {
+        val result = applyMarkdown(TextFieldValue("看这个", TextRange(0, 3)), EditorAction.LINK)
+
+        assertEquals("[看这个](https://)", result.text)
+        assertEquals(TextRange("[看这个](https://".length), result.selection)
+    }
+
+    @Test
+    fun `line prefixes toggle rather than stacking`() {
+        val quoted = applyMarkdown(TextFieldValue("第二行", TextRange(1)), EditorAction.QUOTE)
+        assertEquals("> 第二行", quoted.text)
+
+        val unquoted = applyMarkdown(quoted, EditorAction.QUOTE)
+        assertEquals("第二行", unquoted.text)
+    }
+
+    @Test
+    fun `a line prefix applies to the caret's own line`() {
+        val value = TextFieldValue("第一行\n第二行", TextRange(5))
+
+        val result = applyMarkdown(value, EditorAction.LIST)
+
+        assertEquals("第一行\n- 第二行", result.text)
+    }
+
+    @Test
+    fun `an appended image starts its own block, and removing it leaves the body as it was`() {
+        val image = "![a.png](https://cdn.nodeimage.com/i/a.webp)"
+
+        val withImage = appendBlock("正文", image)
+
+        assertEquals("正文\n\n$image", withImage)
+        assertEquals("正文", removeBlock(withImage, image))
+    }
+
+    @Test
+    fun `appending to an empty body does not open with blank lines`() {
+        assertEquals("![a](u)", appendBlock("", "![a](u)"))
+    }
+
+    @Test
+    fun `backspace removes a whole emoji rather than half of it`() {
+        val value = TextFieldValue("赞一个🎉", TextRange("赞一个🎉".length))
+
+        val result = value.deleteBackwards()
+
+        assertEquals("赞一个", result.text)
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/composer/PostComposerScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/composer/PostComposerScreenTest.kt
@@ -1,0 +1,144 @@
+package io.github.nsreader.ui.composer
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.github.nsreader.data.composer.ImageAttachment
+import io.github.nsreader.data.composer.PostDraft
+import io.github.nsreader.data.composer.UploadStatus
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/** Screen-level tests for the post editor (boards 7a–7c and C5). */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class PostComposerScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private var viewMode = ComposerViewMode.CONTENT
+    private var removed: ImageAttachment? = null
+
+    private fun setScreen(state: PostComposerUiState) {
+        composeRule.setContent {
+            NodeSeekTheme {
+                PostComposerScreen(
+                    state = state,
+                    snackbarHostState = SnackbarHostState(),
+                    onClose = {},
+                    onTitleChange = {},
+                    onBodyChange = {},
+                    onBoardSelect = {},
+                    onPermissionSelect = {},
+                    onViewModeChange = { viewMode = it },
+                    onPickImages = {},
+                    onRemoveAttachment = { removed = it },
+                    onRetryAttachment = {},
+                    onPublish = {},
+                    onContinueDraft = {},
+                    onDiscardDraft = {},
+                )
+            }
+        }
+    }
+
+    private fun draftState(
+        title: String = "Debian 13 上用 nftables 做端口转发的坑",
+        body: String = "最近把小鸡从 Debian 12 升到 13。",
+    ) = PostComposerUiState(
+        title = title,
+        body = body,
+        boardSlug = "tech",
+        boardTitle = "技术",
+        draftDecisionMade = true,
+        isSignedIn = true,
+    )
+
+    @Test
+    fun `the editor shows the board, the reading limit and the title counter`() {
+        setScreen(draftState())
+
+        composeRule.onNodeWithText("技术").assertIsDisplayed()
+        composeRule.onNodeWithText("公开").assertIsDisplayed()
+        composeRule.onNodeWithText("29/60").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the view switch offers all three site views`() {
+        setScreen(draftState())
+
+        composeRule.onNodeWithText("内容").assertIsDisplayed()
+        composeRule.onNodeWithText("对照").assertIsDisplayed()
+        composeRule.onNodeWithText("预览").performClick()
+
+        assertEquals(ComposerViewMode.PREVIEW, viewMode)
+    }
+
+    @Test
+    fun `the rules card is on every preview, not only the tech board`() {
+        setScreen(draftState().copy(viewMode = ComposerViewMode.PREVIEW, boardSlug = "daily", boardTitle = "日常"))
+
+        composeRule.onNodeWithText("重要提醒").assertIsDisplayed()
+        composeRule.onNodeWithText("敏感话题请发内版 · 发卡站 / 大量出售必须发推广 · 禁止人身攻击 · 违规将受惩罚")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `a publish in flight replaces the button rather than leaving it tappable`() {
+        setScreen(draftState().copy(isPublishing = true))
+
+        composeRule.onNodeWithText("发布中").assertIsDisplayed()
+    }
+
+    @Test
+    fun `every upload state in the queue is labelled, and a cell can be dismissed`() {
+        val failed = ImageAttachment("3", "content://c", "c.png", UploadStatus.FAILED)
+        setScreen(
+            draftState().copy(
+                attachments = listOf(
+                    ImageAttachment("1", "content://a", "a.png", UploadStatus.UPLOADING, progress = 0.45f),
+                    ImageAttachment("2", "content://b", "b.png", UploadStatus.UPLOADED, remoteUrl = "https://x/1.webp"),
+                    failed,
+                    ImageAttachment("4", "content://d", "d.png", UploadStatus.WAITING),
+                ),
+            ),
+        )
+
+        composeRule.onNodeWithText("上传中 45%").assertIsDisplayed()
+        composeRule.onNodeWithText("已上传").assertIsDisplayed()
+        composeRule.onNodeWithText("失败 · 重试").assertIsDisplayed()
+        composeRule.onNodeWithText("等待中").assertIsDisplayed()
+
+        composeRule.onNodeWithContentDescription("移除 c.png").performClick()
+
+        assertEquals(failed, removed)
+    }
+
+    @Test
+    fun `the draft dialog counts the images it is holding on to`() {
+        setScreen(
+            PostComposerUiState(
+                pendingDraft = PostDraft(
+                    title = "洛杉矶 4837 年付小鸡测评",
+                    body = "正文\n\n![a.png](https://cdn.nodeimage.com/i/a.webp)",
+                    boardSlug = "review",
+                    boardTitle = "测评",
+                    savedAtMillis = 1_700_000_000_000L,
+                ),
+            ),
+        )
+
+        composeRule.onNodeWithText("继续上次的草稿？").assertIsDisplayed()
+        composeRule.onNodeWithText("含 1 张图片", substring = true).assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/composer/PostComposerViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/composer/PostComposerViewModelTest.kt
@@ -4,9 +4,13 @@ import io.github.nsreader.core.net.NodeSeekError
 import io.github.nsreader.core.net.NodeSeekException
 import io.github.nsreader.data.Board
 import io.github.nsreader.data.MutableClock
+import io.github.nsreader.data.composer.ImageAttachment
+import io.github.nsreader.data.composer.ImageUploader
+import io.github.nsreader.data.composer.PickedImage
 import io.github.nsreader.data.composer.PostComposerRepository
 import io.github.nsreader.data.composer.PostDraft
 import io.github.nsreader.data.composer.PostSubmission
+import io.github.nsreader.data.composer.UploadStatus
 import io.github.nsreader.data.session.SessionState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,6 +36,7 @@ class PostComposerViewModelTest {
     private val repository = FakeComposerRepository()
     private val clock = MutableClock()
     private val boards = MutableStateFlow(listOf(Board("tech", "技术", null)))
+    private val uploader = FakeImageUploader()
     private val session = MutableStateFlow(SessionState(isSignedIn = true))
 
     @Before
@@ -44,7 +49,7 @@ class PostComposerViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun viewModel() = PostComposerViewModel(repository, boards, session, clock)
+    private fun viewModel() = PostComposerViewModel(repository, boards, session, clock, uploader)
 
     @Test
     fun `offers a saved draft and restores every field`() = runTest(dispatcher) {
@@ -66,7 +71,6 @@ class PostComposerViewModelTest {
         assertEquals("旧标题", viewModel.uiState.value.title)
         assertEquals("旧正文", viewModel.uiState.value.body)
         assertEquals("tech", viewModel.uiState.value.boardSlug)
-        assertTrue(viewModel.uiState.value.showRuleReminder)
     }
 
     @Test
@@ -155,6 +159,65 @@ class PostComposerViewModelTest {
         assertTrue(callbackInvoked)
         assertEquals(1, repository.deleteCount)
         assertNull(viewModel.uiState.value.publishError)
+    }
+
+    @Test
+    fun `an uploaded image is appended to the body and removed with its cell`() = runTest(dispatcher) {
+        val viewModel = viewModel()
+        advanceUntilIdle()
+        viewModel.updateBody("正文")
+
+        viewModel.addImages(listOf(PickedImage("content://pick/1", "screenshot.png")))
+        advanceUntilIdle()
+
+        val attachment = viewModel.uiState.value.attachments.single()
+        assertEquals(UploadStatus.UPLOADED, attachment.status)
+        assertEquals("正文\n\n![screenshot.png](https://cdn.nodeimage.com/i/fake.webp)", viewModel.uiState.value.body)
+
+        viewModel.removeAttachment(attachment)
+        advanceUntilIdle()
+
+        assertEquals("正文", viewModel.uiState.value.body)
+        assertTrue(viewModel.uiState.value.attachments.isEmpty())
+    }
+
+    @Test
+    fun `a failed upload is retryable and blocks publishing until it settles`() = runTest(dispatcher) {
+        uploader.failures = 1
+        val viewModel = viewModel()
+        advanceUntilIdle()
+        viewModel.updateTitle("标题")
+        viewModel.updateBody("正文")
+        viewModel.selectBoard(boards.value.single())
+
+        viewModel.addImages(listOf(PickedImage("content://pick/1", "a.png")))
+        advanceUntilIdle()
+
+        assertEquals(1, viewModel.uiState.value.failedUploadCount)
+        // A failed upload is settled: nothing more is coming, so publishing is allowed again.
+        assertTrue(viewModel.uiState.value.canPublish)
+
+        viewModel.retryFailedUploads()
+        advanceUntilIdle()
+
+        assertEquals(0, viewModel.uiState.value.failedUploadCount)
+        assertEquals(UploadStatus.UPLOADED, viewModel.uiState.value.attachments.single().status)
+    }
+}
+
+private class FakeImageUploader : ImageUploader {
+    var failures = 0
+
+    override suspend fun upload(
+        attachment: ImageAttachment,
+        onProgress: (Float) -> Unit,
+    ): String {
+        if (failures > 0) {
+            failures--
+            throw NodeSeekException(NodeSeekError.Network)
+        }
+        onProgress(1f)
+        return "https://cdn.nodeimage.com/i/fake.webp"
     }
 }
 

--- a/app/src/test/java/io/github/nsreader/ui/composer/ReplyComposerViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/composer/ReplyComposerViewModelTest.kt
@@ -130,6 +130,18 @@ class ReplyComposerViewModelTest {
     }
 
     @Test
+    fun `a bracketed display name cannot break the image markdown`() {
+        val attachment = ImageAttachment(
+            id = "1",
+            source = "content://pick/1",
+            name = "shot [v2] (final).png",
+            remoteUrl = "https://cdn.nodeimage.com/i/x.webp",
+        )
+
+        assertEquals("![shot  v2   final .png](https://cdn.nodeimage.com/i/x.webp)", attachment.markdown)
+    }
+
+    @Test
     fun `clearing the reply removes the stored draft`() = runTest(dispatcher) {
         val viewModel = viewModel()
         viewModel.open()

--- a/app/src/test/java/io/github/nsreader/ui/composer/ReplyComposerViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/composer/ReplyComposerViewModelTest.kt
@@ -1,0 +1,174 @@
+package io.github.nsreader.ui.composer
+
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.data.MutableClock
+import io.github.nsreader.data.composer.CommentComposerRepository
+import io.github.nsreader.data.composer.CommentDraft
+import io.github.nsreader.data.composer.CommentSubmission
+import io.github.nsreader.data.composer.ImageAttachment
+import io.github.nsreader.data.composer.ImageUploader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReplyComposerViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val repository = FakeCommentComposerRepository()
+    private val clock = MutableClock()
+    private val uploader = ImageUploader { _: ImageAttachment, _: (Float) -> Unit -> "https://cdn.nodeimage.com/i/x.webp" }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel(postId: Long = 1L) =
+        ReplyComposerViewModel(postId, repository, clock, uploader)
+
+    @Test
+    fun `closing the sheet keeps the reply, and reopening restores the stored draft`() = runTest(dispatcher) {
+        val viewModel = viewModel()
+        viewModel.open()
+        advanceUntilIdle()
+        viewModel.updateBody("写到一半")
+        advanceUntilIdle()
+
+        assertEquals("写到一半", repository.saved[1L]?.body)
+
+        viewModel.close()
+        assertFalse(viewModel.uiState.value.visible)
+        assertEquals("写到一半", viewModel.uiState.value.body)
+
+        // A fresh instance is what a process death leaves behind; the draft has to survive that too.
+        val restored = viewModel()
+        restored.open()
+        advanceUntilIdle()
+
+        assertEquals("写到一半", restored.uiState.value.body)
+    }
+
+    @Test
+    fun `drafts do not leak between threads`() = runTest(dispatcher) {
+        val first = viewModel(postId = 1L)
+        first.open()
+        advanceUntilIdle()
+        first.updateBody("第一帖")
+        advanceUntilIdle()
+
+        val second = viewModel(postId = 2L)
+        second.open()
+        advanceUntilIdle()
+
+        assertEquals("", second.uiState.value.body)
+    }
+
+    @Test
+    fun `replying to a floor quotes it, and the quote is sent as a blockquote`() = runTest(dispatcher) {
+        val viewModel = viewModel()
+        viewModel.open(ReplyQuote(floor = 12, author = "nssk", excerpt = "还没有这个功能"))
+        advanceUntilIdle()
+        viewModel.updateBody("赞成用星辰兑换改名")
+        advanceUntilIdle()
+
+        viewModel.publish {}
+        advanceUntilIdle()
+
+        val submission = repository.submission
+        assertEquals(12, submission?.quotedFloor)
+        assertEquals("> 还没有这个功能\n\n@nssk 赞成用星辰兑换改名", submission?.body)
+    }
+
+    @Test
+    fun `a later floor replaces the quote instead of answering the old one`() = runTest(dispatcher) {
+        val viewModel = viewModel()
+        viewModel.open(ReplyQuote(floor = 12, author = "nssk", excerpt = "第一段"))
+        advanceUntilIdle()
+        viewModel.close()
+        viewModel.open(ReplyQuote(floor = 20, author = "other", excerpt = "第二段"))
+        advanceUntilIdle()
+
+        assertEquals(20, viewModel.uiState.value.quote?.floor)
+    }
+
+    @Test
+    fun `a failed publish keeps the draft and surfaces the reason`() = runTest(dispatcher) {
+        repository.publishError = NodeSeekException(NodeSeekError.Unknown, detail = "评论发布接口尚未接入")
+        val viewModel = viewModel()
+        viewModel.open()
+        advanceUntilIdle()
+        viewModel.updateBody("这条要留住")
+        advanceUntilIdle()
+
+        viewModel.publish { error("must not report success") }
+        advanceUntilIdle()
+
+        assertEquals(NodeSeekError.Unknown, viewModel.uiState.value.publishError)
+        assertEquals("评论发布接口尚未接入", viewModel.uiState.value.publishErrorDetail)
+        assertEquals("这条要留住", viewModel.uiState.value.body)
+        assertTrue(viewModel.uiState.value.visible)
+        assertEquals("这条要留住", repository.saved[1L]?.body)
+    }
+
+    @Test
+    fun `clearing the reply removes the stored draft`() = runTest(dispatcher) {
+        val viewModel = viewModel()
+        viewModel.open()
+        advanceUntilIdle()
+        viewModel.updateBody("先写点")
+        advanceUntilIdle()
+        assertEquals("先写点", repository.saved[1L]?.body)
+
+        viewModel.updateBody("")
+        advanceUntilIdle()
+
+        assertNull(repository.saved[1L])
+        assertNull(viewModel.uiState.value.savedAtMillis)
+    }
+}
+
+private class FakeCommentComposerRepository : CommentComposerRepository {
+    val saved = mutableMapOf<Long, CommentDraft>()
+    var submission: CommentSubmission? = null
+    var publishError: Throwable? = null
+    private val drafts = mutableMapOf<Long, MutableStateFlow<CommentDraft?>>()
+
+    private fun flow(postId: Long) = drafts.getOrPut(postId) { MutableStateFlow(null) }
+
+    override fun draft(postId: Long): Flow<CommentDraft?> = flow(postId)
+
+    override suspend fun saveDraft(postId: Long, draft: CommentDraft) {
+        saved[postId] = draft
+        flow(postId).value = draft
+    }
+
+    override suspend fun deleteDraft(postId: Long) {
+        saved.remove(postId)
+        flow(postId).value = null
+    }
+
+    override suspend fun publish(submission: CommentSubmission): Int? {
+        this.submission = submission
+        publishError?.let { throw it }
+        return 13
+    }
+}


### PR DESCRIPTION
## 改了什么

按设计稿 `design/` 的 6d / 7a / 7b / 7c / C4 / C5 / C6 七张画板落地编辑器批次，旧的低质量实现直接覆盖。23 个文件，+3321/−477。

### 发帖编辑器（7a–7c，重写 `PostComposerScreen`）
- 版块 / 阅读限制（公开·Lv1·私有）下拉 chip，必填未选时 error 描边
- 标题单行计数 n/60；图标版 Markdown 工具栏贴键盘上沿
- **内容 / 预览 / 对照** 三视图切换；对照在手机上做成上下分栏实时渲染
- 「重要提醒」卡改为**全局常驻**（v1 误做成技术版专属可关闭，按 docs/design-requirements-remaining.md §0.8 修正，文案取站点原文）
- 预览复用详情页 `RichContent` 渲染管线；byline 从 getInfo 取真实用户名
- 发布中态（灰底 spinner 按钮替换发布键）、失败 Snackbar（原因 + 重试/登录/去验证分流，正文不清空）、草稿恢复 dialog（含图片数）

### 回复编辑器（6d / C4，全新）
- Modal sheet：「回复 #N · 用户名」标题、可关闭引用 chip、按帖子 ID 分开的草稿（关 sheet 不丢、杀进程可恢复）
- 楼层操作行新增回复入口，携带该楼引用进编辑器；FAB 打开空回复
- Shared Axis Y 弹簧转场展开为全屏预览，返回逆向收回

### 图片上传队列（C5，`ImageUploadQueue`）
- 单工位串行上传，四态真实可达：上传中（进度环）/ 已上传 / 失败重试（error 边框）/ 等待
- 单张移除同步撤掉已插入正文的 Markdown；失败 Snackbar 批量重试
- 系统 Photo Picker 接入（无需存储权限）；上传中/等待时禁止发布，防止图片被静默丢弃

### 表情面板（C6，`EmojiPanel`）
- 与键盘同高切换（不叠加）；五组 pill（AC娘/洋葱头/小黄鸡/Fluent/App）；最近使用；删除键按 code point 删除（不会删半个 emoji）
- 发帖与回复共用同一面板

## 有意留桩的部分（reviewer 请留意）

这些接口无法在沙箱中探测（curl 一律被 Cloudflare 403），留桩且**走真实失败路径**，不假装成功：

- **评论发布**：`LocalCommentComposerRepository.publish` 抛「评论发布接口尚未接入」，UI 显示失败条 + 重试 + 草稿保留。接口抓包确认后只需改这一个类。
- **NodeImage 上传**：`NodeImageUploader` 同样留桩；`ImageUploader` 为单方法接口，替换为真实 multipart 即可，队列与 UI 无需改动。
- **站内贴图**（AC娘/洋葱头/小黄鸡）：素材 URL 未捕获，面板内明确提示，`EmojiGroup` 填入条目即生效。

## 验证

- 197 个单元测试全部通过（新增 24 个：Markdown 变换含光标位置、回复 VM 草稿/引用/失败路径、composer Robolectric 屏幕级、上传队列）
- lint（warningsAsErrors）+ spotless 通过
- 三星 SM-S9310 真机走通全流程：发帖→选版块→表情插入→预览→对照→草稿恢复；帖内→楼层回复→引用→全屏预览→发布失败→草稿保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)