### PR TITLE
实现通知三分组与私信 7D-7F

### DIFF
--- a/app/src/main/java/io/github/nsreader/Navigation.kt
+++ b/app/src/main/java/io/github/nsreader/Navigation.kt
@@ -28,6 +28,8 @@ import io.github.nsreader.ui.composer.PostComposerRoute
 import io.github.nsreader.ui.composer.PostComposerViewModel
 import io.github.nsreader.ui.login.WebViewGoal
 import io.github.nsreader.ui.login.WebViewRoute
+import io.github.nsreader.ui.messages.MessageThreadRoute
+import io.github.nsreader.ui.messages.MessageThreadViewModel
 import io.github.nsreader.ui.navigation.NodeSeekNavigationItems
 import io.github.nsreader.ui.navigation.TopLevelDestination
 import io.github.nsreader.ui.notifications.NotificationsRoute
@@ -181,6 +183,33 @@ fun MainNavigation(container: AppContainer) {
                                 backStack.add(PostDetailKey(it, notification.floor))
                             }
                         },
+                        onOpenThread = { uid, name ->
+                            backStack.add(MessageThreadKey(uid, name))
+                        },
+                    )
+                }
+
+                entry<MessageThreadKey> { key ->
+                    val viewModel: MessageThreadViewModel =
+                        viewModel(
+                            key = "message-${key.uid}",
+                            factory =
+                            MessageThreadViewModel.factory(container, key.uid, key.userName),
+                        )
+                    MessageThreadRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
+                        onVerify = {
+                            backStack.add(
+                                WebKey(
+                                    NodeSeekSite.BASE_URL + NodeSeekSite.NOTIFICATION_PATH,
+                                    siteTitle,
+                                    WebViewGoal.CHALLENGE,
+                                ),
+                            )
+                        },
+                        onOpenBrowser = openExternalUrl,
                     )
                 }
 

--- a/app/src/main/java/io/github/nsreader/NavigationKeys.kt
+++ b/app/src/main/java/io/github/nsreader/NavigationKeys.kt
@@ -23,6 +23,19 @@ data object SettingsKey : NavKey
 @Serializable
 data object PostComposerKey : NavKey
 
+/**
+ * A private-message conversation (board 7f).
+ *
+ * [userName] travels with the key so the app bar has a title before the thread has loaded — the
+ * conversation list already knew it, and re-deriving it from a network round trip would leave the
+ * header blank for as long as that takes.
+ */
+@Serializable
+data class MessageThreadKey(
+    val uid: Long,
+    val userName: String,
+) : NavKey
+
 @Serializable
 data class PostDetailKey(
     val postId: Long,

--- a/app/src/main/java/io/github/nsreader/core/NodeSeekSite.kt
+++ b/app/src/main/java/io/github/nsreader/core/NodeSeekSite.kt
@@ -72,6 +72,14 @@ object NodeSeekSite {
 
     fun spacePath(uid: Long): String = "/space/$uid"
 
+    /** Accounts without an upload 404 here; [io.github.nsreader.ui.common.UserAvatar] draws the initial instead. */
+    fun avatarUrl(uid: Long): String? = absoluteUrl("/avatar/$uid.png")
+
+    const val NOTIFICATION_PATH = "/notification"
+
+    /** The web conversation, for the "open in browser" escape hatch on the message thread. */
+    fun messageThreadWebPath(uid: Long): String = "$NOTIFICATION_PATH#/message?mode=talk&to=$uid"
+
     const val NEW_DISCUSSION_PATH = "/new-discussion"
     const val NEW_DISCUSSION_API_PATH = "/api/content/new-discussion"
 

--- a/app/src/main/java/io/github/nsreader/core/TimeFormat.kt
+++ b/app/src/main/java/io/github/nsreader/core/TimeFormat.kt
@@ -1,0 +1,135 @@
+package io.github.nsreader.core
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+/**
+ * Wall-clock formatting for the notification and direct-message screens.
+ *
+ * NodeSeek's JSON endpoints are inconsistent about time: some rows carry an ISO-8601 instant, some
+ * carry epoch milliseconds, and some carry a string the server already rendered ("5分钟前"). Parsing
+ * is therefore best-effort — [parseTimestamp] answers `null` for the pre-rendered case and callers
+ * fall back to showing the server's own string rather than inventing a time.
+ *
+ * The zone is the device's, not the site's: a timestamp is only useful relative to the reader.
+ */
+object TimeFormat {
+
+    /** Boards 7d/7e/7f pair a relative label with a full timestamp, so both live here. */
+    fun parseTimestamp(
+        raw: String?,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Long? {
+        val value = raw?.trim().orEmpty()
+        if (value.isEmpty()) return null
+        value.toLongOrNull()?.let { number ->
+            // Ten digits is seconds, thirteen is milliseconds; anything shorter is an id, not a time.
+            return when {
+                number >= EPOCH_MILLIS_FLOOR -> number
+                number >= EPOCH_SECONDS_FLOOR -> number * 1_000
+                else -> null
+            }
+        }
+        runCatching { Instant.parse(value) }.getOrNull()?.let { return it.toEpochMilli() }
+        // `2026-07-26 09:56:03` and `2026-07-26T09:56:03` — neither carries a zone, so assume local.
+        val normalized = value.replace(' ', 'T')
+        return try {
+            LocalDateTime.parse(normalized).atZone(zone).toInstant().toEpochMilli()
+        } catch (_: DateTimeParseException) {
+            null
+        }
+    }
+
+    /** `26 分钟前` / `昨天` / `3 天前` / `7月15日` — the leading half of a 7d timestamp row. */
+    fun relative(
+        millis: Long,
+        nowMillis: Long,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): String {
+        val elapsed = nowMillis - millis
+        if (elapsed < 0) return absolute(millis, zone)
+        val day = millis.toLocalDate(zone)
+        val today = nowMillis.toLocalDate(zone)
+        val daysApart = ChronoUnit.DAYS.between(day, today)
+        return when {
+            elapsed < MINUTE -> "刚刚"
+            elapsed < HOUR -> "${elapsed / MINUTE} 分钟前"
+            daysApart == 0L -> "${elapsed / HOUR} 小时前"
+            daysApart == 1L -> "昨天"
+            daysApart < WEEK_DAYS -> "$daysApart 天前"
+            day.year == today.year -> "${day.monthValue}月${day.dayOfMonth}日"
+            else -> "${day.year}年${day.monthValue}月${day.dayOfMonth}日"
+        }
+    }
+
+    /** `2026/7/26 09:56:03` — the trailing half, kept unabbreviated because 7d asks for seconds. */
+    fun absolute(
+        millis: Long,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): String {
+        val time = millis.toLocalDateTime(zone)
+        return "${time.year}/${time.monthValue}/${time.dayOfMonth} " +
+            "${time.hour.pad()}:${time.minute.pad()}:${time.second.pad()}"
+    }
+
+    /** Conversation-list stamp (7e): the clock today, a weekday this week, a date before that. */
+    fun conversationStamp(
+        millis: Long,
+        nowMillis: Long,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): String {
+        val day = millis.toLocalDate(zone)
+        val today = nowMillis.toLocalDate(zone)
+        val daysApart = ChronoUnit.DAYS.between(day, today)
+        return when {
+            daysApart <= 0L -> millis.toLocalDateTime(zone).let { "${it.hour.pad()}:${it.minute.pad()}" }
+            daysApart == 1L -> "昨天"
+            daysApart < WEEK_DAYS -> WEEKDAYS[day.dayOfWeek.value - 1]
+            else -> "${day.monthValue}月${day.dayOfMonth}日"
+        }
+    }
+
+    /** The centred chip that separates a run of messages in 7f: `今天 09:41`. */
+    fun messageDivider(
+        millis: Long,
+        nowMillis: Long,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): String {
+        val day = millis.toLocalDate(zone)
+        val today = nowMillis.toLocalDate(zone)
+        val time = millis.toLocalDateTime(zone)
+        val clock = "${time.hour.pad()}:${time.minute.pad()}"
+        return when (ChronoUnit.DAYS.between(day, today)) {
+            0L -> "今天 $clock"
+            1L -> "昨天 $clock"
+            else -> "${day.monthValue}月${day.dayOfMonth}日 $clock"
+        }
+    }
+
+    /** `09:44` — the stamp under a single bubble. */
+    fun clock(
+        millis: Long,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): String {
+        val time = millis.toLocalDateTime(zone)
+        return "${time.hour.pad()}:${time.minute.pad()}"
+    }
+
+    private fun Long.toLocalDateTime(zone: ZoneId): LocalDateTime =
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(this), zone)
+
+    private fun Long.toLocalDate(zone: ZoneId): LocalDate = toLocalDateTime(zone).toLocalDate()
+
+    private fun Int.pad(): String = toString().padStart(2, '0')
+
+    private const val MINUTE = 60_000L
+    private const val HOUR = 60 * MINUTE
+    private const val WEEK_DAYS = 7L
+    private const val EPOCH_SECONDS_FLOOR = 1_000_000_000L
+    private const val EPOCH_MILLIS_FLOOR = 100_000_000_000L
+    private val WEEKDAYS = listOf("周一", "周二", "周三", "周四", "周五", "周六", "周日")
+}

--- a/app/src/main/java/io/github/nsreader/core/TimeFormat.kt
+++ b/app/src/main/java/io/github/nsreader/core/TimeFormat.kt
@@ -16,6 +16,10 @@ import java.time.temporal.ChronoUnit
  * fall back to showing the server's own string rather than inventing a time.
  *
  * The zone is the device's, not the site's: a timestamp is only useful relative to the reader.
+ *
+ * The wording is Chinese and hardcoded, which is the one place this app lets a data-shaped class
+ * decide copy. It holds only because NodeSeek is a Chinese-language forum with no localised build;
+ * adding a second language means moving these strings to resources and the formatting to the UI.
  */
 object TimeFormat {
 

--- a/app/src/main/java/io/github/nsreader/core/net/NodeSeekError.kt
+++ b/app/src/main/java/io/github/nsreader/core/net/NodeSeekError.kt
@@ -27,11 +27,17 @@ sealed interface NodeSeekError {
     data object Unknown : NodeSeekError
 }
 
-/** Thrown by the data layer; carries [error] so the UI can pick both wording and recovery action. */
+/**
+ * Thrown by the data layer; carries [error] so the UI can pick both wording and recovery action.
+ *
+ * [detail] is the server's own sentence when there is one — "对方已屏蔽你" and the like. Kept as a
+ * property rather than folded into the message because a screen that can show it should not have to
+ * guess whether [Exception.message] holds a reason or just the name of an [error] case.
+ */
 class NodeSeekException(
     val error: NodeSeekError,
     cause: Throwable? = null,
-    detail: String? = null,
+    val detail: String? = null,
 ) : Exception(detail ?: error.toString(), cause)
 
 /** True when a human can clear this by acting inside a WebView. */

--- a/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
+++ b/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
@@ -130,17 +130,23 @@ class NodeSeekJsonClient(
 
         fun accountInfoPath(uid: Long) = "/api/account/getInfo/$uid"
 
+        /** `?all=true` with an empty body; the per-item form takes a JSON array we do not need. */
+        fun markAllViewedPath(type: String) = "/api/notification/$type/markViewed?all=true"
+
         /*
-         * Direct messages, checked against a signed-in device (Galaxy S24, 2026-07-26).
+         * Direct messages.
          *
-         * The list endpoint is real and is the *only* read endpoint: it answers with a flat list of
-         * individual messages, both directions mixed, which `MessageRepository` folds into
-         * conversations and threads. A per-conversation path (`message/talk/{uid}` was tried) does
-         * not exist — 404. The send path is still inferred from the shape of the rest of the API;
-         * the thread screen keeps an "open in browser" escape hatch until it is confirmed.
+         * Read out of the site's own `notification.js` on a signed-in device (2026-07-26) rather
+         * than inferred: `list` returns one row per conversation holding only its latest message,
+         * `with/{uid}` returns the full history plus a `talkTo` header, and `send` is a POST whose
+         * recipient field is camel-cased `receiverUid` while every other field on this API is
+         * snake_case. A `message/talk/{uid}` path does not exist — that guess 404ed.
          */
         fun messageListPath(page: Int = 1) = notificationListPath("message", page)
 
+        fun messageThreadPath(uid: Long) = "/api/notification/message/with/$uid"
+
         const val PATH_MESSAGE_SEND = "/api/notification/message/send"
+        const val PATH_MESSAGE_MARK_VIEWED_ALL = "/api/notification/message/markViewed?all=true"
     }
 }

--- a/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
+++ b/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
@@ -131,19 +131,15 @@ class NodeSeekJsonClient(
         fun accountInfoPath(uid: Long) = "/api/account/getInfo/$uid"
 
         /*
-         * Direct messages.
+         * Direct messages, checked against a signed-in device (Galaxy S24, 2026-07-26).
          *
-         * These three are **inferred**, not observed: Cloudflare keeps the endpoints out of reach of
-         * anything but a signed-in browser, so they are modelled on the hash routes the web client
-         * uses (`#/message?mode=list`, `#/message?mode=talk&to={uid}`) and on the shape every other
-         * `/api/notification` endpoint follows. They are gathered here so confirming them on a device
-         * is a one-file edit; until then the screens degrade to their error state, and board 7f keeps
-         * an "open in browser" action for exactly that case.
+         * The list endpoint is real and is the *only* read endpoint: it answers with a flat list of
+         * individual messages, both directions mixed, which `MessageRepository` folds into
+         * conversations and threads. A per-conversation path (`message/talk/{uid}` was tried) does
+         * not exist — 404. The send path is still inferred from the shape of the rest of the API;
+         * the thread screen keeps an "open in browser" escape hatch until it is confirmed.
          */
         fun messageListPath(page: Int = 1) = notificationListPath("message", page)
-
-        fun messageThreadPath(uid: Long, page: Int = 1) =
-            "/api/notification/message/talk/$uid?page=$page"
 
         const val PATH_MESSAGE_SEND = "/api/notification/message/send"
     }

--- a/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
+++ b/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
@@ -72,11 +72,13 @@ class NodeSeekJsonClient(
 
             response.use {
                 val body = it.body?.string().orEmpty()
-                if (!it.isSuccessful) throw NodeSeekException(NodeSeekError.Http(it.code))
-                // An HTML body on a JSON endpoint means Cloudflare intercepted the call.
+                // An HTML body on a JSON endpoint means Cloudflare intercepted the call, and it says
+                // so with 403 — so the body has to be read before the status, or every challenge on a
+                // read looks like a server fault and sends the user to "retry" instead of "verify".
                 if (body.trimStart().startsWith("<")) {
                     throw NodeSeekException(NodeSeekError.Cloudflare)
                 }
+                if (!it.isSuccessful) throw NodeSeekException(NodeSeekError.Http(it.code))
                 body
             }
         }
@@ -142,6 +144,8 @@ class NodeSeekJsonClient(
          * recipient field is camel-cased `receiverUid` while every other field on this API is
          * snake_case. A `message/talk/{uid}` path does not exist — that guess 404ed.
          */
+        // Callers currently read page 1 only, so a very long inbox is truncated; the parameter is
+        // here so paging is a call-site change rather than a new endpoint.
         fun messageListPath(page: Int = 1) = notificationListPath("message", page)
 
         fun messageThreadPath(uid: Long) = "/api/notification/message/with/$uid"

--- a/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
+++ b/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
@@ -3,8 +3,10 @@ package io.github.nsreader.core.net
 import io.github.nsreader.core.AppDispatchers
 import io.github.nsreader.core.NodeSeekSite
 import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 
 /**
@@ -18,10 +20,34 @@ interface JsonSource {
     suspend fun getJson(path: String, referer: String = NodeSeekSite.BASE_URL + "/"): String
 }
 
+/**
+ * Writes, kept apart from [JsonSource] so a repository that only reads cannot accidentally post —
+ * and so the many read-only test doubles stay as small as they are.
+ */
+interface JsonWriteSource {
+    /**
+     * Sends a JSON body and returns the JSON answer.
+     *
+     * Unlike [JsonSource.getJson] this maps 401/403 to [NodeSeekError.LoginRequired]: a write is the
+     * one moment where a session that quietly expired has to be told apart from a server fault,
+     * because the recovery is "sign in and send again" rather than "retry".
+     */
+    suspend fun postJson(
+        path: String,
+        body: String,
+        referer: String = NodeSeekSite.BASE_URL + "/",
+    ): String
+}
+
+/** Both halves, for the repositories that read a list and then add to it. */
+interface JsonApi :
+    JsonSource,
+    JsonWriteSource
+
 class NodeSeekJsonClient(
     private val okHttpClient: OkHttpClient,
     private val dispatchers: AppDispatchers,
-) : JsonSource {
+) : JsonApi {
 
     override suspend fun getJson(path: String, referer: String): String =
         withContext(dispatchers.io) {
@@ -55,7 +81,47 @@ class NodeSeekJsonClient(
             }
         }
 
+    override suspend fun postJson(path: String, body: String, referer: String): String =
+        withContext(dispatchers.io) {
+            val url = NodeSeekSite.absoluteUrl(path) ?: error("Invalid path: $path")
+            val request = Request.Builder()
+                .url(url)
+                .header("Accept", "application/json, text/plain, */*")
+                .header("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
+                .header("Content-Type", "application/json")
+                .header("Origin", NodeSeekSite.BASE_URL)
+                .header("Referer", referer)
+                .header("X-Requested-With", "XMLHttpRequest")
+                .header("Sec-Fetch-Dest", "empty")
+                .header("Sec-Fetch-Mode", "cors")
+                .header("Sec-Fetch-Site", "same-origin")
+                .post(body.toRequestBody(JSON_MEDIA_TYPE))
+                .build()
+
+            val response = try {
+                okHttpClient.newCall(request).execute()
+            } catch (e: IOException) {
+                throw NodeSeekException(NodeSeekError.Network, e)
+            }
+
+            response.use {
+                val payload = it.body?.string().orEmpty()
+                // Cloudflare answers a blocked write with 403 plus challenge HTML, so the shape of the
+                // body decides before the status code does — "verify" and "sign in" are different fixes.
+                if (payload.trimStart().startsWith("<")) {
+                    throw NodeSeekException(NodeSeekError.Cloudflare)
+                }
+                if (it.code == 401 || it.code == 403) {
+                    throw NodeSeekException(NodeSeekError.LoginRequired)
+                }
+                if (!it.isSuccessful) throw NodeSeekException(NodeSeekError.Http(it.code))
+                payload
+            }
+        }
+
     companion object {
+        private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
+
         const val PATH_CATEGORIES = "/api/content/list-categories"
         const val PATH_UNREAD_COUNT = "/api/notification/unread-count"
 
@@ -63,5 +129,22 @@ class NodeSeekJsonClient(
             "/api/notification/$type/list?page=$page"
 
         fun accountInfoPath(uid: Long) = "/api/account/getInfo/$uid"
+
+        /*
+         * Direct messages.
+         *
+         * These three are **inferred**, not observed: Cloudflare keeps the endpoints out of reach of
+         * anything but a signed-in browser, so they are modelled on the hash routes the web client
+         * uses (`#/message?mode=list`, `#/message?mode=talk&to={uid}`) and on the shape every other
+         * `/api/notification` endpoint follows. They are gathered here so confirming them on a device
+         * is a one-file edit; until then the screens degrade to their error state, and board 7f keeps
+         * an "open in browser" action for exactly that case.
+         */
+        fun messageListPath(page: Int = 1) = notificationListPath("message", page)
+
+        fun messageThreadPath(uid: Long, page: Int = 1) =
+            "/api/notification/message/talk/$uid?page=$page"
+
+        const val PATH_MESSAGE_SEND = "/api/notification/message/send"
     }
 }

--- a/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
@@ -1,0 +1,264 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.TimeFormat
+import io.github.nsreader.core.net.JsonApi
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.net.NodeSeekJsonClient
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+
+/**
+ * One row of board 7e's conversation list.
+ *
+ * [isSystem] is the pinned 系统通知 conversation. It is an ordinary conversation on the site — there
+ * is no separate system notification group — but it is the one whose snippet arrives as Markdown, so
+ * the row renders it as inline rich text rather than plain characters.
+ */
+data class MessageConversation(
+    val uid: Long,
+    val userName: String,
+    val avatarUrl: String?,
+    val snippet: String,
+    /** The last message is ours, which the design shows as a `你：` prefix. */
+    val isSnippetMine: Boolean,
+    val updatedAtMillis: Long?,
+    val updatedAtText: String?,
+    val unreadCount: Int,
+    val isSystem: Boolean,
+) {
+    companion object {
+        const val SYSTEM_NAME = "系统通知"
+    }
+}
+
+/** One bubble in board 7f. Private messages are editable on NodeSeek, hence [isEdited]. */
+data class DirectMessage(
+    val id: String,
+    val isMine: Boolean,
+    val content: String,
+    val sentAtMillis: Long?,
+    val sentAtText: String?,
+    val isEdited: Boolean,
+)
+
+data class MessageThread(
+    val uid: Long,
+    val userName: String,
+    val avatarUrl: String?,
+    val level: Int?,
+    /** Oldest first, which is the order the conversation reads in. */
+    val messages: List<DirectMessage>,
+)
+
+interface MessageRepository {
+    suspend fun conversations(): List<MessageConversation>
+
+    suspend fun thread(uid: Long): MessageThread
+
+    /** Returns the accepted message so the optimistic bubble can be replaced by the real one. */
+    suspend fun send(
+        uid: Long,
+        content: String,
+        markdown: Boolean,
+    ): DirectMessage?
+}
+
+/**
+ * Direct messages over the site's notification API.
+ *
+ * **The endpoints are inferred** — see [NodeSeekJsonClient]'s companion. Parsing is therefore
+ * deliberately shape-tolerant in the same way [NotificationRepository] is: field names are probed in
+ * order rather than bound to a `@Serializable` schema, so a name that differs from the guess costs a
+ * missing field instead of an unparsable screen.
+ *
+ * Direction is derived by comparing each message's sender against the person being talked to, which
+ * avoids a second round trip just to learn our own uid.
+ */
+class NetworkMessageRepository(
+    private val jsonApi: JsonApi,
+) : MessageRepository {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun conversations(): List<MessageConversation> {
+        val root = json.parseToJsonElement(jsonApi.getJson(NodeSeekJsonClient.messageListPath(), REFERER))
+        val rows = root.findObjectArray(PREFERRED_LIST_KEYS)
+        val conversations =
+            rows.mapNotNull { element ->
+                (element as? JsonObject)?.toConversation()
+            }
+        // The site pins 系统通知 to the top of the list; the endpoint does not promise that order.
+        return conversations.sortedWith(
+            compareByDescending(MessageConversation::isSystem)
+                .thenByDescending { it.updatedAtMillis ?: 0L },
+        )
+    }
+
+    override suspend fun thread(uid: Long): MessageThread {
+        val root =
+            json.parseToJsonElement(
+                jsonApi.getJson(
+                    path = NodeSeekJsonClient.messageThreadPath(uid),
+                    referer = NodeSeekSite.BASE_URL + NodeSeekSite.messageThreadWebPath(uid),
+                ),
+            )
+        val rows = root.findObjectArray(PREFERRED_THREAD_KEYS)
+        val messages =
+            rows
+                .mapIndexedNotNull { index, element ->
+                    (element as? JsonObject)?.toMessage(otherUid = uid, index = index)
+                }.sortedBy { it.sentAtMillis ?: 0L }
+        val header = root.findMemberObject()
+        return MessageThread(
+            uid = uid,
+            userName = header?.text("member_name", "username", "name") ?: "NodeSeek 用户",
+            avatarUrl = NodeSeekSite.avatarUrl(uid),
+            level = header?.get("rank")?.jsonPrimitive?.intOrNull,
+            messages = messages,
+        )
+    }
+
+    override suspend fun send(
+        uid: Long,
+        content: String,
+        markdown: Boolean,
+    ): DirectMessage? {
+        val payload =
+            buildJsonObject {
+                put("receiver_id", uid)
+                put("content", content)
+                put("markdown", markdown)
+            }
+        val body =
+            jsonApi.postJson(
+                path = NodeSeekJsonClient.PATH_MESSAGE_SEND,
+                body = payload.toString(),
+                referer = NodeSeekSite.BASE_URL + NodeSeekSite.messageThreadWebPath(uid),
+            )
+        val root = json.parseToJsonElement(body) as? JsonObject
+            ?: throw NodeSeekException(NodeSeekError.Unparsable)
+        // `success: false` carries a human-readable reason — a blocked recipient, a rate limit — and
+        // that reason is worth more to the user than the retry affordance alone.
+        val success = root["success"]?.jsonPrimitive?.booleanOrNull ?: true
+        if (!success) {
+            throw NodeSeekException(
+                error = NodeSeekError.Unknown,
+                detail = root.text("message", "error"),
+            )
+        }
+        val accepted =
+            listOf("data", "message", "detail").firstNotNullOfOrNull { key ->
+                root[key] as? JsonObject
+            }
+        return accepted?.toMessage(otherUid = uid, index = 0)
+    }
+
+    private companion object {
+        val REFERER = NodeSeekSite.BASE_URL + NodeSeekSite.NOTIFICATION_PATH
+        val PREFERRED_LIST_KEYS = listOf("msgArray", "messageList", "conversations", "list", "data")
+        val PREFERRED_THREAD_KEYS = listOf("msgArray", "messageList", "talkList", "list", "data")
+    }
+}
+
+private fun JsonObject.toConversation(): MessageConversation? {
+    val uid =
+        long("member_id", "uid", "to", "target_id", "user_id", "sender_id")
+            ?: return null
+    val name = text("member_name", "username", "name") ?: "NodeSeek 用户"
+    val lastSender = long("sender_id", "last_sender_id", "from")
+    val updatedAt = text("created_at", "updated_at", "time", "last_time")
+    val isSystem = name == MessageConversation.SYSTEM_NAME || boolean("is_system", "system") == true
+    return MessageConversation(
+        uid = uid,
+        userName = name,
+        avatarUrl = if (isSystem) null else NodeSeekSite.avatarUrl(uid),
+        snippet = text("content", "last_content", "message", "excerpt")?.collapseWhitespace().orEmpty(),
+        isSnippetMine = lastSender != null && lastSender != uid,
+        updatedAtMillis = TimeFormat.parseTimestamp(updatedAt),
+        updatedAtText = updatedAt?.trim()?.ifBlank { null },
+        unreadCount = int("unread", "unread_count", "unreadCount", "nUnread"),
+        isSystem = isSystem,
+    )
+}
+
+private fun JsonObject.toMessage(
+    otherUid: Long,
+    index: Int,
+): DirectMessage? {
+    val content = text("content", "message", "text") ?: return null
+    val sender = long("sender_id", "member_id", "from", "uid")
+    val sentAt = text("created_at", "time", "sent_at")
+    val updatedAt = text("updated_at", "edited_at")
+    return DirectMessage(
+        id = text("id", "message_id", "msg_id") ?: "$otherUid-$index-${content.hashCode()}",
+        // Unknown sender reads as theirs: showing an incoming message on the right is a lie about who
+        // said it, while showing our own on the left is only a cosmetic misalignment.
+        isMine = sender != null && sender != otherUid,
+        content = content,
+        sentAtMillis = TimeFormat.parseTimestamp(sentAt),
+        sentAtText = sentAt?.trim()?.ifBlank { null },
+        isEdited =
+        boolean("edited", "is_edited")
+            ?: (updatedAt != null && updatedAt != sentAt),
+    )
+}
+
+private fun JsonElement.findObjectArray(preferred: List<String>): JsonArray {
+    if (this is JsonArray && any { it is JsonObject }) return this
+    if (this !is JsonObject) return JsonArray(emptyList())
+    preferred.forEach { key ->
+        val found = this[key]?.findObjectArray(preferred) ?: return@forEach
+        if (found.isNotEmpty()) return found
+    }
+    values.forEach { child ->
+        val found = child.findObjectArray(preferred)
+        if (found.isNotEmpty()) return found
+    }
+    return JsonArray(emptyList())
+}
+
+/** The counterparty's name and level, when the endpoint wraps the rows in a header object. */
+private fun JsonElement.findMemberObject(): JsonObject? {
+    val root = this as? JsonObject ?: return null
+    listOf("member", "target", "user", "to").forEach { key ->
+        (root[key] as? JsonObject)?.let { return it }
+    }
+    return null
+}
+
+private fun JsonObject.text(vararg names: String): String? {
+    names.forEach { name -> this[name]?.jsonPrimitive?.contentOrNull?.let { return it } }
+    return null
+}
+
+private fun JsonObject.long(vararg names: String): Long? {
+    names.forEach { name -> this[name]?.jsonPrimitive?.longOrNull?.let { return it } }
+    return null
+}
+
+private fun JsonObject.int(vararg names: String): Int {
+    names.forEach { name -> this[name]?.jsonPrimitive?.intOrNull?.let { return it } }
+    return 0
+}
+
+private fun JsonObject.boolean(vararg names: String): Boolean? {
+    names.forEach { name ->
+        this[name]?.jsonPrimitive?.let { primitive ->
+            primitive.booleanOrNull?.let { return it }
+            primitive.intOrNull?.let { return it != 0 }
+        }
+    }
+    return null
+}
+
+private fun String.collapseWhitespace(): String = trim().replace(Regex("\\s+"), " ")

--- a/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
@@ -91,6 +91,11 @@ interface MessageRepository {
  */
 class NetworkMessageRepository(
     private val jsonApi: JsonApi,
+    /**
+     * Our own uid, for the one case the rows cannot resolve on their own. Suspending and nullable
+     * because the only source is a network round trip that is allowed to fail — see [inferOwnUid].
+     */
+    private val currentUid: suspend () -> Long?,
 ) : MessageRepository {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -185,18 +190,27 @@ class NetworkMessageRepository(
     }
 
     /**
-     * We are a party to every conversation, so ours is the uid that recurs across the list; a
-     * counterparty's cannot — two conversations never share one. With a single conversation both
-     * ids tie, but there [RawMessage.counterpart] still resolves: whichever this picks, the other
-     * becomes the conversation.
+     * Which uid in these rows is us.
+     *
+     * We are a party to every conversation, so our uid is in the intersection of every row's two
+     * ends; a counterparty's cannot be, because no two conversations share one. That settles it as
+     * soon as there are two conversations.
+     *
+     * One conversation is genuinely ambiguous — both ids appear once — and guessing there is not
+     * harmless: a new account's inbox holds exactly the system conversation, and picking wrong keys
+     * the row on ourselves and flips the whole thread. So that case asks who we are instead. A
+     * failed lookup falls back to the sender, which is right whenever the last word was theirs.
      */
-    private fun inferOwnUid(rows: List<RawMessage>): Long? =
-        rows
-            .flatMap { listOfNotNull(it.senderId, it.receiverId) }
-            .groupingBy { it }
-            .eachCount()
-            .maxByOrNull { it.value }
-            ?.key
+    private suspend fun inferOwnUid(rows: List<RawMessage>): Long? {
+        val candidates =
+            rows
+                .map { setOfNotNull(it.senderId, it.receiverId) }
+                .reduceOrNull { shared, row -> shared intersect row }
+                .orEmpty()
+        return candidates.singleOrNull()
+            ?: currentUid()?.takeIf { it in candidates }
+            ?: candidates.firstOrNull { it != rows.firstOrNull()?.senderId }
+    }
 
     private fun conversationOf(
         uid: Long,

--- a/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
@@ -91,40 +91,83 @@ class NetworkMessageRepository(
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun conversations(): List<MessageConversation> {
-        val root = json.parseToJsonElement(jsonApi.getJson(NodeSeekJsonClient.messageListPath(), REFERER))
-        val rows = root.findObjectArray(PREFERRED_LIST_KEYS)
-        val conversations =
-            rows.mapNotNull { element ->
-                (element as? JsonObject)?.toConversation()
-            }
+        val rows = listRawMessages()
+        val ownUid = inferOwnUid(rows)
         // The site pins 系统通知 to the top of the list; the endpoint does not promise that order.
-        return conversations.sortedWith(
-            compareByDescending(MessageConversation::isSystem)
-                .thenByDescending { it.updatedAtMillis ?: 0L },
+        return rows
+            .groupBy { it.counterpart(ownUid) }
+            .mapNotNull { (uid, messages) -> uid?.let { foldConversation(it, messages) } }
+            .sortedWith(
+                compareByDescending(MessageConversation::isSystem)
+                    .thenByDescending { it.updatedAtMillis ?: 0L },
+            )
+    }
+
+    /**
+     * Confirmed on a device (Galaxy S24, 2026-07-26): the message endpoint answers with a flat list
+     * of individual messages — one row per *message*, both directions, the same counterparty
+     * repeated. Both screens are projections of it: 7e folds the rows into conversations (without
+     * which the uid-keyed list crashed on the first person with two messages), 7f slices out one
+     * counterparty's rows.
+     */
+    private suspend fun listRawMessages(): List<RawMessage> {
+        val root = json.parseToJsonElement(jsonApi.getJson(NodeSeekJsonClient.messageListPath(), REFERER))
+        return root
+            .findObjectArray(PREFERRED_LIST_KEYS)
+            .mapNotNull { element -> (element as? JsonObject)?.toRawMessage() }
+    }
+
+    /**
+     * We are a party to every message, so ours is the uid that shows up most across the list; a
+     * counterparty's cannot — two conversations never share one. A single-conversation list is
+     * genuinely ambiguous, but there [RawMessage.counterpart] still resolves: whichever id this
+     * picks, the other becomes the conversation.
+     */
+    private fun inferOwnUid(rows: List<RawMessage>): Long? =
+        rows
+            .flatMap { listOfNotNull(it.senderId, it.receiverId) }
+            .groupingBy { it }
+            .eachCount()
+            .maxByOrNull { it.value }
+            ?.key
+
+    private fun foldConversation(
+        uid: Long,
+        messages: List<RawMessage>,
+    ): MessageConversation {
+        val newest = messages.maxBy { it.createdAtMillis ?: 0L }
+        val name =
+            messages.firstNotNullOfOrNull { it.nameOf(uid) } ?: "NodeSeek 用户"
+        val isSystem =
+            name == MessageConversation.SYSTEM_NAME || messages.any { it.isSystem }
+        return MessageConversation(
+            uid = uid,
+            userName = name,
+            avatarUrl = if (isSystem) null else NodeSeekSite.avatarUrl(uid),
+            snippet = newest.content,
+            isSnippetMine = newest.senderId != null && newest.senderId != uid,
+            updatedAtMillis = newest.createdAtMillis,
+            updatedAtText = newest.createdAtText,
+            unreadCount = messages.count { !it.viewed && it.senderId == uid },
+            isSystem = isSystem,
         )
     }
 
     override suspend fun thread(uid: Long): MessageThread {
-        val root =
-            json.parseToJsonElement(
-                jsonApi.getJson(
-                    path = NodeSeekJsonClient.messageThreadPath(uid),
-                    referer = NodeSeekSite.BASE_URL + NodeSeekSite.messageThreadWebPath(uid),
-                ),
-            )
-        val rows = root.findObjectArray(PREFERRED_THREAD_KEYS)
+        // No per-conversation endpoint exists — the talk-path guess 404ed on a real device — so the
+        // thread is the flat list filtered to this counterparty. See [listRawMessages].
+        val rows = listRawMessages()
+        val ownUid = inferOwnUid(rows)
         val messages =
             rows
-                .mapIndexedNotNull { index, element ->
-                    (element as? JsonObject)?.toMessage(otherUid = uid, index = index)
-                }.sortedBy { it.sentAtMillis ?: 0L }
-        val header = root.findMemberObject()
+                .filter { it.counterpart(ownUid) == uid }
+                .sortedBy { it.createdAtMillis ?: 0L }
         return MessageThread(
             uid = uid,
-            userName = header?.text("member_name", "username", "name") ?: "NodeSeek 用户",
+            userName = messages.firstNotNullOfOrNull { it.nameOf(uid) } ?: "NodeSeek 用户",
             avatarUrl = NodeSeekSite.avatarUrl(uid),
-            level = header?.get("rank")?.jsonPrimitive?.intOrNull,
-            messages = messages,
+            level = null,
+            messages = messages.mapIndexed { index, raw -> raw.toDirectMessage(uid, index) },
         )
     }
 
@@ -166,28 +209,77 @@ class NetworkMessageRepository(
     private companion object {
         val REFERER = NodeSeekSite.BASE_URL + NodeSeekSite.NOTIFICATION_PATH
         val PREFERRED_LIST_KEYS = listOf("msgArray", "messageList", "conversations", "list", "data")
-        val PREFERRED_THREAD_KEYS = listOf("msgArray", "messageList", "talkList", "list", "data")
     }
 }
 
-private fun JsonObject.toConversation(): MessageConversation? {
-    val uid =
-        long("member_id", "uid", "to", "target_id", "user_id", "sender_id")
+/** One wire row of the flat message list, before folding into conversations. */
+private data class RawMessage(
+    val id: String?,
+    val senderId: Long?,
+    val receiverId: Long?,
+    val senderName: String?,
+    val receiverName: String?,
+    val content: String,
+    val createdAtMillis: Long?,
+    val createdAtText: String?,
+    val viewed: Boolean,
+    val isEdited: Boolean,
+    val isSystem: Boolean,
+) {
+    /** The conversation this message belongs to: whichever end of it is not us. */
+    fun counterpart(ownUid: Long?): Long? =
+        when {
+            receiverId == null -> senderId
+            senderId == null -> receiverId
+            senderId == ownUid -> receiverId
+            else -> senderId
+        }
+
+    fun nameOf(uid: Long): String? =
+        when (uid) {
+            senderId -> senderName
+            receiverId -> receiverName
+            else -> null
+        } ?: senderName.takeIf { receiverId == null }
+
+    fun toDirectMessage(
+        counterpartUid: Long,
+        index: Int,
+    ) = DirectMessage(
+        id = id ?: "$counterpartUid-$index-${content.hashCode()}",
+        isMine = senderId != null && senderId != counterpartUid,
+        content = content,
+        sentAtMillis = createdAtMillis,
+        sentAtText = createdAtText,
+        isEdited = isEdited,
+    )
+}
+
+private fun JsonObject.toRawMessage(): RawMessage? {
+    val content =
+        text("content", "last_content", "message", "excerpt")?.collapseWhitespace()?.ifBlank { null }
             ?: return null
-    val name = text("member_name", "username", "name") ?: "NodeSeek 用户"
-    val lastSender = long("sender_id", "last_sender_id", "from")
-    val updatedAt = text("created_at", "updated_at", "time", "last_time")
-    val isSystem = name == MessageConversation.SYSTEM_NAME || boolean("is_system", "system") == true
-    return MessageConversation(
-        uid = uid,
-        userName = name,
-        avatarUrl = if (isSystem) null else NodeSeekSite.avatarUrl(uid),
-        snippet = text("content", "last_content", "message", "excerpt")?.collapseWhitespace().orEmpty(),
-        isSnippetMine = lastSender != null && lastSender != uid,
-        updatedAtMillis = TimeFormat.parseTimestamp(updatedAt),
-        updatedAtText = updatedAt?.trim()?.ifBlank { null },
-        unreadCount = int("unread", "unread_count", "unreadCount", "nUnread"),
-        isSystem = isSystem,
+    val createdAt = text("created_at", "time", "sent_at", "last_time")
+    val updatedAt = text("updated_at", "edited_at")
+    val name = text("member_name", "username", "name")
+    return RawMessage(
+        id = text("id", "message_id", "msg_id"),
+        senderId = long("sender_id", "from", "member_id", "uid"),
+        receiverId = long("receiver_id", "to", "target_id"),
+        senderName = text("sender_name") ?: name,
+        receiverName = text("receiver_name", "target_name") ?: name,
+        content = content,
+        createdAtMillis = TimeFormat.parseTimestamp(createdAt ?: updatedAt),
+        createdAtText = (createdAt ?: updatedAt)?.trim()?.ifBlank { null },
+        // Absent flag reads as read: inventing unread noise is worse than missing some.
+        viewed = boolean("viewed", "is_read", "read") ?: true,
+        isEdited =
+        boolean("edited", "is_edited")
+            ?: (createdAt != null && updatedAt != null && updatedAt != createdAt),
+        isSystem =
+        boolean("is_system", "system") == true ||
+            name == MessageConversation.SYSTEM_NAME ||
+            text("sender_name") == MessageConversation.SYSTEM_NAME,
     )
 }
 
@@ -227,15 +319,6 @@ private fun JsonElement.findObjectArray(preferred: List<String>): JsonArray {
     return JsonArray(emptyList())
 }
 
-/** The counterparty's name and level, when the endpoint wraps the rows in a header object. */
-private fun JsonElement.findMemberObject(): JsonObject? {
-    val root = this as? JsonObject ?: return null
-    listOf("member", "target", "user", "to").forEach { key ->
-        (root[key] as? JsonObject)?.let { return it }
-    }
-    return null
-}
-
 private fun JsonObject.text(vararg names: String): String? {
     names.forEach { name -> this[name]?.jsonPrimitive?.contentOrNull?.let { return it } }
     return null
@@ -244,11 +327,6 @@ private fun JsonObject.text(vararg names: String): String? {
 private fun JsonObject.long(vararg names: String): Long? {
     names.forEach { name -> this[name]?.jsonPrimitive?.longOrNull?.let { return it } }
     return null
-}
-
-private fun JsonObject.int(vararg names: String): Int {
-    names.forEach { name -> this[name]?.jsonPrimitive?.intOrNull?.let { return it } }
-    return 0
 }
 
 private fun JsonObject.boolean(vararg names: String): Boolean? {

--- a/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/MessageRepository.kt
@@ -22,8 +22,8 @@ import kotlinx.serialization.json.put
  * One row of board 7e's conversation list.
  *
  * [isSystem] is the pinned 系统通知 conversation. It is an ordinary conversation on the site — there
- * is no separate system notification group — but it is the one whose snippet arrives as Markdown, so
- * the row renders it as inline rich text rather than plain characters.
+ * is no separate system notification group — but its messages arrive as Markdown, so the row renders
+ * the snippet as inline rich text rather than plain characters.
  */
 data class MessageConversation(
     val uid: Long,
@@ -42,14 +42,15 @@ data class MessageConversation(
     }
 }
 
-/** One bubble in board 7f. Private messages are editable on NodeSeek, hence [isEdited]. */
+/** One bubble in board 7f. */
 data class DirectMessage(
     val id: String,
     val isMine: Boolean,
     val content: String,
+    /** The site stores this per message; the composer's own switch must not decide how one renders. */
+    val isMarkdown: Boolean,
     val sentAtMillis: Long?,
     val sentAtText: String?,
-    val isEdited: Boolean,
 )
 
 data class MessageThread(
@@ -72,18 +73,21 @@ interface MessageRepository {
         content: String,
         markdown: Boolean,
     ): DirectMessage?
+
+    /** Clears every unread message in the 私信 group. */
+    suspend fun markAllRead()
 }
 
 /**
- * Direct messages over the site's notification API.
+ * Direct messages, over the same three endpoints the site's own `notification.js` calls.
  *
- * **The endpoints are inferred** — see [NodeSeekJsonClient]'s companion. Parsing is therefore
- * deliberately shape-tolerant in the same way [NotificationRepository] is: field names are probed in
- * order rather than bound to a `@Serializable` schema, so a name that differs from the guess costs a
- * missing field instead of an unparsable screen.
+ * Read off the live bundle rather than guessed (2026-07-26, signed-in device): `message/list` is one
+ * row per *conversation* carrying only its latest message, `message/with/{uid}` is the full history,
+ * and `message/send` takes `receiverUid` — not the `receiver_id` the other endpoints use, which is
+ * the kind of detail no amount of consistency reasoning would have produced.
  *
- * Direction is derived by comparing each message's sender against the person being talked to, which
- * avoids a second round trip just to learn our own uid.
+ * Parsing stays shape-tolerant (field names probed in order, as in [NotificationRepository]) so a
+ * server-side rename costs a field rather than the screen.
  */
 class NetworkMessageRepository(
     private val jsonApi: JsonApi,
@@ -91,82 +95,48 @@ class NetworkMessageRepository(
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun conversations(): List<MessageConversation> {
-        val rows = listRawMessages()
+        val body = jsonApi.getJson(NodeSeekJsonClient.messageListPath(), REFERER)
+        val rows =
+            json
+                .parseToJsonElement(body)
+                .findObjectArray(PREFERRED_LIST_KEYS)
+                .mapNotNull { element -> (element as? JsonObject)?.toRawMessage() }
+        /*
+         * Each row names both ends of a conversation and neither is labelled "the other person", so
+         * the counterparty is whichever uid is not ours — the same reduction `notification.js` does.
+         * Grouping rather than mapping is what fixed the crash this screen shipped with: keying the
+         * list on a uid picked field-by-field made every row key on the sender, which is us.
+         */
         val ownUid = inferOwnUid(rows)
-        // The site pins 系统通知 to the top of the list; the endpoint does not promise that order.
         return rows
             .groupBy { it.counterpart(ownUid) }
-            .mapNotNull { (uid, messages) -> uid?.let { foldConversation(it, messages) } }
+            .mapNotNull { (uid, messages) -> uid?.let { conversationOf(it, messages, ownUid) } }
+            // The site pins 系统通知 to the top; the endpoint does not promise that order.
             .sortedWith(
                 compareByDescending(MessageConversation::isSystem)
                     .thenByDescending { it.updatedAtMillis ?: 0L },
             )
     }
 
-    /**
-     * Confirmed on a device (Galaxy S24, 2026-07-26): the message endpoint answers with a flat list
-     * of individual messages — one row per *message*, both directions, the same counterparty
-     * repeated. Both screens are projections of it: 7e folds the rows into conversations (without
-     * which the uid-keyed list crashed on the first person with two messages), 7f slices out one
-     * counterparty's rows.
-     */
-    private suspend fun listRawMessages(): List<RawMessage> {
-        val root = json.parseToJsonElement(jsonApi.getJson(NodeSeekJsonClient.messageListPath(), REFERER))
-        return root
-            .findObjectArray(PREFERRED_LIST_KEYS)
-            .mapNotNull { element -> (element as? JsonObject)?.toRawMessage() }
-    }
-
-    /**
-     * We are a party to every message, so ours is the uid that shows up most across the list; a
-     * counterparty's cannot — two conversations never share one. A single-conversation list is
-     * genuinely ambiguous, but there [RawMessage.counterpart] still resolves: whichever id this
-     * picks, the other becomes the conversation.
-     */
-    private fun inferOwnUid(rows: List<RawMessage>): Long? =
-        rows
-            .flatMap { listOfNotNull(it.senderId, it.receiverId) }
-            .groupingBy { it }
-            .eachCount()
-            .maxByOrNull { it.value }
-            ?.key
-
-    private fun foldConversation(
-        uid: Long,
-        messages: List<RawMessage>,
-    ): MessageConversation {
-        val newest = messages.maxBy { it.createdAtMillis ?: 0L }
-        val name =
-            messages.firstNotNullOfOrNull { it.nameOf(uid) } ?: "NodeSeek 用户"
-        val isSystem =
-            name == MessageConversation.SYSTEM_NAME || messages.any { it.isSystem }
-        return MessageConversation(
-            uid = uid,
-            userName = name,
-            avatarUrl = if (isSystem) null else NodeSeekSite.avatarUrl(uid),
-            snippet = newest.content,
-            isSnippetMine = newest.senderId != null && newest.senderId != uid,
-            updatedAtMillis = newest.createdAtMillis,
-            updatedAtText = newest.createdAtText,
-            unreadCount = messages.count { !it.viewed && it.senderId == uid },
-            isSystem = isSystem,
-        )
-    }
-
     override suspend fun thread(uid: Long): MessageThread {
-        // No per-conversation endpoint exists — the talk-path guess 404ed on a real device — so the
-        // thread is the flat list filtered to this counterparty. See [listRawMessages].
-        val rows = listRawMessages()
-        val ownUid = inferOwnUid(rows)
+        val body =
+            jsonApi.getJson(
+                path = NodeSeekJsonClient.messageThreadPath(uid),
+                referer = NodeSeekSite.BASE_URL + NodeSeekSite.messageThreadWebPath(uid),
+            )
+        val root = json.parseToJsonElement(body) as? JsonObject
+            ?: throw NodeSeekException(NodeSeekError.Unparsable)
+        val header = root["talkTo"] as? JsonObject
         val messages =
-            rows
-                .filter { it.counterpart(ownUid) == uid }
+            root
+                .findObjectArray(PREFERRED_THREAD_KEYS)
+                .mapNotNull { element -> (element as? JsonObject)?.toRawMessage() }
                 .sortedBy { it.createdAtMillis ?: 0L }
         return MessageThread(
             uid = uid,
-            userName = messages.firstNotNullOfOrNull { it.nameOf(uid) } ?: "NodeSeek 用户",
+            userName = header?.text("member_name", "username", "name") ?: "NodeSeek 用户",
             avatarUrl = NodeSeekSite.avatarUrl(uid),
-            level = null,
+            level = header?.get("rank")?.jsonPrimitive?.intOrNull,
             messages = messages.mapIndexed { index, raw -> raw.toDirectMessage(uid, index) },
         )
     }
@@ -178,7 +148,8 @@ class NetworkMessageRepository(
     ): DirectMessage? {
         val payload =
             buildJsonObject {
-                put("receiver_id", uid)
+                // `receiverUid`, camel-cased, unlike every other field in this API.
+                put("receiverUid", uid)
                 put("content", content)
                 put("markdown", markdown)
             }
@@ -199,20 +170,64 @@ class NetworkMessageRepository(
                 detail = root.text("message", "error"),
             )
         }
-        val accepted =
-            listOf("data", "message", "detail").firstNotNullOfOrNull { key ->
-                root[key] as? JsonObject
-            }
-        return accepted?.toMessage(otherUid = uid, index = 0)
+        // The endpoint answers with a bare ack; the screen keeps its own optimistic bubble.
+        return (root["data"] as? JsonObject)
+            ?.toRawMessage()
+            ?.toDirectMessage(uid, index = 0)
+    }
+
+    override suspend fun markAllRead() {
+        jsonApi.postJson(
+            path = NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED_ALL,
+            body = "",
+            referer = REFERER,
+        )
+    }
+
+    /**
+     * We are a party to every conversation, so ours is the uid that recurs across the list; a
+     * counterparty's cannot — two conversations never share one. With a single conversation both
+     * ids tie, but there [RawMessage.counterpart] still resolves: whichever this picks, the other
+     * becomes the conversation.
+     */
+    private fun inferOwnUid(rows: List<RawMessage>): Long? =
+        rows
+            .flatMap { listOfNotNull(it.senderId, it.receiverId) }
+            .groupingBy { it }
+            .eachCount()
+            .maxByOrNull { it.value }
+            ?.key
+
+    private fun conversationOf(
+        uid: Long,
+        rows: List<RawMessage>,
+        ownUid: Long?,
+    ): MessageConversation {
+        val newest = rows.maxBy { it.createdAtMillis ?: 0L }
+        val name = rows.firstNotNullOfOrNull { it.nameOf(uid) } ?: "NodeSeek 用户"
+        val isSystem = name == MessageConversation.SYSTEM_NAME
+        return MessageConversation(
+            uid = uid,
+            userName = name,
+            avatarUrl = if (isSystem) null else NodeSeekSite.avatarUrl(uid),
+            snippet = newest.content,
+            isSnippetMine = newest.senderId != null && newest.senderId == ownUid,
+            updatedAtMillis = newest.createdAtMillis,
+            updatedAtText = newest.createdAtText,
+            // The list carries one row per conversation, so this is "has unread", counted as one.
+            unreadCount = rows.count { !it.viewed && it.senderId == uid },
+            isSystem = isSystem,
+        )
     }
 
     private companion object {
         val REFERER = NodeSeekSite.BASE_URL + NodeSeekSite.NOTIFICATION_PATH
         val PREFERRED_LIST_KEYS = listOf("msgArray", "messageList", "conversations", "list", "data")
+        val PREFERRED_THREAD_KEYS = listOf("msgArray", "messageList", "list", "data")
     }
 }
 
-/** One wire row of the flat message list, before folding into conversations. */
+/** One wire row. The list and thread endpoints share a shape; only the completeness differs. */
 private data class RawMessage(
     val id: String?,
     val senderId: Long?,
@@ -220,11 +235,10 @@ private data class RawMessage(
     val senderName: String?,
     val receiverName: String?,
     val content: String,
+    val isMarkdown: Boolean,
     val createdAtMillis: Long?,
     val createdAtText: String?,
     val viewed: Boolean,
-    val isEdited: Boolean,
-    val isSystem: Boolean,
 ) {
     /** The conversation this message belongs to: whichever end of it is not us. */
     fun counterpart(ownUid: Long?): Long? =
@@ -249,18 +263,17 @@ private data class RawMessage(
         id = id ?: "$counterpartUid-$index-${content.hashCode()}",
         isMine = senderId != null && senderId != counterpartUid,
         content = content,
+        isMarkdown = isMarkdown,
         sentAtMillis = createdAtMillis,
         sentAtText = createdAtText,
-        isEdited = isEdited,
     )
 }
 
 private fun JsonObject.toRawMessage(): RawMessage? {
     val content =
-        text("content", "last_content", "message", "excerpt")?.collapseWhitespace()?.ifBlank { null }
+        text("content", "last_content", "message", "excerpt")?.trim()?.ifBlank { null }
             ?: return null
     val createdAt = text("created_at", "time", "sent_at", "last_time")
-    val updatedAt = text("updated_at", "edited_at")
     val name = text("member_name", "username", "name")
     return RawMessage(
         id = text("id", "message_id", "msg_id"),
@@ -269,39 +282,13 @@ private fun JsonObject.toRawMessage(): RawMessage? {
         senderName = text("sender_name") ?: name,
         receiverName = text("receiver_name", "target_name") ?: name,
         content = content,
-        createdAtMillis = TimeFormat.parseTimestamp(createdAt ?: updatedAt),
-        createdAtText = (createdAt ?: updatedAt)?.trim()?.ifBlank { null },
+        // Absent flag reads as Markdown: this forum writes Markdown, and rendering a plain message
+        // as Markdown is at worst a lost asterisk, while the reverse leaks link syntax into a bubble.
+        isMarkdown = boolean("is_markdown", "markdown") ?: true,
+        createdAtMillis = TimeFormat.parseTimestamp(createdAt),
+        createdAtText = createdAt?.trim()?.ifBlank { null },
         // Absent flag reads as read: inventing unread noise is worse than missing some.
         viewed = boolean("viewed", "is_read", "read") ?: true,
-        isEdited =
-        boolean("edited", "is_edited")
-            ?: (createdAt != null && updatedAt != null && updatedAt != createdAt),
-        isSystem =
-        boolean("is_system", "system") == true ||
-            name == MessageConversation.SYSTEM_NAME ||
-            text("sender_name") == MessageConversation.SYSTEM_NAME,
-    )
-}
-
-private fun JsonObject.toMessage(
-    otherUid: Long,
-    index: Int,
-): DirectMessage? {
-    val content = text("content", "message", "text") ?: return null
-    val sender = long("sender_id", "member_id", "from", "uid")
-    val sentAt = text("created_at", "time", "sent_at")
-    val updatedAt = text("updated_at", "edited_at")
-    return DirectMessage(
-        id = text("id", "message_id", "msg_id") ?: "$otherUid-$index-${content.hashCode()}",
-        // Unknown sender reads as theirs: showing an incoming message on the right is a lie about who
-        // said it, while showing our own on the left is only a cosmetic misalignment.
-        isMine = sender != null && sender != otherUid,
-        content = content,
-        sentAtMillis = TimeFormat.parseTimestamp(sentAt),
-        sentAtText = sentAt?.trim()?.ifBlank { null },
-        isEdited =
-        boolean("edited", "is_edited")
-            ?: (updatedAt != null && updatedAt != sentAt),
     )
 }
 
@@ -338,5 +325,3 @@ private fun JsonObject.boolean(vararg names: String): Boolean? {
     }
     return null
 }
-
-private fun String.collapseWhitespace(): String = trim().replace(Regex("\\s+"), " ")

--- a/app/src/main/java/io/github/nsreader/data/NotificationRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/NotificationRepository.kt
@@ -2,7 +2,7 @@ package io.github.nsreader.data
 
 import io.github.nsreader.core.NodeSeekSite
 import io.github.nsreader.core.TimeFormat
-import io.github.nsreader.core.net.JsonSource
+import io.github.nsreader.core.net.JsonApi
 import io.github.nsreader.core.net.NodeSeekJsonClient
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -67,7 +67,7 @@ data class ForumNotification(
 )
 
 class NotificationRepository(
-    private val jsonSource: JsonSource,
+    private val jsonSource: JsonApi,
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -77,6 +77,21 @@ class NotificationRepository(
             replies = root.int("reply", "replyCount"),
             mentions = root.int("atMe", "at_me", "mention"),
             messages = root.int("message", "messages", "msg"),
+        )
+    }
+
+    /**
+     * Clears the group server-side.
+     *
+     * The screen used to only grey the rows out locally, so the badge came back on the next refresh.
+     * The site's own 全部标记已读 posts to `markViewed?all=true` per group — see `notification.js`.
+     */
+    suspend fun markAllRead(category: NotificationCategory) {
+        val endpoint = category.endpoint ?: return
+        jsonSource.postJson(
+            path = NodeSeekJsonClient.markAllViewedPath(endpoint),
+            body = "",
+            referer = NodeSeekSite.BASE_URL + NodeSeekSite.NOTIFICATION_PATH,
         )
     }
 

--- a/app/src/main/java/io/github/nsreader/data/NotificationRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/NotificationRepository.kt
@@ -1,5 +1,7 @@
 package io.github.nsreader.data
 
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.TimeFormat
 import io.github.nsreader.core.net.JsonSource
 import io.github.nsreader.core.net.NodeSeekJsonClient
 import kotlinx.serialization.json.Json
@@ -12,37 +14,55 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 
+/**
+ * The site's three notification groups, in the order `/notification` shows them.
+ *
+ * There is no fourth "system" group: what looks like one on the web is a pinned conversation named
+ * 系统通知 inside [MESSAGES] — see `docs/design-requirements-remaining.md` §0.1. [MESSAGES] has no
+ * notification rows of its own either; selecting it shows the conversation list (board 7e), which is
+ * why its endpoint lives in [MessageRepository] rather than here.
+ */
 enum class NotificationCategory(val endpoint: String?) {
-    REPLIES("reply-to-me"),
     MENTIONS("at-me"),
-    MESSAGES("message"),
-    SYSTEM(null),
+    REPLIES("reply-to-me"),
+    MESSAGES(null),
 }
 
 data class NotificationCounts(
     val replies: Int = 0,
     val mentions: Int = 0,
     val messages: Int = 0,
-    val all: Int = 0,
 ) {
+    val all: Int get() = replies + mentions + messages
+
     fun forCategory(category: NotificationCategory): Int =
         when (category) {
-            NotificationCategory.REPLIES -> replies
             NotificationCategory.MENTIONS -> mentions
+            NotificationCategory.REPLIES -> replies
             NotificationCategory.MESSAGES -> messages
-            NotificationCategory.SYSTEM -> (all - replies - mentions - messages).coerceAtLeast(0)
         }
 }
 
+/**
+ * One notification row.
+ *
+ * The sentence is not stored: board 7d renders it as "{actor} 在帖子 {title} 中@了我" with the actor
+ * and the thread styled differently, so the screen composes it from these parts and a string
+ * resource. [createdAtMillis] is null when the endpoint pre-rendered the time, in which case
+ * [createdAtText] is all we have.
+ */
 data class ForumNotification(
     val id: String,
+    val category: NotificationCategory,
     val postId: Long?,
     val floor: String?,
+    val actorUid: Long?,
     val actorName: String,
-    val action: String,
+    val avatarUrl: String?,
     val excerpt: String?,
     val threadTitle: String?,
-    val createdAt: String?,
+    val createdAtMillis: Long?,
+    val createdAtText: String?,
     val isUnread: Boolean,
 )
 
@@ -53,15 +73,10 @@ class NotificationRepository(
 
     suspend fun unreadCounts(): NotificationCounts {
         val root = json.parseToJsonElement(jsonSource.getJson(NodeSeekJsonClient.PATH_UNREAD_COUNT))
-        val replies = root.int("reply", "replyCount")
-        val mentions = root.int("atMe", "at_me", "mention")
-        val messages = root.int("message", "messages", "msg")
-        val declaredAll = root.int("all", "total")
         return NotificationCounts(
-            replies = replies,
-            mentions = mentions,
-            messages = messages,
-            all = if (declaredAll > 0) declaredAll else replies + mentions + messages,
+            replies = root.int("reply", "replyCount"),
+            mentions = root.int("atMe", "at_me", "mention"),
+            messages = root.int("message", "messages", "msg"),
         )
     }
 
@@ -123,24 +138,23 @@ private fun JsonObject.toNotification(
 
     val postId = long("post_id", "postId", "discussion_id")
     val floorValue = text("floor_id", "floor", "floorId")
+    val actorUid = long("member_id", "commenter_id", "sender_id", "uid", "user_id")
     val actor = text("commenter_name", "username", "sender_name", "name") ?: "NodeSeek 用户"
+    val createdAt = text("created_at", "createdAt", "time")
     val viewed =
         this["viewed"]?.jsonPrimitive?.let { it.booleanOrNull ?: (it.intOrNull ?: 0) != 0 } ?: false
     return ForumNotification(
         id = text("comment_id", "id", "message_id") ?: "${category.name}-$postId-$index",
+        category = category,
         postId = postId,
         floor = floorValue?.let { if (it.startsWith('#')) it else "#$it" },
+        actorUid = actorUid,
         actorName = actor,
-        action =
-        when (category) {
-            NotificationCategory.REPLIES -> "回复了你的帖子"
-            NotificationCategory.MENTIONS -> "提到了你"
-            NotificationCategory.MESSAGES -> "给你发来私信"
-            NotificationCategory.SYSTEM -> "发来系统通知"
-        },
-        excerpt = text("content", "comment_content", "excerpt", "message"),
+        avatarUrl = actorUid?.let { NodeSeekSite.avatarUrl(it) },
+        excerpt = text("content", "comment_content", "excerpt", "message")?.trim()?.ifBlank { null },
         threadTitle = text("post_title", "discussion_title", "title"),
-        createdAt = text("created_at", "createdAt", "time"),
+        createdAtMillis = TimeFormat.parseTimestamp(createdAt),
+        createdAtText = createdAt?.trim()?.ifBlank { null },
         isUnread = !viewed,
     )
 }

--- a/app/src/main/java/io/github/nsreader/data/SearchRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/SearchRepository.kt
@@ -142,7 +142,7 @@ private data class UserSearchDto(
         UserSearchResult(
             uid = uid,
             name = name,
-            avatarUrl = NodeSeekSite.absoluteUrl("/avatar/$uid.png"),
+            avatarUrl = NodeSeekSite.avatarUrl(uid),
             level = rank,
             bio = bio?.trim()?.ifBlank { null },
             joinedText = joinedText?.trim()?.ifBlank { null },

--- a/app/src/main/java/io/github/nsreader/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nsreader/di/AppContainer.kt
@@ -13,6 +13,8 @@ import io.github.nsreader.core.net.UserAgent
 import io.github.nsreader.core.net.WebViewCookieJar
 import io.github.nsreader.core.net.resolveUserAgent
 import io.github.nsreader.data.CategoryRepository
+import io.github.nsreader.data.MessageRepository
+import io.github.nsreader.data.NetworkMessageRepository
 import io.github.nsreader.data.NetworkPostDataSource
 import io.github.nsreader.data.NetworkProfileRepository
 import io.github.nsreader.data.NetworkSearchRepository
@@ -47,6 +49,7 @@ interface AppContainer {
     val categoryRepository: CategoryRepository
     val settingsRepository: SettingsRepository
     val notificationRepository: NotificationRepository
+    val messageRepository: MessageRepository
     val profileRepository: ProfileRepository
     val searchRepository: SearchRepository
     val postComposerRepository: PostComposerRepository
@@ -118,6 +121,10 @@ class DefaultAppContainer(
 
     override val notificationRepository: NotificationRepository by lazy {
         NotificationRepository(jsonClient)
+    }
+
+    override val messageRepository: MessageRepository by lazy {
+        NetworkMessageRepository(jsonClient)
     }
 
     override val profileRepository: ProfileRepository by lazy {

--- a/app/src/main/java/io/github/nsreader/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nsreader/di/AppContainer.kt
@@ -12,6 +12,7 @@ import io.github.nsreader.core.net.NodeSeekJsonClient
 import io.github.nsreader.core.net.UserAgent
 import io.github.nsreader.core.net.WebViewCookieJar
 import io.github.nsreader.core.net.resolveUserAgent
+import io.github.nsreader.core.runCatchingExceptCancellation
 import io.github.nsreader.data.CategoryRepository
 import io.github.nsreader.data.MessageRepository
 import io.github.nsreader.data.NetworkMessageRepository
@@ -124,7 +125,11 @@ class DefaultAppContainer(
     }
 
     override val messageRepository: MessageRepository by lazy {
-        NetworkMessageRepository(jsonClient)
+        NetworkMessageRepository(jsonClient) {
+            // Only consulted when a one-conversation inbox leaves the rows ambiguous, and allowed to
+            // fail: a missing uid degrades the guess, it does not fail the screen.
+            runCatchingExceptCancellation { profileRepository.profile().uid }.getOrNull()
+        }
     }
 
     override val profileRepository: ProfileRepository by lazy {

--- a/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
@@ -104,6 +104,34 @@ object NodeSeekIcons {
         )
     }
 
+    /** Sends a direct message (board 7f). */
+    val Send: ImageVector by lazy {
+        materialIcon(
+            name = "Send",
+            pathData = "M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z",
+        )
+    }
+
+    /** Starts a conversation from the message list's FAB (board 7e). */
+    val AddComment: ImageVector by lazy {
+        materialIcon(
+            name = "AddComment",
+            pathData =
+            "M22,4c0,-1.1 -0.9,-2 -2,-2H4c-1.1,0 -2,0.9 -2,2v18l4,-4h14c1.1,0 2,-0.9 2,-2V4z" +
+                "M17,11h-4v4h-2v-4H7V9h4V5h2v4h4v2z",
+        )
+    }
+
+    /** A message that failed to send (board 7f). */
+    val ErrorCircle: ImageVector by lazy {
+        materialIcon(
+            name = "ErrorCircle",
+            pathData =
+            "M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z" +
+                "m1,15h-2v-2h2v2zm0,-4h-2L11,7h2v6z",
+        )
+    }
+
     val ThumbDown: ImageVector by lazy {
         materialIcon(
             name = "ThumbDown",

--- a/app/src/main/java/io/github/nsreader/ui/common/StatusViews.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/StatusViews.kt
@@ -172,6 +172,23 @@ fun LoadingState(modifier: Modifier = Modifier) {
 // -------------------------------------------------------------------------------------------------
 
 /**
+ * The same failures as one line, for somewhere a [StatusView] will not fit — a bottom sheet, a row.
+ *
+ * Shares the titles with the full-screen states so the two never drift into saying different things
+ * about the same failure.
+ */
+@Composable
+fun NodeSeekError.shortMessage(): String =
+    when (this) {
+        NodeSeekError.Cloudflare -> stringResource(R.string.status_challenge_title)
+        NodeSeekError.LoginRequired -> stringResource(R.string.status_sign_in_title)
+        NodeSeekError.Network -> stringResource(R.string.status_network_title)
+        NodeSeekError.Unparsable -> stringResource(R.string.status_unparsable_title)
+        is NodeSeekError.Http -> stringResource(R.string.status_http_title, statusCode)
+        NodeSeekError.Unknown -> stringResource(R.string.status_unknown_title)
+    }
+
+/**
  * Turns a data-layer failure into a screen.
  *
  * Most NodeSeek failures are not really errors — they are a human step the app cannot take: solve

--- a/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
@@ -37,6 +38,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -199,41 +201,66 @@ private fun MessageBubbles(
     onRetrySend: (String) -> Unit,
 ) {
     val listState = rememberLazyListState()
-    LaunchedEffect(state.messages.size) {
-        if (state.messages.isNotEmpty()) listState.animateScrollToItem(state.messages.lastIndex)
+    /*
+     * The rows are built up front rather than emitted inline because the day separators are items
+     * too. Scrolling to `messages.lastIndex` stopped short by one position per separator, which on a
+     * conversation spanning a few days left the newest message off screen — the one place the screen
+     * must always land.
+     */
+    val rows = remember(state.messages, state.nowMillis) { threadRows(state.messages, state.nowMillis) }
+    LaunchedEffect(rows.size) {
+        if (rows.isNotEmpty()) listState.animateScrollToItem(rows.lastIndex)
     }
     LazyColumn(
         state = listState,
         contentPadding = PaddingValues(horizontal = Spacing.lg, vertical = 14.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        state.messages.forEachIndexed { index, message ->
-            dividerLabel(message, state.messages.getOrNull(index - 1), state.nowMillis)?.let { label ->
-                item(key = "divider-${message.id}") { DayDivider(label) }
-            }
-            item(key = message.id) {
-                MessageBubbleRow(
-                    message = message,
-                    onOpenBrowser = onOpenBrowser,
-                    onRetrySend = { onRetrySend(message.id) },
-                )
+        items(rows, key = ThreadRow::key) { row ->
+            when (row) {
+                is ThreadRow.Day -> DayDivider(row.label)
+
+                is ThreadRow.Bubble ->
+                    MessageBubbleRow(
+                        message = row.message,
+                        onOpenBrowser = onOpenBrowser,
+                        onRetrySend = { onRetrySend(row.message.id) },
+                    )
             }
         }
     }
 }
 
-/** A chip appears at the start of the thread and whenever the conversation crosses to a new day. */
-private fun dividerLabel(
-    message: MessageBubble,
-    previous: MessageBubble?,
+internal sealed interface ThreadRow {
+    val key: String
+
+    data class Day(val label: String) : ThreadRow {
+        override val key get() = "day-$label"
+    }
+
+    data class Bubble(val message: MessageBubble) : ThreadRow {
+        override val key get() = message.id
+    }
+}
+
+/** A separator opens the thread and reappears whenever the conversation crosses into a new day. */
+internal fun threadRows(
+    messages: List<MessageBubble>,
     nowMillis: Long,
-): String? {
-    val millis = message.sentAtMillis ?: return null
-    val label = TimeFormat.messageDivider(millis, nowMillis)
-    val previousLabel =
-        previous?.sentAtMillis?.let { TimeFormat.messageDivider(it, nowMillis) } ?: return label
-    // The label carries a clock as well as a day, so only the day half decides.
-    return label.takeIf { it.substringBefore(' ') != previousLabel.substringBefore(' ') }
+): List<ThreadRow> {
+    val rows = mutableListOf<ThreadRow>()
+    var currentDay: String? = null
+    messages.forEach { message ->
+        val label = message.sentAtMillis?.let { TimeFormat.messageDivider(it, nowMillis) }
+        // The label carries a clock as well as a day, so only the day half decides.
+        val day = label?.substringBefore(' ')
+        if (label != null && day != currentDay) {
+            rows += ThreadRow.Day(label)
+            currentDay = day
+        }
+        rows += ThreadRow.Bubble(message)
+    }
+    return rows
 }
 
 @Composable
@@ -340,7 +367,8 @@ private fun MessageStatusLine(
                     modifier = Modifier.size(13.dp),
                 )
                 Text(
-                    stringResource(R.string.message_status_failed),
+                    // The server's reason when it gave one — retrying a block never succeeds.
+                    text = message.failureReason ?: stringResource(R.string.message_status_failed),
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.error,
                 )
@@ -350,7 +378,11 @@ private fun MessageStatusLine(
                     fontWeight = FontWeight.Bold,
                     textDecoration = TextDecoration.Underline,
                     color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.clickable(onClick = onRetrySend).padding(horizontal = 2.dp),
+                    modifier =
+                    Modifier
+                        .minimumInteractiveComponentSize()
+                        .clickable(onClick = onRetrySend)
+                        .padding(horizontal = 2.dp),
                 )
             }
 
@@ -424,6 +456,7 @@ private fun MessageInputBar(
         Box(
             modifier =
             Modifier
+                .minimumInteractiveComponentSize()
                 .size(44.dp)
                 .clip(RoundedCornerShape(14.dp))
                 .background(
@@ -468,6 +501,7 @@ private fun MarkdownToggle(
     Column(
         modifier =
         Modifier
+            .minimumInteractiveComponentSize()
             .width(48.dp)
             .height(44.dp)
             .clip(RoundedCornerShape(14.dp))

--- a/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadScreen.kt
@@ -1,0 +1,623 @@
+package io.github.nsreader.ui.messages
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.TimeFormat
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.ui.common.LoadingState
+import io.github.nsreader.ui.common.NodeSeekErrorState
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.composer.parseMarkdown
+import io.github.nsreader.ui.richtext.RichContent
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+
+@Composable
+fun MessageThreadRoute(
+    viewModel: MessageThreadViewModel,
+    onBack: () -> Unit,
+    onSignIn: () -> Unit,
+    onVerify: () -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    MessageThreadScreen(
+        state = state,
+        onBack = onBack,
+        onSignIn = onSignIn,
+        onVerify = onVerify,
+        onOpenBrowser = onOpenBrowser,
+        onRetryLoad = viewModel::refresh,
+        onDraftChange = viewModel::updateDraft,
+        onToggleMarkdown = viewModel::toggleMarkdown,
+        onSend = viewModel::send,
+        onRetrySend = viewModel::retry,
+        modifier = modifier,
+    )
+}
+
+/** Board 7f — full screen, so the tab bar stays out of a conversation. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MessageThreadScreen(
+    state: MessageThreadUiState,
+    onBack: () -> Unit,
+    onSignIn: () -> Unit,
+    onVerify: () -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onRetryLoad: () -> Unit,
+    onDraftChange: (String) -> Unit,
+    onToggleMarkdown: () -> Unit,
+    onSend: () -> Unit,
+    onRetrySend: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val webUrl = NodeSeekSite.BASE_URL + NodeSeekSite.messageThreadWebPath(state.uid)
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                title = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                    ) {
+                        UserAvatar(url = state.avatarUrl, name = state.userName, size = 32.dp)
+                        Column {
+                            Text(
+                                stringResource(R.string.message_thread_title, state.userName),
+                                style = MaterialTheme.typography.titleMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text =
+                                state.level?.let {
+                                    stringResource(R.string.message_thread_subtitle_level, state.uid, it)
+                                } ?: stringResource(R.string.message_thread_subtitle, state.uid),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                },
+                actions = { ThreadMenu(onOpenBrowser = { onOpenBrowser(webUrl) }) },
+            )
+        },
+    ) { padding ->
+        Column(Modifier.padding(padding).fillMaxSize().imePadding()) {
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Box(Modifier.weight(1f)) {
+                when {
+                    state.isLoading && state.messages.isEmpty() -> LoadingState()
+
+                    state.error != null && state.messages.isEmpty() ->
+                        NodeSeekErrorState(
+                            error = state.error,
+                            onRetry = onRetryLoad,
+                            onOpenBrowser = {
+                                if (state.error == NodeSeekError.LoginRequired) onSignIn() else onVerify()
+                            },
+                        )
+
+                    state.messages.isEmpty() ->
+                        Text(
+                            stringResource(R.string.message_thread_empty),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+
+                    else -> MessageBubbles(state, onOpenBrowser, onRetrySend)
+                }
+            }
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            MessageInputBar(
+                draft = state.draft,
+                isMarkdown = state.isMarkdown,
+                canSend = state.canSend,
+                onDraftChange = onDraftChange,
+                onToggleMarkdown = onToggleMarkdown,
+                onSend = onSend,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MessageBubbles(
+    state: MessageThreadUiState,
+    onOpenBrowser: (String) -> Unit,
+    onRetrySend: (String) -> Unit,
+) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(state.messages.size) {
+        if (state.messages.isNotEmpty()) listState.animateScrollToItem(state.messages.lastIndex)
+    }
+    LazyColumn(
+        state = listState,
+        contentPadding = PaddingValues(horizontal = Spacing.lg, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        state.messages.forEachIndexed { index, message ->
+            dividerLabel(message, state.messages.getOrNull(index - 1), state.nowMillis)?.let { label ->
+                item(key = "divider-${message.id}") { DayDivider(label) }
+            }
+            item(key = message.id) {
+                MessageBubbleRow(
+                    message = message,
+                    isMarkdown = state.isMarkdown,
+                    onOpenBrowser = onOpenBrowser,
+                    onRetrySend = { onRetrySend(message.id) },
+                )
+            }
+        }
+    }
+}
+
+/** A chip appears at the start of the thread and whenever the conversation crosses to a new day. */
+private fun dividerLabel(
+    message: MessageBubble,
+    previous: MessageBubble?,
+    nowMillis: Long,
+): String? {
+    val millis = message.sentAtMillis ?: return null
+    val label = TimeFormat.messageDivider(millis, nowMillis)
+    val previousLabel =
+        previous?.sentAtMillis?.let { TimeFormat.messageDivider(it, nowMillis) } ?: return label
+    // The label carries a clock as well as a day, so only the day half decides.
+    return label.takeIf { it.substringBefore(' ') != previousLabel.substringBefore(' ') }
+}
+
+@Composable
+private fun DayDivider(label: String) {
+    Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier =
+            Modifier
+                .clip(RoundedCornerShape(10.dp))
+                .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                .padding(horizontal = 10.dp, vertical = 3.dp),
+        )
+    }
+}
+
+@Composable
+private fun MessageBubbleRow(
+    message: MessageBubble,
+    isMarkdown: Boolean,
+    onOpenBrowser: (String) -> Unit,
+    onRetrySend: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = if (message.isMine) Alignment.End else Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        Box(
+            modifier =
+            Modifier
+                .fillMaxWidth(BUBBLE_MAX_WIDTH)
+                .wrapContentWidthTo(message.isMine)
+                .clip(
+                    if (message.isMine) {
+                        RoundedCornerShape(18.dp, 18.dp, 6.dp, 18.dp)
+                    } else {
+                        RoundedCornerShape(18.dp, 18.dp, 18.dp, 6.dp)
+                    },
+                ).background(
+                    if (message.isMine) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    },
+                ).padding(horizontal = 14.dp, vertical = 10.dp),
+        ) {
+            val textStyle =
+                MaterialTheme.typography.bodyLarge.copy(
+                    fontSize = 15.sp,
+                    lineHeight = 24.sp,
+                    color =
+                    if (message.isMine) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                )
+            if (isMarkdown) {
+                RichContent(
+                    nodes = parseMarkdown(message.content),
+                    onLinkClick = onOpenBrowser,
+                    onImageClick = onOpenBrowser,
+                    textStyle = textStyle,
+                )
+            } else {
+                Text(message.content, style = textStyle)
+            }
+        }
+        MessageStatusLine(message = message, onRetrySend = onRetrySend)
+    }
+}
+
+@Composable
+private fun MessageStatusLine(
+    message: MessageBubble,
+    onRetrySend: () -> Unit,
+) {
+    val clock = message.sentAtMillis?.let(TimeFormat::clock) ?: message.sentAtText
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        when (message.status) {
+            SendStatus.SENDING -> {
+                CircularProgressIndicator(
+                    strokeWidth = 1.6.dp,
+                    modifier = Modifier.size(10.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    stringResource(R.string.message_status_sending),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            SendStatus.FAILED -> {
+                Icon(
+                    NodeSeekIcons.ErrorCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.size(13.dp),
+                )
+                Text(
+                    stringResource(R.string.message_status_failed),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                Text(
+                    text = stringResource(R.string.action_retry),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    textDecoration = TextDecoration.Underline,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.clickable(onClick = onRetrySend).padding(horizontal = 2.dp),
+                )
+            }
+
+            SendStatus.SENT ->
+                when {
+                    message.isEdited && clock != null ->
+                        Text(
+                            stringResource(R.string.message_edited, clock),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+
+                    message.isMine && clock != null -> {
+                        Icon(
+                            Icons.Default.Check,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(13.dp),
+                        )
+                        Text(
+                            stringResource(R.string.message_status_sent, clock),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    clock != null ->
+                        Text(
+                            clock,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MessageInputBar(
+    draft: String,
+    isMarkdown: Boolean,
+    canSend: Boolean,
+    onDraftChange: (String) -> Unit,
+    onToggleMarkdown: () -> Unit,
+    onSend: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(start = 10.dp, end = 10.dp, top = Spacing.sm, bottom = 14.dp),
+        verticalAlignment = Alignment.Bottom,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        MarkdownToggle(isMarkdown = isMarkdown, onToggle = onToggleMarkdown)
+        TextField(
+            value = draft,
+            onValueChange = onDraftChange,
+            placeholder = {
+                Text(
+                    stringResource(
+                        if (isMarkdown) {
+                            R.string.message_input_hint_markdown
+                        } else {
+                            R.string.message_input_hint_plain
+                        },
+                    ),
+                )
+            },
+            maxLines = MAX_INPUT_LINES,
+            shape = RoundedCornerShape(22.dp),
+            colors =
+            TextFieldDefaults.colors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                disabledIndicatorColor = Color.Transparent,
+            ),
+            modifier = Modifier.weight(1f),
+        )
+        Box(
+            modifier =
+            Modifier
+                .size(44.dp)
+                .clip(RoundedCornerShape(14.dp))
+                .background(
+                    if (canSend) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerHighest
+                    },
+                ).clickable(enabled = canSend, onClick = onSend),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                NodeSeekIcons.Send,
+                contentDescription = stringResource(R.string.message_send),
+                tint =
+                if (canSend) {
+                    MaterialTheme.colorScheme.onPrimary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+/**
+ * The site's MD On/Off switch, drawn small enough to sit in a message bar.
+ *
+ * A Material `Switch` is 52×32 before its touch target, which would take the width of two buttons in
+ * a row that also has to hold a growing text field.
+ */
+@Composable
+private fun MarkdownToggle(
+    isMarkdown: Boolean,
+    onToggle: () -> Unit,
+) {
+    val trackColor =
+        if (isMarkdown) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+    // "MD" alone tells a screen reader nothing, so the switch carries the full name.
+    val label = stringResource(R.string.message_markdown_toggle)
+    Column(
+        modifier =
+        Modifier
+            .width(48.dp)
+            .height(44.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .toggleable(
+                value = isMarkdown,
+                role = Role.Switch,
+                onValueChange = { onToggle() },
+            ).semantics(mergeDescendants = true) { contentDescription = label },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(3.dp, Alignment.CenterVertically),
+    ) {
+        Box(
+            Modifier
+                .width(30.dp)
+                .height(16.dp)
+                .clip(CircleShape)
+                .background(trackColor)
+                .padding(2.dp),
+            contentAlignment = if (isMarkdown) Alignment.CenterEnd else Alignment.CenterStart,
+        ) {
+            Box(
+                Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface),
+            )
+        }
+        Text(
+            text = stringResource(R.string.message_markdown_label),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color =
+            if (isMarkdown) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+        )
+    }
+}
+
+@Composable
+private fun ThreadMenu(onOpenBrowser: () -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    IconButton(onClick = { expanded = true }) {
+        Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.action_more))
+    }
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.action_open_in_browser)) },
+            onClick = {
+                expanded = false
+                onOpenBrowser()
+            },
+        )
+    }
+}
+
+/**
+ * A bubble hugs its text; only the 78 % cap comes from the parent.
+ *
+ * `fillMaxWidth` claims the fraction and `wrapContentWidth` then releases the minimum-width
+ * constraint it would otherwise impose — the same two-step the readable-width cap uses.
+ */
+private fun Modifier.wrapContentWidthTo(isMine: Boolean): Modifier =
+    this.wrapContentWidth(align = if (isMine) Alignment.End else Alignment.Start)
+
+private const val BUBBLE_MAX_WIDTH = 0.78f
+private const val MAX_INPUT_LINES = 5
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun MessageThreadPreview() {
+    val now = 1_785_000_000_000L
+    NodeSeekTheme {
+        MessageThreadScreen(
+            state =
+            MessageThreadUiState(
+                uid = 4471,
+                userName = "iwil",
+                level = 4,
+                nowMillis = now,
+                messages =
+                listOf(
+                    MessageBubble(
+                        id = "1",
+                        isMine = false,
+                        content = "改名的事我问过管理，说要等 UID 显示上线",
+                        sentAtMillis = now - 40 * 60_000L,
+                        sentAtText = null,
+                        isEdited = false,
+                        status = SendStatus.SENT,
+                    ),
+                    MessageBubble(
+                        id = "2",
+                        isMine = true,
+                        content = "那大概什么时候？我这 ID 打错字快两年了",
+                        sentAtMillis = now - 37 * 60_000L,
+                        sentAtText = null,
+                        isEdited = false,
+                        status = SendStatus.SENT,
+                    ),
+                    MessageBubble(
+                        id = "3",
+                        isMine = false,
+                        content = "没给时间点。你可以先在 [求教如何改用户名](/post-1-1) 里顶一下",
+                        sentAtMillis = now - 29 * 60_000L,
+                        sentAtText = null,
+                        isEdited = true,
+                        status = SendStatus.SENT,
+                    ),
+                    MessageBubble(
+                        id = "4",
+                        isMine = true,
+                        content = "行，我发个投票试试",
+                        sentAtMillis = now - 60_000L,
+                        sentAtText = null,
+                        isEdited = false,
+                        status = SendStatus.SENDING,
+                    ),
+                    MessageBubble(
+                        id = "5",
+                        isMine = true,
+                        content = "顺便问下星辰能转账吗",
+                        sentAtMillis = now,
+                        sentAtText = null,
+                        isEdited = false,
+                        status = SendStatus.FAILED,
+                    ),
+                ),
+            ),
+            onBack = {},
+            onSignIn = {},
+            onVerify = {},
+            onOpenBrowser = {},
+            onRetryLoad = {},
+            onDraftChange = {},
+            onToggleMarkdown = {},
+            onSend = {},
+            onRetrySend = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadScreen.kt
@@ -214,7 +214,6 @@ private fun MessageBubbles(
             item(key = message.id) {
                 MessageBubbleRow(
                     message = message,
-                    isMarkdown = state.isMarkdown,
                     onOpenBrowser = onOpenBrowser,
                     onRetrySend = { onRetrySend(message.id) },
                 )
@@ -256,7 +255,6 @@ private fun DayDivider(label: String) {
 @Composable
 private fun MessageBubbleRow(
     message: MessageBubble,
-    isMarkdown: Boolean,
     onOpenBrowser: (String) -> Unit,
     onRetrySend: () -> Unit,
 ) {
@@ -295,7 +293,7 @@ private fun MessageBubbleRow(
                         MaterialTheme.colorScheme.onSurface
                     },
                 )
-            if (isMarkdown) {
+            if (message.isMarkdown) {
                 RichContent(
                     nodes = parseMarkdown(message.content),
                     onLinkClick = onOpenBrowser,
@@ -358,13 +356,6 @@ private fun MessageStatusLine(
 
             SendStatus.SENT ->
                 when {
-                    message.isEdited && clock != null ->
-                        Text(
-                            stringResource(R.string.message_edited, clock),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-
                     message.isMine && clock != null -> {
                         Icon(
                             Icons.Default.Check,
@@ -568,7 +559,7 @@ private fun MessageThreadPreview() {
                         content = "改名的事我问过管理，说要等 UID 显示上线",
                         sentAtMillis = now - 40 * 60_000L,
                         sentAtText = null,
-                        isEdited = false,
+                        isMarkdown = true,
                         status = SendStatus.SENT,
                     ),
                     MessageBubble(
@@ -577,7 +568,7 @@ private fun MessageThreadPreview() {
                         content = "那大概什么时候？我这 ID 打错字快两年了",
                         sentAtMillis = now - 37 * 60_000L,
                         sentAtText = null,
-                        isEdited = false,
+                        isMarkdown = true,
                         status = SendStatus.SENT,
                     ),
                     MessageBubble(
@@ -586,7 +577,7 @@ private fun MessageThreadPreview() {
                         content = "没给时间点。你可以先在 [求教如何改用户名](/post-1-1) 里顶一下",
                         sentAtMillis = now - 29 * 60_000L,
                         sentAtText = null,
-                        isEdited = true,
+                        isMarkdown = true,
                         status = SendStatus.SENT,
                     ),
                     MessageBubble(
@@ -595,7 +586,7 @@ private fun MessageThreadPreview() {
                         content = "行，我发个投票试试",
                         sentAtMillis = now - 60_000L,
                         sentAtText = null,
-                        isEdited = false,
+                        isMarkdown = true,
                         status = SendStatus.SENDING,
                     ),
                     MessageBubble(
@@ -604,7 +595,7 @@ private fun MessageThreadPreview() {
                         content = "顺便问下星辰能转账吗",
                         sentAtMillis = now,
                         sentAtText = null,
-                        isEdited = false,
+                        isMarkdown = true,
                         status = SendStatus.FAILED,
                     ),
                 ),

--- a/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadViewModel.kt
@@ -1,0 +1,210 @@
+package io.github.nsreader.ui.messages
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.AppClock
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.DirectMessage
+import io.github.nsreader.data.MessageRepository
+import io.github.nsreader.data.session.SessionRepository
+import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Board 7f.
+ *
+ * The delivery states are the app's, not the site's: NodeSeek posts a message and re-renders the
+ * page, so there is nothing to observe between "typed" and "there". Keeping the optimistic bubble in
+ * the list — rather than clearing the field and waiting — is what makes a failed send recoverable
+ * without the user having retyped anything.
+ */
+class MessageThreadViewModel(
+    private val repository: MessageRepository,
+    private val session: SessionRepository,
+    private val clock: AppClock,
+    uid: Long,
+    userName: String,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(MessageThreadUiState(uid = uid, userName = userName))
+    val uiState: StateFlow<MessageThreadUiState> = _uiState.asStateFlow()
+    private var loadJob: Job? = null
+    private var pendingSeed = 0L
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        if (!session.state.value.isSignedIn) {
+            _uiState.update { it.copy(error = NodeSeekError.LoginRequired) }
+            return
+        }
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                runCatchingExceptCancellation { repository.thread(_uiState.value.uid) }
+                    .onSuccess { thread ->
+                        _uiState.update { state ->
+                            state.copy(
+                                // The server list replaces the delivered history but must not drop a
+                                // bubble that is still in flight or waiting to be retried.
+                                messages =
+                                thread.messages.map(::delivered) +
+                                    state.messages.filter { it.status != SendStatus.SENT },
+                                userName = thread.userName.ifBlank { state.userName },
+                                avatarUrl = thread.avatarUrl,
+                                level = thread.level,
+                                isLoading = false,
+                                error = null,
+                                nowMillis = clock.nowMillis(),
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(isLoading = false, error = throwable.toNodeSeekError())
+                        }
+                    }
+            }
+    }
+
+    fun updateDraft(value: String) {
+        _uiState.update { it.copy(draft = value) }
+    }
+
+    fun toggleMarkdown() {
+        _uiState.update { it.copy(isMarkdown = !it.isMarkdown) }
+    }
+
+    fun send() {
+        val content = _uiState.value.draft.trim()
+        if (content.isEmpty()) return
+        val bubble =
+            MessageBubble(
+                id = "pending-${pendingSeed++}",
+                isMine = true,
+                content = content,
+                sentAtMillis = clock.nowMillis(),
+                sentAtText = null,
+                isEdited = false,
+                status = SendStatus.SENDING,
+            )
+        _uiState.update {
+            it.copy(draft = "", messages = it.messages + bubble, nowMillis = clock.nowMillis())
+        }
+        deliver(bubble)
+    }
+
+    fun retry(id: String) {
+        val bubble = _uiState.value.messages.firstOrNull { it.id == id } ?: return
+        if (bubble.status != SendStatus.FAILED) return
+        replace(id) { it.copy(status = SendStatus.SENDING) }
+        deliver(bubble)
+    }
+
+    private fun deliver(bubble: MessageBubble) {
+        viewModelScope.launch {
+            runCatchingExceptCancellation {
+                repository.send(
+                    uid = _uiState.value.uid,
+                    content = bubble.content,
+                    markdown = _uiState.value.isMarkdown,
+                )
+            }.onSuccess { accepted ->
+                replace(bubble.id) {
+                    accepted?.let(::delivered)?.copy(id = bubble.id)
+                        ?: it.copy(status = SendStatus.SENT)
+                }
+            }.onFailure { throwable ->
+                replace(bubble.id) {
+                    it.copy(status = SendStatus.FAILED, failure = throwable.toNodeSeekError())
+                }
+            }
+        }
+    }
+
+    private fun replace(
+        id: String,
+        transform: (MessageBubble) -> MessageBubble,
+    ) {
+        _uiState.update { state ->
+            state.copy(
+                messages = state.messages.map { if (it.id == id) transform(it) else it },
+                nowMillis = clock.nowMillis(),
+            )
+        }
+    }
+
+    private fun delivered(message: DirectMessage) =
+        MessageBubble(
+            id = message.id,
+            isMine = message.isMine,
+            content = message.content,
+            sentAtMillis = message.sentAtMillis,
+            sentAtText = message.sentAtText,
+            isEdited = message.isEdited,
+            status = SendStatus.SENT,
+        )
+
+    companion object {
+        fun factory(
+            container: AppContainer,
+            uid: Long,
+            userName: String,
+        ): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    MessageThreadViewModel(
+                        repository = container.messageRepository,
+                        session = container.sessionRepository,
+                        clock = container.clock,
+                        uid = uid,
+                        userName = userName,
+                    )
+                }
+            }
+    }
+}
+
+enum class SendStatus {
+    SENT,
+    SENDING,
+    FAILED,
+}
+
+data class MessageBubble(
+    val id: String,
+    val isMine: Boolean,
+    val content: String,
+    val sentAtMillis: Long?,
+    val sentAtText: String?,
+    val isEdited: Boolean,
+    val status: SendStatus,
+    val failure: NodeSeekError? = null,
+)
+
+data class MessageThreadUiState(
+    val uid: Long,
+    val userName: String,
+    val avatarUrl: String? = null,
+    val level: Int? = null,
+    val messages: List<MessageBubble> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: NodeSeekError? = null,
+    val draft: String = "",
+    /** The site's own MD On/Off switch; off sends the text verbatim. */
+    val isMarkdown: Boolean = true,
+    val nowMillis: Long = 0L,
+) {
+    val canSend: Boolean get() = draft.isNotBlank()
+}

--- a/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import io.github.nsreader.core.AppClock
 import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
 import io.github.nsreader.core.runCatchingExceptCancellation
 import io.github.nsreader.data.DirectMessage
 import io.github.nsreader.data.MessageRepository
@@ -122,12 +123,19 @@ class MessageThreadViewModel(
                 )
             }.onSuccess { accepted ->
                 replace(bubble.id) {
-                    accepted?.let(::delivered)?.copy(id = bubble.id)
+                    // Whatever the echo says, this bubble is ours: an ack without a sender must not
+                    // send the message we just wrote over to the other side of the thread.
+                    accepted?.let(::delivered)?.copy(id = bubble.id, isMine = true)
                         ?: it.copy(status = SendStatus.SENT)
                 }
             }.onFailure { throwable ->
                 replace(bubble.id) {
-                    it.copy(status = SendStatus.FAILED, failure = throwable.toNodeSeekError())
+                    it.copy(
+                        status = SendStatus.FAILED,
+                        // "对方已屏蔽你" is not something retrying will fix, and it is the only way
+                        // the user finds that out — a bare 发送失败 invites tapping 重试 forever.
+                        failureReason = (throwable as? NodeSeekException)?.detail,
+                    )
                 }
             }
         }
@@ -191,7 +199,8 @@ data class MessageBubble(
     val sentAtMillis: Long?,
     val sentAtText: String?,
     val status: SendStatus,
-    val failure: NodeSeekError? = null,
+    /** The server's own words for a rejection, when it gave any. */
+    val failureReason: String? = null,
 )
 
 data class MessageThreadUiState(

--- a/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/messages/MessageThreadViewModel.kt
@@ -94,9 +94,9 @@ class MessageThreadViewModel(
                 id = "pending-${pendingSeed++}",
                 isMine = true,
                 content = content,
+                isMarkdown = _uiState.value.isMarkdown,
                 sentAtMillis = clock.nowMillis(),
                 sentAtText = null,
-                isEdited = false,
                 status = SendStatus.SENDING,
             )
         _uiState.update {
@@ -150,9 +150,9 @@ class MessageThreadViewModel(
             id = message.id,
             isMine = message.isMine,
             content = message.content,
+            isMarkdown = message.isMarkdown,
             sentAtMillis = message.sentAtMillis,
             sentAtText = message.sentAtText,
-            isEdited = message.isEdited,
             status = SendStatus.SENT,
         )
 
@@ -186,9 +186,10 @@ data class MessageBubble(
     val id: String,
     val isMine: Boolean,
     val content: String,
+    /** The site records this per message, so an old plain message stays plain. */
+    val isMarkdown: Boolean,
     val sentAtMillis: Long?,
     val sentAtText: String?,
-    val isEdited: Boolean,
     val status: SendStatus,
     val failure: NodeSeekError? = null,
 )

--- a/app/src/main/java/io/github/nsreader/ui/notifications/ConversationList.kt
+++ b/app/src/main/java/io/github/nsreader/ui/notifications/ConversationList.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -54,6 +53,7 @@ import io.github.nsreader.ui.common.shortMessage
 import io.github.nsreader.ui.composer.parseMarkdown
 import io.github.nsreader.ui.theme.NodeSeekTheme
 import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
 
 /**
  * Board 7e — the 私信 group of the notification tab.
@@ -166,30 +166,45 @@ private fun ConversationRow(
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = conversation.userName,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = if (isUnread) FontWeight.Bold else FontWeight.SemiBold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    // `fill = false` keeps the pin beside the name instead of at the far right; the
-                    // stamp is pushed away by the spacer below.
-                    modifier = Modifier.weight(1f, fill = false),
-                )
-                if (conversation.isSystem) {
-                    Icon(
-                        NodeSeekIcons.PushPin,
-                        contentDescription = stringResource(R.string.messages_pinned),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(14.dp),
+                /*
+                 * The name and its pin travel together inside one weighted row, and the stamp is the
+                 * only unweighted child, so it sits against the right edge of every row alike.
+                 *
+                 * Weighting the name *and* a spacer instead made the two split the slack evenly,
+                 * which parked each row's stamp a different distance in from the edge — a column of
+                 * times that visibly failed to line up.
+                 */
+                Row(
+                    modifier = Modifier.weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = conversation.userName,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = if (isUnread) FontWeight.Bold else FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
+                    if (conversation.isSystem) {
+                        Icon(
+                            NodeSeekIcons.PushPin,
+                            contentDescription = stringResource(R.string.messages_pinned),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(14.dp),
+                        )
+                    }
                 }
-                Spacer(Modifier.weight(1f))
                 conversationStamp(conversation, nowMillis)?.let { stamp ->
                     Text(
                         text = stamp,
-                        style = MaterialTheme.typography.labelMedium,
+                        style =
+                        MaterialTheme.typography.labelMedium.copy(
+                            fontFeatureSettings = TABULAR_FIGURES,
+                        ),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
                     )
                 }
             }

--- a/app/src/main/java/io/github/nsreader/ui/notifications/ConversationList.kt
+++ b/app/src/main/java/io/github/nsreader/ui/notifications/ConversationList.kt
@@ -1,0 +1,392 @@
+package io.github.nsreader.ui.notifications
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.R
+import io.github.nsreader.core.TimeFormat
+import io.github.nsreader.data.MessageConversation
+import io.github.nsreader.data.UserSearchResult
+import io.github.nsreader.model.InlineNode
+import io.github.nsreader.model.RichNode
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.composer.parseMarkdown
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+
+/**
+ * Board 7e — the 私信 group of the notification tab.
+ *
+ * 系统通知 is pinned at the top by [io.github.nsreader.data.NetworkMessageRepository]; it is an
+ * ordinary conversation whose messages happen to be Markdown, which is why its snippet renders as
+ * styled text while everyone else's is plain.
+ */
+@Composable
+internal fun ConversationList(
+    state: NotificationsUiState,
+    onConversationClick: (MessageConversation) -> Unit,
+    onNewConversation: () -> Unit,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    onDismiss: () -> Unit,
+    onRecipientClick: (UserSearchResult) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier.fillMaxSize()) {
+        if (state.conversations.isEmpty()) {
+            Text(
+                text = stringResource(R.string.messages_empty),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        } else {
+            LazyColumn(contentPadding = PaddingValues(bottom = FAB_CLEARANCE)) {
+                items(state.conversations, key = MessageConversation::uid) { conversation ->
+                    ConversationRow(
+                        conversation = conversation,
+                        nowMillis = state.nowMillis,
+                        onClick = { onConversationClick(conversation) },
+                    )
+                }
+            }
+        }
+
+        FloatingActionButton(
+            onClick = onNewConversation,
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            modifier = Modifier.align(Alignment.BottomEnd).padding(Spacing.lg),
+        ) {
+            Icon(
+                NodeSeekIcons.AddComment,
+                contentDescription = stringResource(R.string.messages_new_conversation),
+            )
+        }
+    }
+
+    if (state.newConversation.isVisible) {
+        NewConversationSheet(
+            state = state.newConversation,
+            onQueryChange = onQueryChange,
+            onSearch = onSearch,
+            onDismiss = onDismiss,
+            onRecipientClick = onRecipientClick,
+        )
+    }
+}
+
+@Composable
+private fun ConversationRow(
+    conversation: MessageConversation,
+    nowMillis: Long,
+    onClick: () -> Unit,
+) {
+    val isUnread = conversation.unreadCount > 0
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .background(
+                if (isUnread) {
+                    MaterialTheme.colorScheme.surfaceContainerLow
+                } else {
+                    MaterialTheme.colorScheme.surface
+                },
+            ).clickable(onClick = onClick)
+            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (conversation.isSystem) {
+            Box(
+                Modifier
+                    .size(AVATAR)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primaryContainer),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.Notifications,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+        } else {
+            UserAvatar(
+                url = conversation.avatarUrl,
+                name = conversation.userName,
+                size = AVATAR,
+            )
+        }
+
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = conversation.userName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = if (isUnread) FontWeight.Bold else FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    // `fill = false` keeps the pin beside the name instead of at the far right; the
+                    // stamp is pushed away by the spacer below.
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                if (conversation.isSystem) {
+                    Icon(
+                        NodeSeekIcons.PushPin,
+                        contentDescription = stringResource(R.string.messages_pinned),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                conversationStamp(conversation, nowMillis)?.let { stamp ->
+                    Text(
+                        text = stamp,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = conversationSnippet(conversation),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (isUnread) {
+                    Box(
+                        Modifier
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primary)
+                            .padding(horizontal = 5.dp, vertical = 1.dp),
+                    ) {
+                        Text(
+                            text = conversation.unreadCount.coerceAtMost(MAX_UNREAD).toString(),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun conversationStamp(
+    conversation: MessageConversation,
+    nowMillis: Long,
+): String? =
+    conversation.updatedAtMillis
+        ?.let { TimeFormat.conversationStamp(it, nowMillis) }
+        ?: conversation.updatedAtText
+
+/**
+ * The snippet, with the system conversation's Markdown links picked out in the brand colour.
+ *
+ * Only the link text survives — the row has one line, and the target is whatever the conversation
+ * opens onto anyway.
+ */
+@Composable
+private fun conversationSnippet(conversation: MessageConversation): AnnotatedString {
+    val emphasis = SpanStyle(color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.SemiBold)
+    val body =
+        if (conversation.isSystem) {
+            buildAnnotatedString {
+                parseMarkdown(conversation.snippet)
+                    .filterIsInstance<RichNode.Paragraph>()
+                    .flatMap(RichNode.Paragraph::inlines)
+                    .forEach { inline ->
+                        when (inline) {
+                            is InlineNode.Text -> append(inline.text)
+                            is InlineNode.Link -> withStyle(emphasis) { append(inline.text) }
+                            else -> Unit
+                        }
+                    }
+            }
+        } else {
+            AnnotatedString(conversation.snippet)
+        }
+    if (!conversation.isSnippetMine) return body
+    val prefix = stringResource(R.string.messages_snippet_mine_prefix)
+    return buildAnnotatedString {
+        append(prefix)
+        append(body)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NewConversationSheet(
+    state: NewConversationState,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    onDismiss: () -> Unit,
+    onRecipientClick: (UserSearchResult) -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = rememberModalBottomSheetState()) {
+        Column(
+            modifier = Modifier.padding(horizontal = Spacing.lg).padding(bottom = Spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            Text(
+                stringResource(R.string.messages_new_conversation),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                stringResource(R.string.messages_new_conversation_intro),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = state.query,
+                onValueChange = onQueryChange,
+                singleLine = true,
+                label = { Text(stringResource(R.string.messages_new_conversation_hint)) },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onSearch() }),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            when {
+                state.isSearching -> CircularProgressIndicator(Modifier.align(Alignment.CenterHorizontally))
+
+                state.results.isEmpty() && state.query.isNotBlank() ->
+                    Text(
+                        stringResource(R.string.messages_new_conversation_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+
+                else ->
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                        items(state.results, key = UserSearchResult::uid) { user ->
+                            Row(
+                                modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onRecipientClick(user) }
+                                    .padding(vertical = Spacing.sm),
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                UserAvatar(url = user.avatarUrl, name = user.name, size = 34.dp)
+                                Text(user.name, style = MaterialTheme.typography.bodyLarge)
+                            }
+                        }
+                    }
+            }
+        }
+    }
+}
+
+private val AVATAR = 44.dp
+private val FAB_CLEARANCE = 88.dp
+private const val MAX_UNREAD = 99
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 640)
+@Composable
+private fun ConversationListPreview() {
+    NodeSeekTheme {
+        ConversationList(
+            state =
+            NotificationsUiState(
+                isSignedIn = true,
+                nowMillis = PREVIEW_NOW,
+                conversations =
+                listOf(
+                    MessageConversation(
+                        uid = 1,
+                        userName = MessageConversation.SYSTEM_NAME,
+                        avatarUrl = null,
+                        snippet = "您的[评论](/post-1-1)被用户[iwil](/space/4471)投喂鸡腿",
+                        isSnippetMine = false,
+                        updatedAtMillis = PREVIEW_NOW - 70 * 60_000L,
+                        updatedAtText = null,
+                        unreadCount = 1,
+                        isSystem = true,
+                    ),
+                    MessageConversation(
+                        uid = 2,
+                        userName = "nssk",
+                        avatarUrl = null,
+                        snippet = "改名的事我问过管理，说要等 UID 显示上线",
+                        isSnippetMine = false,
+                        updatedAtMillis = PREVIEW_NOW - 4 * 60_000L,
+                        updatedAtText = null,
+                        unreadCount = 2,
+                        isSystem = false,
+                    ),
+                    MessageConversation(
+                        uid = 3,
+                        userName = "demain",
+                        avatarUrl = null,
+                        snippet = "好的，我先转账，晚点把 push 链接发我",
+                        isSnippetMine = true,
+                        updatedAtMillis = PREVIEW_NOW - 26 * 60 * 60_000L,
+                        updatedAtText = null,
+                        unreadCount = 0,
+                        isSystem = false,
+                    ),
+                ),
+            ),
+            onConversationClick = {},
+            onNewConversation = {},
+            onQueryChange = {},
+            onSearch = {},
+            onDismiss = {},
+            onRecipientClick = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/notifications/ConversationList.kt
+++ b/app/src/main/java/io/github/nsreader/ui/notifications/ConversationList.kt
@@ -50,6 +50,7 @@ import io.github.nsreader.model.InlineNode
 import io.github.nsreader.model.RichNode
 import io.github.nsreader.ui.common.NodeSeekIcons
 import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.common.shortMessage
 import io.github.nsreader.ui.composer.parseMarkdown
 import io.github.nsreader.ui.theme.NodeSeekTheme
 import io.github.nsreader.ui.theme.Spacing
@@ -301,6 +302,15 @@ private fun NewConversationSheet(
             )
             when {
                 state.isSearching -> CircularProgressIndicator(Modifier.align(Alignment.CenterHorizontally))
+
+                // Before the empty case: a search that never reached the server has not found
+                // "no such user", and telling the user it did sends them off renaming their query.
+                state.error != null ->
+                    Text(
+                        state.error.shortMessage(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
 
                 state.results.isEmpty() && state.query.isNotBlank() ->
                     Text(

--- a/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,10 +18,12 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.MailOutline
-import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -31,20 +34,30 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nsreader.R
+import io.github.nsreader.core.TimeFormat
+import io.github.nsreader.core.net.NodeSeekError
 import io.github.nsreader.data.ForumNotification
+import io.github.nsreader.data.MessageConversation
 import io.github.nsreader.data.NotificationCategory
+import io.github.nsreader.data.NotificationCounts
+import io.github.nsreader.data.UserSearchResult
 import io.github.nsreader.ui.common.LoadingState
 import io.github.nsreader.ui.common.NodeSeekErrorState
 import io.github.nsreader.ui.common.SignedOutState
 import io.github.nsreader.ui.common.UserAvatar
 import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Sizes
 import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
 import io.github.nsreader.ui.theme.readableWidth
 
 @Composable
@@ -53,6 +66,7 @@ fun NotificationsRoute(
     onSignIn: () -> Unit,
     onVerify: () -> Unit,
     onNotificationClick: (ForumNotification) -> Unit,
+    onOpenThread: (Long, String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -67,10 +81,28 @@ fun NotificationsRoute(
             viewModel.markOpened(it.id)
             onNotificationClick(it)
         },
+        onConversationClick = { conversation ->
+            viewModel.markConversationOpened(conversation.uid)
+            onOpenThread(conversation.uid, conversation.userName)
+        },
+        onNewConversation = viewModel::showNewConversation,
+        onNewConversationQueryChange = viewModel::updateNewConversationQuery,
+        onNewConversationSearch = viewModel::searchRecipients,
+        onNewConversationDismiss = viewModel::dismissNewConversation,
+        onRecipientClick = { user ->
+            viewModel.dismissNewConversation()
+            onOpenThread(user.uid, user.name)
+        },
         modifier = modifier,
     )
 }
 
+/**
+ * Boards 7d and 7e.
+ *
+ * One screen rather than two: 私信 is a *group* of the same 通知 tab on the site, so it keeps the
+ * title, the 全部已读 action and the group chips and swaps only the list underneath.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationsScreen(
@@ -81,6 +113,12 @@ fun NotificationsScreen(
     onRetry: () -> Unit,
     onMarkAllRead: () -> Unit,
     onNotificationClick: (ForumNotification) -> Unit,
+    onConversationClick: (MessageConversation) -> Unit,
+    onNewConversation: () -> Unit,
+    onNewConversationQueryChange: (String) -> Unit,
+    onNewConversationSearch: () -> Unit,
+    onNewConversationDismiss: () -> Unit,
+    onRecipientClick: (UserSearchResult) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(modifier = modifier) { padding ->
@@ -96,17 +134,14 @@ fun NotificationsScreen(
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.weight(1f),
                 )
-                TextButton(
-                    onClick = onMarkAllRead,
-                    enabled = state.items.any(ForumNotification::isUnread),
-                ) {
-                    androidx.compose.material3.Icon(Icons.Default.Check, contentDescription = null)
+                TextButton(onClick = onMarkAllRead, enabled = state.hasUnread) {
+                    Icon(Icons.Default.Check, contentDescription = null)
                     Text(stringResource(R.string.notifications_mark_all_read))
                 }
             }
 
             LazyRow(
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = Spacing.lg),
+                contentPadding = PaddingValues(horizontal = Spacing.lg),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
                 items(NotificationCategory.entries, key = { it.name }) { category ->
@@ -114,9 +149,25 @@ fun NotificationsScreen(
                         selected = category == state.selectedCategory,
                         onClick = { onCategoryChange(category) },
                         label = { Text(category.label()) },
+                        colors =
+                        FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = MaterialTheme.colorScheme.primary,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                            selectedTrailingIconColor = MaterialTheme.colorScheme.onPrimary,
+                        ),
                         trailingIcon = {
+                            // A plain tabular numeral, not a Badge: the count belongs to the chip's own
+                            // colour pair, and Badge would drop a red pill into a row of brand chips.
                             val count = state.counts.forCategory(category)
-                            if (count > 0) Badge { Text(count.coerceAtMost(99).toString()) }
+                            if (count > 0) {
+                                Text(
+                                    text = count.coerceAtMost(MAX_BADGE).toString(),
+                                    style =
+                                    MaterialTheme.typography.labelLarge.copy(
+                                        fontFeatureSettings = TABULAR_FIGURES,
+                                    ),
+                                )
+                            }
                         },
                     )
                 }
@@ -126,18 +177,25 @@ fun NotificationsScreen(
                 when {
                     !state.isSignedIn -> SignedOutState(onSignIn = onSignIn)
 
-                    state.isLoading && state.items.isEmpty() -> LoadingState()
+                    state.isLoading && state.isEmpty -> LoadingState()
 
-                    state.error != null && state.items.isEmpty() ->
+                    state.error != null && state.isEmpty ->
                         NodeSeekErrorState(
                             error = state.error,
                             onRetry = onRetry,
                             onOpenBrowser =
-                            if (state.error == io.github.nsreader.core.net.NodeSeekError.LoginRequired) {
-                                onSignIn
-                            } else {
-                                onVerify
-                            },
+                            if (state.error == NodeSeekError.LoginRequired) onSignIn else onVerify,
+                        )
+
+                    state.selectedCategory == NotificationCategory.MESSAGES ->
+                        ConversationList(
+                            state = state,
+                            onConversationClick = onConversationClick,
+                            onNewConversation = onNewConversation,
+                            onQueryChange = onNewConversationQueryChange,
+                            onSearch = onNewConversationSearch,
+                            onDismiss = onNewConversationDismiss,
+                            onRecipientClick = onRecipientClick,
                         )
 
                     state.items.isEmpty() ->
@@ -151,8 +209,10 @@ fun NotificationsScreen(
                             items(state.items, key = ForumNotification::id) { item ->
                                 NotificationRow(
                                     item = item,
+                                    nowMillis = state.nowMillis,
                                     onClick = { onNotificationClick(item) },
                                 )
+                                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                             }
                         }
                 }
@@ -164,6 +224,7 @@ fun NotificationsScreen(
 @Composable
 private fun NotificationRow(
     item: ForumNotification,
+    nowMillis: Long,
     onClick: () -> Unit,
 ) {
     Row(
@@ -177,47 +238,92 @@ private fun NotificationRow(
                     MaterialTheme.colorScheme.surface
                 },
             ).clickable(enabled = item.postId != null, onClick = onClick)
-            .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+            .padding(start = 10.dp, end = Spacing.lg, top = 14.dp, bottom = 14.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Box(Modifier.size(8.dp).padding(top = 2.dp)) {
+        // Aligned with the first line of the sentence rather than the top of the row.
+        Box(Modifier.padding(top = 7.dp).size(6.dp)) {
             if (item.isUnread) {
                 Box(
                     Modifier
-                        .size(8.dp)
+                        .size(6.dp)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.primary),
                 )
             }
         }
-        UserAvatar(url = null, name = item.actorName, size = 34.dp)
-        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        UserAvatar(url = item.avatarUrl, name = item.actorName, size = Sizes.avatarList)
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(5.dp)) {
             Text(
-                text = item.actorName + " " + item.action,
-                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Medium),
+                text = notificationSentence(item),
+                style = MaterialTheme.typography.bodyMedium,
+                color =
+                if (item.isUnread) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
             )
-            item.excerpt?.let {
+            timestampLabel(item.createdAtMillis, item.createdAtText, nowMillis)?.let { stamp ->
                 Text(
-                    text = it,
-                    style = MaterialTheme.typography.bodySmall,
+                    text = stamp,
+                    style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-            val footer = listOfNotNull(item.threadTitle, item.createdAt).joinToString(" · ")
-            if (footer.isNotEmpty()) {
-                Text(
-                    text = footer,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
     }
 }
+
+/**
+ * "{actor} 在帖子 {title} 中@了我", with the actor and the thread carrying their own emphasis.
+ *
+ * Built from the template's placeholders instead of `String.format` + `indexOf`, so a user whose
+ * name also occurs inside the thread title cannot shift the spans onto the wrong words.
+ */
+@Composable
+private fun notificationSentence(item: ForumNotification): AnnotatedString {
+    val template =
+        stringResource(
+            when (item.category) {
+                NotificationCategory.REPLIES -> R.string.notification_sentence_reply
+                else -> R.string.notification_sentence_mention
+            },
+        )
+    val title = item.threadTitle ?: stringResource(R.string.notification_unknown_thread)
+    val actorStyle = SpanStyle(color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Bold)
+    val titleStyle = SpanStyle(color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.SemiBold)
+    return buildAnnotatedString {
+        var cursor = 0
+        PLACEHOLDER.findAll(template).forEach { match ->
+            append(template.substring(cursor, match.range.first))
+            when (match.groupValues[1]) {
+                "1" -> withStyle(actorStyle) { append(item.actorName) }
+                else -> withStyle(titleStyle) { append(title) }
+            }
+            cursor = match.range.last + 1
+        }
+        append(template.substring(cursor))
+    }
+}
+
+/** `26 分钟前 · 2026/7/26 09:56:03`, or the server's own wording when it sent no parsable time. */
+@Composable
+internal fun timestampLabel(
+    millis: Long?,
+    fallback: String?,
+    nowMillis: Long,
+): String? =
+    when {
+        millis == null -> fallback
+
+        else ->
+            stringResource(
+                R.string.notification_time_pair,
+                TimeFormat.relative(millis, nowMillis),
+                TimeFormat.absolute(millis),
+            )
+    }
 
 @Composable
 private fun EmptyNotifications(
@@ -229,7 +335,7 @@ private fun EmptyNotifications(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
-        androidx.compose.material3.Icon(
+        Icon(
             Icons.Default.MailOutline,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -244,12 +350,15 @@ private fun EmptyNotifications(
 private fun NotificationCategory.label(): String =
     stringResource(
         when (this) {
-            NotificationCategory.REPLIES -> R.string.notifications_replies
             NotificationCategory.MENTIONS -> R.string.notifications_mentions
+            NotificationCategory.REPLIES -> R.string.notifications_replies
             NotificationCategory.MESSAGES -> R.string.notifications_messages
-            NotificationCategory.SYSTEM -> R.string.notifications_system
         },
     )
+
+/** `%1$s` / `%2$s` in the sentence templates; the class keeps the dollar out of the raw string. */
+private val PLACEHOLDER = Regex("""%(\d)[$]s""")
+private const val MAX_BADGE = 99
 
 @Preview(showBackground = true, widthDp = 360, heightDp = 800)
 @Composable
@@ -259,18 +368,37 @@ private fun NotificationsPreview() {
             state =
             NotificationsUiState(
                 isSignedIn = true,
+                counts = NotificationCounts(replies = 5, mentions = 2, messages = 3),
+                nowMillis = PREVIEW_NOW,
                 items =
                 listOf(
                     ForumNotification(
                         id = "1",
+                        category = NotificationCategory.MENTIONS,
                         postId = 1,
                         floor = "#3",
-                        actorName = "zhh123",
-                        action = "回复了你的帖子",
-                        excerpt = "你试试前台等，一般是浏览器把下载放后台了",
-                        threadTitle = "为啥 nodequality 复制格式非常慢…",
-                        createdAt = "5分钟前",
+                        actorUid = 12,
+                        actorName = "nssk",
+                        avatarUrl = null,
+                        excerpt = null,
+                        threadTitle = "求教如何改用户名",
+                        createdAtMillis = PREVIEW_NOW - 26 * 60_000L,
+                        createdAtText = null,
                         isUnread = true,
+                    ),
+                    ForumNotification(
+                        id = "2",
+                        category = NotificationCategory.MENTIONS,
+                        postId = 2,
+                        floor = null,
+                        actorUid = 13,
+                        actorName = "羽落无声",
+                        avatarUrl = null,
+                        excerpt = null,
+                        threadTitle = "Debian 13 上用 nftables 做端口转发的坑",
+                        createdAtMillis = PREVIEW_NOW - 26 * 60 * 60_000L,
+                        createdAtText = null,
+                        isUnread = false,
                     ),
                 ),
             ),
@@ -280,6 +408,15 @@ private fun NotificationsPreview() {
             onRetry = {},
             onMarkAllRead = {},
             onNotificationClick = {},
+            onConversationClick = {},
+            onNewConversation = {},
+            onNewConversationQueryChange = {},
+            onNewConversationSearch = {},
+            onNewConversationDismiss = {},
+            onRecipientClick = {},
         )
     }
 }
+
+/** Fixed so the preview's relative labels do not drift with the render clock. */
+internal const val PREVIEW_NOW = 1_785_000_000_000L

--- a/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsViewModel.kt
@@ -100,16 +100,29 @@ class NotificationsViewModel(
     }
 
     /**
-     * The observed endpoint marks notifications as they are opened; this action clears the current
-     * presentation immediately and the next refresh reconciles with the server's authoritative count.
+     * Clears the group, optimistically and then for real.
+     *
+     * The local update lands first because the button should not feel like a network round trip; the
+     * request that follows is what makes it survive a refresh. A failure re-reads the server rather
+     * than restoring the badges by hand — whatever it says is the truth either way.
      */
     fun markAllRead() {
+        val category = _uiState.value.selectedCategory
         _uiState.update { state ->
             state.copy(
                 items = state.items.map { it.copy(isUnread = false) },
                 conversations = state.conversations.map { it.copy(unreadCount = 0) },
                 counts = NotificationCounts(),
             )
+        }
+        viewModelScope.launch {
+            runCatchingExceptCancellation {
+                if (category == NotificationCategory.MESSAGES) {
+                    messages.markAllRead()
+                } else {
+                    repository.markAllRead(category)
+                }
+            }.onFailure { refresh() }
         }
     }
 

--- a/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsViewModel.kt
@@ -5,12 +5,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.AppClock
 import io.github.nsreader.core.net.NodeSeekError
 import io.github.nsreader.core.runCatchingExceptCancellation
 import io.github.nsreader.data.ForumNotification
+import io.github.nsreader.data.MessageConversation
+import io.github.nsreader.data.MessageRepository
 import io.github.nsreader.data.NotificationCategory
 import io.github.nsreader.data.NotificationCounts
 import io.github.nsreader.data.NotificationRepository
+import io.github.nsreader.data.SearchRepository
+import io.github.nsreader.data.UserSearchResult
 import io.github.nsreader.data.session.SessionRepository
 import io.github.nsreader.di.AppContainer
 import io.github.nsreader.ui.postlist.toNodeSeekError
@@ -26,12 +31,16 @@ import kotlinx.coroutines.launch
 
 class NotificationsViewModel(
     private val repository: NotificationRepository,
+    private val messages: MessageRepository,
+    private val search: SearchRepository,
     private val session: SessionRepository,
+    private val clock: AppClock,
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow(NotificationsUiState(isSignedIn = session.state.value.isSignedIn))
     val uiState: StateFlow<NotificationsUiState> = _uiState.asStateFlow()
     private var loadJob: Job? = null
+    private var pickerJob: Job? = null
 
     init {
         session.state
@@ -46,10 +55,19 @@ class NotificationsViewModel(
 
     fun selectCategory(category: NotificationCategory) {
         if (_uiState.value.selectedCategory == category) return
-        _uiState.update { it.copy(selectedCategory = category, items = emptyList()) }
+        _uiState.update {
+            it.copy(selectedCategory = category, items = emptyList(), conversations = emptyList())
+        }
         refresh()
     }
 
+    /**
+     * Loads the counts plus whichever list the selected group shows.
+     *
+     * 私信 is not a list of notifications — it is the conversation list of board 7e — so the group
+     * decides which repository answers, and the counts call is shared because the chips show all
+     * three badges whatever is selected.
+     */
     fun refresh() {
         if (!session.state.value.isSignedIn) return
         val category = _uiState.value.selectedCategory
@@ -59,11 +77,21 @@ class NotificationsViewModel(
                 _uiState.update { it.copy(isLoading = true, error = null) }
                 runCatchingExceptCancellation {
                     val counts = repository.unreadCounts()
-                    val items = repository.notifications(category)
-                    counts to items
-                }.onSuccess { (counts, items) ->
+                    if (category == NotificationCategory.MESSAGES) {
+                        Loaded(counts, conversations = messages.conversations())
+                    } else {
+                        Loaded(counts, items = repository.notifications(category))
+                    }
+                }.onSuccess { loaded ->
                     _uiState.update {
-                        it.copy(counts = counts, items = items, isLoading = false, error = null)
+                        it.copy(
+                            counts = loaded.counts,
+                            items = loaded.items,
+                            conversations = loaded.conversations,
+                            isLoading = false,
+                            error = null,
+                            nowMillis = clock.nowMillis(),
+                        )
                     }
                 }.onFailure { throwable ->
                     _uiState.update { it.copy(isLoading = false, error = throwable.toNodeSeekError()) }
@@ -79,6 +107,7 @@ class NotificationsViewModel(
         _uiState.update { state ->
             state.copy(
                 items = state.items.map { it.copy(isUnread = false) },
+                conversations = state.conversations.map { it.copy(unreadCount = 0) },
                 counts = NotificationCounts(),
             )
         }
@@ -90,24 +119,118 @@ class NotificationsViewModel(
         }
     }
 
+    fun markConversationOpened(uid: Long) {
+        _uiState.update { state ->
+            state.copy(
+                conversations =
+                state.conversations.map { if (it.uid == uid) it.copy(unreadCount = 0) else it },
+            )
+        }
+    }
+
+    fun showNewConversation() {
+        _uiState.update { it.copy(newConversation = NewConversationState(isVisible = true)) }
+    }
+
+    fun dismissNewConversation() {
+        pickerJob?.cancel()
+        _uiState.update { it.copy(newConversation = NewConversationState()) }
+    }
+
+    fun updateNewConversationQuery(value: String) {
+        _uiState.update { it.copy(newConversation = it.newConversation.copy(query = value)) }
+    }
+
+    fun searchRecipients() {
+        val query = _uiState.value.newConversation.query.trim()
+        if (query.isEmpty()) return
+        pickerJob?.cancel()
+        pickerJob =
+            viewModelScope.launch {
+                _uiState.update {
+                    it.copy(
+                        newConversation =
+                        it.newConversation.copy(isSearching = true, error = null, results = emptyList()),
+                    )
+                }
+                runCatchingExceptCancellation { search.searchUsers(query) }
+                    .onSuccess { users ->
+                        _uiState.update {
+                            it.copy(
+                                newConversation =
+                                it.newConversation.copy(isSearching = false, results = users),
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(
+                                newConversation =
+                                it.newConversation.copy(
+                                    isSearching = false,
+                                    error = throwable.toNodeSeekError(),
+                                ),
+                            )
+                        }
+                    }
+            }
+    }
+
+    private data class Loaded(
+        val counts: NotificationCounts,
+        val items: List<ForumNotification> = emptyList(),
+        val conversations: List<MessageConversation> = emptyList(),
+    )
+
     companion object {
         fun factory(container: AppContainer): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     NotificationsViewModel(
                         repository = container.notificationRepository,
+                        messages = container.messageRepository,
+                        search = container.searchRepository,
                         session = container.sessionRepository,
+                        clock = container.clock,
                     )
                 }
             }
     }
 }
 
-data class NotificationsUiState(
-    val isSignedIn: Boolean = false,
-    val selectedCategory: NotificationCategory = NotificationCategory.REPLIES,
-    val counts: NotificationCounts = NotificationCounts(),
-    val items: List<ForumNotification> = emptyList(),
-    val isLoading: Boolean = false,
+/**
+ * The 新建私信 picker (board 7e's FAB).
+ *
+ * Marked "App 增强" on the board: the site has no way to start a conversation with someone you have
+ * never talked to, so this reuses the member-search endpoint to pick a recipient.
+ */
+data class NewConversationState(
+    val isVisible: Boolean = false,
+    val query: String = "",
+    val results: List<UserSearchResult> = emptyList(),
+    val isSearching: Boolean = false,
     val error: NodeSeekError? = null,
 )
+
+data class NotificationsUiState(
+    val isSignedIn: Boolean = false,
+    val selectedCategory: NotificationCategory = NotificationCategory.MENTIONS,
+    val counts: NotificationCounts = NotificationCounts(),
+    val items: List<ForumNotification> = emptyList(),
+    val conversations: List<MessageConversation> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: NodeSeekError? = null,
+    /** Stamped when the list loaded, so relative labels stay stable across recomposition. */
+    val nowMillis: Long = 0L,
+    val newConversation: NewConversationState = NewConversationState(),
+) {
+    val hasUnread: Boolean
+        get() = items.any(ForumNotification::isUnread) || conversations.any { it.unreadCount > 0 }
+
+    val isEmpty: Boolean
+        get() =
+            if (selectedCategory == NotificationCategory.MESSAGES) {
+                conversations.isEmpty()
+            } else {
+                items.isEmpty()
+            }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,13 +136,38 @@
     <string name="search_clear_all">全部清除</string>
     <string name="search_remove_recent">删除最近搜索：%1$s</string>
 
-    <!-- Notifications -->
+    <!-- Notifications: the site has three groups, and 私信 is a conversation list rather than rows -->
     <string name="notifications_mark_all_read">全部已读</string>
-    <string name="notifications_replies">回复我的</string>
-    <string name="notifications_mentions">@我的</string>
+    <string name="notifications_mentions">@我</string>
+    <string name="notifications_replies">回复主题</string>
     <string name="notifications_messages">私信</string>
-    <string name="notifications_system">系统</string>
     <string name="notifications_empty">这里暂时没有通知</string>
+    <string name="notification_sentence_mention">%1$s 在帖子 %2$s 中@了我</string>
+    <string name="notification_sentence_reply">%1$s 回复了帖子 %2$s</string>
+    <string name="notification_unknown_thread">某个帖子</string>
+    <string name="notification_time_pair">%1$s · %2$s</string>
+
+    <!-- Direct messages -->
+    <string name="messages_empty">还没有私信</string>
+    <string name="messages_pinned">置顶会话</string>
+    <string name="messages_snippet_mine_prefix">你：</string>
+    <string name="messages_new_conversation">新建私信</string>
+    <string name="messages_new_conversation_hint">搜索用户名</string>
+    <string name="messages_new_conversation_empty">没有找到这个用户</string>
+    <string name="messages_new_conversation_intro">站点没有「新建会话」入口，这里用用户搜索选收件人。</string>
+    <string name="message_thread_title">与 %1$s 的对话</string>
+    <string name="message_thread_subtitle">UID %1$d</string>
+    <string name="message_thread_subtitle_level">UID %1$d · Lv %2$d</string>
+    <string name="message_thread_empty">还没有消息，说点什么吧</string>
+    <string name="message_input_hint_markdown">发消息（Markdown 已开）</string>
+    <string name="message_input_hint_plain">发消息</string>
+    <string name="message_markdown_toggle">Markdown 开关</string>
+    <string name="message_markdown_label" tools:ignore="Typos">MD</string>
+    <string name="message_send">发送</string>
+    <string name="message_status_sending">发送中</string>
+    <string name="message_status_failed">发送失败</string>
+    <string name="message_status_sent">已送达 %1$s</string>
+    <string name="message_edited">%1$s · 已编辑</string>
 
     <!-- Profile -->
     <string name="profile_session_active">NodeSeek 登录会话有效</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,7 +167,6 @@
     <string name="message_status_sending">发送中</string>
     <string name="message_status_failed">发送失败</string>
     <string name="message_status_sent">已送达 %1$s</string>
-    <string name="message_edited">%1$s · 已编辑</string>
 
     <!-- Profile -->
     <string name="profile_session_active">NodeSeek 登录会话有效</string>

--- a/app/src/test/java/io/github/nsreader/core/TimeFormatTest.kt
+++ b/app/src/test/java/io/github/nsreader/core/TimeFormatTest.kt
@@ -1,0 +1,70 @@
+package io.github.nsreader.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.ZoneId
+
+class TimeFormatTest {
+    private val zone = ZoneId.of("Asia/Shanghai")
+
+    /** 10:22 +08:00 — the wall clock every board draws in its status bar. Elapsed time floors. */
+    private val now = TimeFormat.parseTimestamp("2026-07-26 10:22:03", zone)!!
+
+    @Test
+    fun `parses the timestamp formats the endpoints actually send`() {
+        assertEquals(
+            TimeFormat.parseTimestamp("2026-07-26T09:56:03", zone),
+            TimeFormat.parseTimestamp("2026-07-26 09:56:03", zone),
+        )
+        assertEquals(1_774_000_000_000L, TimeFormat.parseTimestamp("1774000000", zone))
+        assertEquals(1_774_000_000_000L, TimeFormat.parseTimestamp("1774000000000", zone))
+    }
+
+    @Test
+    fun `pre-rendered server wording is not a timestamp`() {
+        assertNull(TimeFormat.parseTimestamp("5分钟前", zone))
+        assertNull(TimeFormat.parseTimestamp("", zone))
+        assertNull(TimeFormat.parseTimestamp(null, zone))
+        // Short numbers are ids, not seconds since the epoch.
+        assertNull(TimeFormat.parseTimestamp("42", zone))
+    }
+
+    @Test
+    fun `relative label matches board 7d`() {
+        assertEquals("26 分钟前", TimeFormat.relative(at("2026-07-26 09:56:03"), now, zone))
+        assertEquals("2 小时前", TimeFormat.relative(at("2026-07-26 08:02:45"), now, zone))
+        assertEquals("昨天", TimeFormat.relative(at("2026-07-25 18:09:50"), now, zone))
+        assertEquals("3 天前", TimeFormat.relative(at("2026-07-23 21:14:36"), now, zone))
+        assertEquals("7月15日", TimeFormat.relative(at("2026-07-15 20:33:28"), now, zone))
+        assertEquals("2025年7月15日", TimeFormat.relative(at("2025-07-15 20:33:28"), now, zone))
+    }
+
+    /** An hours-old message from yesterday reads as 昨天, never as "20 小时前". */
+    @Test
+    fun `relative label crosses midnight by calendar day`() {
+        assertEquals("昨天", TimeFormat.relative(at("2026-07-25 23:30:00"), now, zone))
+    }
+
+    @Test
+    fun `absolute label keeps seconds`() {
+        assertEquals("2026/7/26 09:56:03", TimeFormat.absolute(at("2026-07-26 09:56:03"), zone))
+    }
+
+    @Test
+    fun `conversation stamp degrades from clock to weekday to date`() {
+        assertEquals("10:18", TimeFormat.conversationStamp(at("2026-07-26 10:18:00"), now, zone))
+        assertEquals("昨天", TimeFormat.conversationStamp(at("2026-07-25 10:18:00"), now, zone))
+        assertEquals("周三", TimeFormat.conversationStamp(at("2026-07-22 10:18:00"), now, zone))
+        assertEquals("7月18日", TimeFormat.conversationStamp(at("2026-07-18 10:18:00"), now, zone))
+    }
+
+    @Test
+    fun `message divider names the day`() {
+        assertEquals("今天 09:41", TimeFormat.messageDivider(at("2026-07-26 09:41:00"), now, zone))
+        assertEquals("昨天 09:41", TimeFormat.messageDivider(at("2026-07-25 09:41:00"), now, zone))
+        assertEquals("7月18日 09:41", TimeFormat.messageDivider(at("2026-07-18 09:41:00"), now, zone))
+    }
+
+    private fun at(value: String): Long = TimeFormat.parseTimestamp(value, zone)!!
+}

--- a/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
@@ -12,10 +12,14 @@ import org.junit.Test
 
 class MessageRepositoryTest {
     private val listPath = NodeSeekJsonClient.messageListPath()
-    private val threadPath = NodeSeekJsonClient.messageThreadPath(4471)
 
+    /**
+     * Regression for the Galaxy S24 crash: the live endpoint answers with one row per *message*, so
+     * a counterparty with two messages appeared twice and the uid-keyed list threw
+     * "Key … was already used". Rows must fold into one conversation per counterparty.
+     */
     @Test
-    fun `pins the system conversation above newer chats`() =
+    fun `folds the flat message list into one conversation per counterparty`() =
         runTest {
             val api =
                 FakeJsonApi(
@@ -23,11 +27,15 @@ class MessageRepositoryTest {
                         listPath to
                             """
                             {"msgArray":[
-                              {"member_id":2,"member_name":"nssk","sender_id":2,
-                               "content":"改名的事我问过管理","created_at":"2026-07-26 10:18:00","unread":2},
-                              {"member_id":1,"member_name":"系统通知",
+                              {"sender_id":52425,"receiver_id":9,"sender_name":"nssk",
+                               "content":"改名的事我问过管理","created_at":"2026-07-26 10:18:00","viewed":0},
+                              {"sender_id":9,"receiver_id":52425,"receiver_name":"nssk",
+                               "content":"有消息同步我","created_at":"2026-07-26 10:02:00","viewed":1},
+                              {"sender_id":52425,"receiver_id":9,"sender_name":"nssk",
+                               "content":"UID 显示说是在做了","created_at":"2026-07-26 10:15:00","viewed":0},
+                              {"sender_id":1,"receiver_id":9,"sender_name":"系统通知",
                                "content":"您的[评论](/post-1-1)被用户[iwil](/space/4471)投喂鸡腿",
-                               "created_at":"2026-07-26 09:12:00","unread":1}
+                               "created_at":"2026-07-26 09:12:00","viewed":0}
                             ]}
                             """.trimIndent(),
                     ),
@@ -35,26 +43,57 @@ class MessageRepositoryTest {
 
             val conversations = NetworkMessageRepository(api).conversations()
 
+            // One row per counterparty, uids unique, system pinned first despite being older.
             assertEquals(listOf("系统通知", "nssk"), conversations.map(MessageConversation::userName))
+            assertEquals(conversations.size, conversations.distinctBy(MessageConversation::uid).size)
             assertTrue(conversations.first().isSystem)
-            assertEquals(2, conversations[1].unreadCount)
+            val nssk = conversations[1]
+            // Newest message wins the snippet; only their unread messages count.
+            assertEquals("改名的事我问过管理", nssk.snippet)
+            assertFalse(nssk.isSnippetMine)
+            assertEquals(2, nssk.unreadCount)
         }
 
-    /** A message whose sender is the person we are talking to is theirs; anything else is ours. */
+    /** Rows that carry only the counterparty's id (no receiver field) still group correctly. */
     @Test
-    fun `derives direction from the sender without knowing our own uid`() =
+    fun `member-style rows without a receiver id fold by sender`() =
         runTest {
             val api =
                 FakeJsonApi(
                     mapOf(
-                        threadPath to
+                        listPath to
                             """
-                            {"member":{"member_name":"iwil","rank":4},
-                             "msgArray":[
-                               {"id":2,"sender_id":9,"content":"那大概什么时候？",
-                                "created_at":"2026-07-26 09:44:00"},
-                               {"id":1,"sender_id":4471,"content":"改名的事我问过管理",
-                                "created_at":"2026-07-26 09:41:00"}
+                            {"msgArray":[
+                              {"member_id":2,"member_name":"nssk","content":"第一条","created_at":"2026-07-26 10:00:00"},
+                              {"member_id":2,"member_name":"nssk","content":"第二条","created_at":"2026-07-26 10:05:00"},
+                              {"member_id":3,"member_name":"demain","content":"你好","created_at":"2026-07-26 09:00:00"}
+                            ]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            val conversations = NetworkMessageRepository(api).conversations()
+
+            assertEquals(2, conversations.size)
+            assertEquals("第二条", conversations.first { it.userName == "nssk" }.snippet)
+        }
+
+    /** The thread is the flat list sliced to one counterparty — there is no talk endpoint (404ed). */
+    @Test
+    fun `thread slices the list to one counterparty and derives direction`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    mapOf(
+                        listPath to
+                            """
+                            {"msgArray":[
+                              {"id":2,"sender_id":9,"receiver_id":4471,"receiver_name":"iwil",
+                               "content":"那大概什么时候？","created_at":"2026-07-26 09:44:00"},
+                              {"id":1,"sender_id":4471,"receiver_id":9,"sender_name":"iwil",
+                               "content":"改名的事我问过管理","created_at":"2026-07-26 09:41:00"},
+                              {"id":3,"sender_id":7,"receiver_id":9,"sender_name":"demain",
+                               "content":"别的会话的消息","created_at":"2026-07-26 09:50:00"}
                              ]}
                             """.trimIndent(),
                     ),
@@ -63,8 +102,7 @@ class MessageRepositoryTest {
             val thread = NetworkMessageRepository(api).thread(4471)
 
             assertEquals("iwil", thread.userName)
-            assertEquals(4, thread.level)
-            // Sorted oldest first, whatever order the endpoint used.
+            // Another counterparty's message never leaks in; sorted oldest first whatever the wire order.
             assertEquals(listOf("1", "2"), thread.messages.map(DirectMessage::id))
             assertFalse(thread.messages[0].isMine)
             assertTrue(thread.messages[1].isMine)
@@ -76,7 +114,7 @@ class MessageRepositoryTest {
             val api =
                 FakeJsonApi(
                     mapOf(
-                        threadPath to
+                        listPath to
                             """
                             {"msgArray":[{"id":1,"sender_id":4471,"content":"顶一下",
                               "created_at":"2026-07-26 09:41:00","updated_at":"2026-07-26 09:52:00"}]}

--- a/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
@@ -1,0 +1,143 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.net.JsonApi
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.net.NodeSeekJsonClient
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MessageRepositoryTest {
+    private val listPath = NodeSeekJsonClient.messageListPath()
+    private val threadPath = NodeSeekJsonClient.messageThreadPath(4471)
+
+    @Test
+    fun `pins the system conversation above newer chats`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    mapOf(
+                        listPath to
+                            """
+                            {"msgArray":[
+                              {"member_id":2,"member_name":"nssk","sender_id":2,
+                               "content":"改名的事我问过管理","created_at":"2026-07-26 10:18:00","unread":2},
+                              {"member_id":1,"member_name":"系统通知",
+                               "content":"您的[评论](/post-1-1)被用户[iwil](/space/4471)投喂鸡腿",
+                               "created_at":"2026-07-26 09:12:00","unread":1}
+                            ]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            val conversations = NetworkMessageRepository(api).conversations()
+
+            assertEquals(listOf("系统通知", "nssk"), conversations.map(MessageConversation::userName))
+            assertTrue(conversations.first().isSystem)
+            assertEquals(2, conversations[1].unreadCount)
+        }
+
+    /** A message whose sender is the person we are talking to is theirs; anything else is ours. */
+    @Test
+    fun `derives direction from the sender without knowing our own uid`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    mapOf(
+                        threadPath to
+                            """
+                            {"member":{"member_name":"iwil","rank":4},
+                             "msgArray":[
+                               {"id":2,"sender_id":9,"content":"那大概什么时候？",
+                                "created_at":"2026-07-26 09:44:00"},
+                               {"id":1,"sender_id":4471,"content":"改名的事我问过管理",
+                                "created_at":"2026-07-26 09:41:00"}
+                             ]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            val thread = NetworkMessageRepository(api).thread(4471)
+
+            assertEquals("iwil", thread.userName)
+            assertEquals(4, thread.level)
+            // Sorted oldest first, whatever order the endpoint used.
+            assertEquals(listOf("1", "2"), thread.messages.map(DirectMessage::id))
+            assertFalse(thread.messages[0].isMine)
+            assertTrue(thread.messages[1].isMine)
+        }
+
+    @Test
+    fun `an updated timestamp marks a message as edited`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    mapOf(
+                        threadPath to
+                            """
+                            {"msgArray":[{"id":1,"sender_id":4471,"content":"顶一下",
+                              "created_at":"2026-07-26 09:41:00","updated_at":"2026-07-26 09:52:00"}]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            assertTrue(NetworkMessageRepository(api).thread(4471).messages.single().isEdited)
+        }
+
+    @Test
+    fun `send returns the accepted message`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    posts =
+                    mapOf(
+                        NodeSeekJsonClient.PATH_MESSAGE_SEND to
+                            """{"success":true,"data":{"id":7,"sender_id":9,"content":"行"}}""",
+                    ),
+                )
+
+            val sent = NetworkMessageRepository(api).send(4471, "行", markdown = true)
+
+            assertEquals("7", sent?.id)
+            assertTrue(sent!!.isMine)
+            assertTrue(api.postedBodies.single().contains("\"receiver_id\":4471"))
+        }
+
+    @Test
+    fun `a rejected send carries the reason`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    posts =
+                    mapOf(
+                        NodeSeekJsonClient.PATH_MESSAGE_SEND to
+                            """{"success":false,"message":"对方已屏蔽你"}""",
+                    ),
+                )
+
+            val failure =
+                runCatching { NetworkMessageRepository(api).send(4471, "在吗", markdown = false) }
+                    .exceptionOrNull() as NodeSeekException
+
+            assertEquals(NodeSeekError.Unknown, failure.error)
+            assertEquals("对方已屏蔽你", failure.message)
+        }
+}
+
+private class FakeJsonApi(
+    private val responses: Map<String, String> = emptyMap(),
+    private val posts: Map<String, String> = emptyMap(),
+) : JsonApi {
+    val postedBodies = mutableListOf<String>()
+
+    override suspend fun getJson(path: String, referer: String): String =
+        requireNotNull(responses[path]) { "No response for $path" }
+
+    override suspend fun postJson(path: String, body: String, referer: String): String {
+        postedBodies += body
+        return requireNotNull(posts[path]) { "No response for $path" }
+    }
+}

--- a/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
@@ -10,32 +10,37 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Payloads here are trimmed captures of the live endpoints, taken from a signed-in device on
+ * 2026-07-26 — the field names are the site's, not a guess at them.
+ */
 class MessageRepositoryTest {
     private val listPath = NodeSeekJsonClient.messageListPath()
+    private val threadPath = NodeSeekJsonClient.messageThreadPath(5230)
 
     /**
-     * Regression for the Galaxy S24 crash: the live endpoint answers with one row per *message*, so
-     * a counterparty with two messages appeared twice and the uid-keyed list threw
-     * "Key … was already used". Rows must fold into one conversation per counterparty.
+     * Regression for the crash this screen shipped with: no row says which party is "the other
+     * person", so picking a uid field-by-field selected the sender — us — for every row, and the
+     * uid-keyed list threw "Key … was already used".
      */
     @Test
-    fun `folds the flat message list into one conversation per counterparty`() =
+    fun `keys each conversation on the counterparty rather than on us`() =
         runTest {
             val api =
                 FakeJsonApi(
                     mapOf(
                         listPath to
                             """
-                            {"msgArray":[
-                              {"sender_id":52425,"receiver_id":9,"sender_name":"nssk",
-                               "content":"改名的事我问过管理","created_at":"2026-07-26 10:18:00","viewed":0},
-                              {"sender_id":9,"receiver_id":52425,"receiver_name":"nssk",
-                               "content":"有消息同步我","created_at":"2026-07-26 10:02:00","viewed":1},
-                              {"sender_id":52425,"receiver_id":9,"sender_name":"nssk",
-                               "content":"UID 显示说是在做了","created_at":"2026-07-26 10:15:00","viewed":0},
-                              {"sender_id":1,"receiver_id":9,"sender_name":"系统通知",
-                               "content":"您的[评论](/post-1-1)被用户[iwil](/space/4471)投喂鸡腿",
-                               "created_at":"2026-07-26 09:12:00","viewed":0}
+                            {"success":true,"msgArray":[
+                              {"receiver_id":5230,"sender_id":52425,"max_id":7196941,"content":"test",
+                               "created_at":"2026-07-26T14:31:28.000Z","viewed":0,
+                               "sender_name":"林地雪原-0062","receiver_name":"系统通知"},
+                              {"receiver_id":16874,"sender_id":52425,"max_id":7168848,
+                               "content":"@WF5151561","created_at":"2026-07-24T16:24:20.000Z","viewed":1,
+                               "sender_name":"林地雪原-0062","receiver_name":"adang"},
+                              {"receiver_id":52425,"sender_id":51822,"max_id":6115015,"content":"收到了",
+                               "created_at":"2026-05-13T14:21:19.000Z","viewed":1,
+                               "sender_name":"ZcZiXs","receiver_name":"林地雪原-0062"}
                             ]}
                             """.trimIndent(),
                     ),
@@ -43,20 +48,16 @@ class MessageRepositoryTest {
 
             val conversations = NetworkMessageRepository(api).conversations()
 
-            // One row per counterparty, uids unique, system pinned first despite being older.
-            assertEquals(listOf("系统通知", "nssk"), conversations.map(MessageConversation::userName))
+            assertEquals(3, conversations.size)
             assertEquals(conversations.size, conversations.distinctBy(MessageConversation::uid).size)
+            // 系统通知 is pinned above the others even though a newer chat exists.
+            assertEquals("系统通知", conversations.first().userName)
             assertTrue(conversations.first().isSystem)
-            val nssk = conversations[1]
-            // Newest message wins the snippet; only their unread messages count.
-            assertEquals("改名的事我问过管理", nssk.snippet)
-            assertFalse(nssk.isSnippetMine)
-            assertEquals(2, nssk.unreadCount)
+            assertEquals(listOf(5230L, 16874L, 51822L), conversations.map(MessageConversation::uid).sorted())
         }
 
-    /** Rows that carry only the counterparty's id (no receiver field) still group correctly. */
     @Test
-    fun `member-style rows without a receiver id fold by sender`() =
+    fun `marks the snippet as ours only when we sent the last message`() =
         runTest {
             val api =
                 FakeJsonApi(
@@ -64,84 +65,78 @@ class MessageRepositoryTest {
                         listPath to
                             """
                             {"msgArray":[
-                              {"member_id":2,"member_name":"nssk","content":"第一条","created_at":"2026-07-26 10:00:00"},
-                              {"member_id":2,"member_name":"nssk","content":"第二条","created_at":"2026-07-26 10:05:00"},
-                              {"member_id":3,"member_name":"demain","content":"你好","created_at":"2026-07-26 09:00:00"}
+                              {"receiver_id":16874,"sender_id":52425,"content":"我发的",
+                               "created_at":"2026-07-24T16:24:20.000Z","viewed":1,
+                               "sender_name":"我","receiver_name":"adang"},
+                              {"receiver_id":52425,"sender_id":51822,"content":"他发的",
+                               "created_at":"2026-05-13T14:21:19.000Z","viewed":0,
+                               "sender_name":"ZcZiXs","receiver_name":"我"}
                             ]}
                             """.trimIndent(),
                     ),
                 )
 
-            val conversations = NetworkMessageRepository(api).conversations()
+            val conversations = NetworkMessageRepository(api).conversations().associateBy { it.userName }
 
-            assertEquals(2, conversations.size)
-            assertEquals("第二条", conversations.first { it.userName == "nssk" }.snippet)
+            assertTrue(conversations.getValue("adang").isSnippetMine)
+            assertFalse(conversations.getValue("ZcZiXs").isSnippetMine)
+            // Unread counts only their messages, so the one we sent never shows a badge.
+            assertEquals(0, conversations.getValue("adang").unreadCount)
+            assertEquals(1, conversations.getValue("ZcZiXs").unreadCount)
         }
 
-    /** The thread is the flat list sliced to one counterparty — there is no talk endpoint (404ed). */
+    /** The full history lives behind `with/{uid}`; the list only ever holds the latest message. */
     @Test
-    fun `thread slices the list to one counterparty and derives direction`() =
+    fun `thread reads the whole history and the talkTo header`() =
         runTest {
             val api =
                 FakeJsonApi(
                     mapOf(
-                        listPath to
+                        threadPath to
                             """
-                            {"msgArray":[
-                              {"id":2,"sender_id":9,"receiver_id":4471,"receiver_name":"iwil",
-                               "content":"那大概什么时候？","created_at":"2026-07-26 09:44:00"},
-                              {"id":1,"sender_id":4471,"receiver_id":9,"sender_name":"iwil",
-                               "content":"改名的事我问过管理","created_at":"2026-07-26 09:41:00"},
-                              {"id":3,"sender_id":7,"receiver_id":9,"sender_name":"demain",
-                               "content":"别的会话的消息","created_at":"2026-07-26 09:50:00"}
+                            {"success":true,
+                             "talkTo":{"member_id":5230,"member_name":"系统通知","rank":3},
+                             "msgArray":[
+                               {"id":7169823,"receiver_id":52425,"sender_id":5230,"viewed":1,
+                                "content":"您的帖子被投喂鸡腿","created_at":"2026-07-24T18:15:47.000Z",
+                                "is_markdown":1},
+                               {"id":7169651,"receiver_id":52425,"sender_id":5230,"viewed":1,
+                                "content":"您的评论被投喂鸡腿","created_at":"2026-07-24T17:46:45.000Z",
+                                "is_markdown":1},
+                               {"id":7196941,"receiver_id":5230,"sender_id":52425,"viewed":0,
+                                "content":"test","created_at":"2026-07-26T14:31:28.000Z","is_markdown":0}
                              ]}
                             """.trimIndent(),
                     ),
                 )
 
-            val thread = NetworkMessageRepository(api).thread(4471)
+            val thread = NetworkMessageRepository(api).thread(5230)
 
-            assertEquals("iwil", thread.userName)
-            // Another counterparty's message never leaks in; sorted oldest first whatever the wire order.
-            assertEquals(listOf("1", "2"), thread.messages.map(DirectMessage::id))
+            assertEquals("系统通知", thread.userName)
+            assertEquals(3, thread.level)
+            // Oldest first, whatever order the endpoint used.
+            assertEquals(listOf("7169651", "7169823", "7196941"), thread.messages.map(DirectMessage::id))
             assertFalse(thread.messages[0].isMine)
-            assertTrue(thread.messages[1].isMine)
+            assertTrue(thread.messages.last().isMine)
+            // Rendering follows the message's own flag, not the composer's switch.
+            assertTrue(thread.messages[0].isMarkdown)
+            assertFalse(thread.messages.last().isMarkdown)
         }
 
+    /** The recipient field is camel-cased here and nowhere else on this API. */
     @Test
-    fun `an updated timestamp marks a message as edited`() =
+    fun `send posts receiverUid`() =
         runTest {
             val api =
                 FakeJsonApi(
-                    mapOf(
-                        listPath to
-                            """
-                            {"msgArray":[{"id":1,"sender_id":4471,"content":"顶一下",
-                              "created_at":"2026-07-26 09:41:00","updated_at":"2026-07-26 09:52:00"}]}
-                            """.trimIndent(),
-                    ),
+                    posts = mapOf(NodeSeekJsonClient.PATH_MESSAGE_SEND to """{"success":true}"""),
                 )
 
-            assertTrue(NetworkMessageRepository(api).thread(4471).messages.single().isEdited)
-        }
+            NetworkMessageRepository(api).send(5230, "行", markdown = true)
 
-    @Test
-    fun `send returns the accepted message`() =
-        runTest {
-            val api =
-                FakeJsonApi(
-                    posts =
-                    mapOf(
-                        NodeSeekJsonClient.PATH_MESSAGE_SEND to
-                            """{"success":true,"data":{"id":7,"sender_id":9,"content":"行"}}""",
-                    ),
-                )
-
-            val sent = NetworkMessageRepository(api).send(4471, "行", markdown = true)
-
-            assertEquals("7", sent?.id)
-            assertTrue(sent!!.isMine)
-            assertTrue(api.postedBodies.single().contains("\"receiver_id\":4471"))
+            val body = api.postedBodies.single()
+            assertTrue(body, body.contains("\"receiverUid\":5230"))
+            assertTrue(body, body.contains("\"markdown\":true"))
         }
 
     @Test
@@ -163,6 +158,19 @@ class MessageRepositoryTest {
             assertEquals(NodeSeekError.Unknown, failure.error)
             assertEquals("对方已屏蔽你", failure.message)
         }
+
+    @Test
+    fun `mark all read hits the site's own all=true endpoint`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    posts = mapOf(NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED_ALL to """{"success":true}"""),
+                )
+
+            NetworkMessageRepository(api).markAllRead()
+
+            assertEquals(listOf(NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED_ALL), api.postedPaths)
+        }
 }
 
 private class FakeJsonApi(
@@ -170,11 +178,13 @@ private class FakeJsonApi(
     private val posts: Map<String, String> = emptyMap(),
 ) : JsonApi {
     val postedBodies = mutableListOf<String>()
+    val postedPaths = mutableListOf<String>()
 
     override suspend fun getJson(path: String, referer: String): String =
         requireNotNull(responses[path]) { "No response for $path" }
 
     override suspend fun postJson(path: String, body: String, referer: String): String {
+        postedPaths += path
         postedBodies += body
         return requireNotNull(posts[path]) { "No response for $path" }
     }

--- a/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/MessageRepositoryTest.kt
@@ -16,6 +16,17 @@ import org.junit.Test
  */
 class MessageRepositoryTest {
     private val listPath = NodeSeekJsonClient.messageListPath()
+
+    /** Most cases have several conversations, where the rows alone say which uid is ours. */
+    private fun repository(
+        api: JsonApi,
+        ownUid: Long? = null,
+        onAsked: () -> Unit = {},
+    ) = NetworkMessageRepository(api) {
+        onAsked()
+        ownUid
+    }
+
     private val threadPath = NodeSeekJsonClient.messageThreadPath(5230)
 
     /**
@@ -46,7 +57,7 @@ class MessageRepositoryTest {
                     ),
                 )
 
-            val conversations = NetworkMessageRepository(api).conversations()
+            val conversations = repository(api).conversations()
 
             assertEquals(3, conversations.size)
             assertEquals(conversations.size, conversations.distinctBy(MessageConversation::uid).size)
@@ -54,6 +65,66 @@ class MessageRepositoryTest {
             assertEquals("系统通知", conversations.first().userName)
             assertTrue(conversations.first().isSystem)
             assertEquals(listOf(5230L, 16874L, 51822L), conversations.map(MessageConversation::uid).sorted())
+        }
+
+    /**
+     * A brand-new account's inbox holds exactly one conversation — the system one — and both uids
+     * then occur equally often, so counting occurrences cannot say which is ours. Getting it
+     * backwards keys the row on our own uid, loses the name, and puts every incoming message on the
+     * right of the thread as though we had written it.
+     */
+    @Test
+    fun `a single-conversation inbox still identifies the counterparty`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    mapOf(
+                        listPath to
+                            """
+                            {"success":true,"msgArray":[
+                              {"receiver_id":52425,"sender_id":5230,"content":"您的评论被投喂鸡腿",
+                               "created_at":"2026-07-26T14:31:28.000Z","viewed":0,
+                               "sender_name":"系统通知","receiver_name":"林地雪原-0062"}
+                            ]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            val conversation =
+                repository(api, ownUid = 52425L).conversations().single()
+
+            assertEquals(5230L, conversation.uid)
+            assertEquals("系统通知", conversation.userName)
+            assertTrue(conversation.isSystem)
+            assertFalse(conversation.isSnippetMine)
+            assertEquals(1, conversation.unreadCount)
+        }
+
+    /** The uid lookup is only worth a request when the rows cannot answer on their own. */
+    @Test
+    fun `several conversations identify us without asking who we are`() =
+        runTest {
+            var asked = 0
+            val api =
+                FakeJsonApi(
+                    mapOf(
+                        listPath to
+                            """
+                            {"msgArray":[
+                              {"receiver_id":16874,"sender_id":52425,"content":"我发的",
+                               "created_at":"2026-07-24T16:24:20.000Z","viewed":1},
+                              {"receiver_id":52425,"sender_id":51822,"content":"他发的",
+                               "created_at":"2026-05-13T14:21:19.000Z","viewed":1}
+                            ]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            val conversations =
+                repository(api, onAsked = { asked++ }).conversations()
+
+            assertEquals(0, asked)
+            assertEquals(listOf(16874L, 51822L), conversations.map(MessageConversation::uid).sorted())
         }
 
     @Test
@@ -76,7 +147,7 @@ class MessageRepositoryTest {
                     ),
                 )
 
-            val conversations = NetworkMessageRepository(api).conversations().associateBy { it.userName }
+            val conversations = repository(api).conversations().associateBy { it.userName }
 
             assertTrue(conversations.getValue("adang").isSnippetMine)
             assertFalse(conversations.getValue("ZcZiXs").isSnippetMine)
@@ -110,7 +181,7 @@ class MessageRepositoryTest {
                     ),
                 )
 
-            val thread = NetworkMessageRepository(api).thread(5230)
+            val thread = repository(api).thread(5230)
 
             assertEquals("系统通知", thread.userName)
             assertEquals(3, thread.level)
@@ -132,7 +203,7 @@ class MessageRepositoryTest {
                     posts = mapOf(NodeSeekJsonClient.PATH_MESSAGE_SEND to """{"success":true}"""),
                 )
 
-            NetworkMessageRepository(api).send(5230, "行", markdown = true)
+            repository(api).send(5230, "行", markdown = true)
 
             val body = api.postedBodies.single()
             assertTrue(body, body.contains("\"receiverUid\":5230"))
@@ -152,7 +223,7 @@ class MessageRepositoryTest {
                 )
 
             val failure =
-                runCatching { NetworkMessageRepository(api).send(4471, "在吗", markdown = false) }
+                runCatching { repository(api).send(4471, "在吗", markdown = false) }
                     .exceptionOrNull() as NodeSeekException
 
             assertEquals(NodeSeekError.Unknown, failure.error)
@@ -167,7 +238,7 @@ class MessageRepositoryTest {
                     posts = mapOf(NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED_ALL to """{"success":true}"""),
                 )
 
-            NetworkMessageRepository(api).markAllRead()
+            repository(api).markAllRead()
 
             assertEquals(listOf(NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED_ALL), api.postedPaths)
         }

--- a/app/src/test/java/io/github/nsreader/data/NotificationRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/NotificationRepositoryTest.kt
@@ -51,6 +51,42 @@ class NotificationRepositoryTest {
             assertTrue(item.isUnread)
         }
 
+    /** §1.5: 私信 is a conversation list, so it has no notification endpoint of its own. */
+    @Test
+    fun `the message group has no notification rows`() =
+        runTest {
+            val items =
+                NotificationRepository(FakeJsonSource(emptyMap()))
+                    .notifications(NotificationCategory.MESSAGES)
+
+            assertTrue(items.isEmpty())
+        }
+
+    @Test
+    fun `keeps both the parsed instant and the server wording`() =
+        runTest {
+            val path = "/api/notification/at-me/list?page=1"
+            val source =
+                FakeJsonSource(
+                    mapOf(
+                        path to
+                            """
+                            {"atList":[{"id":1,"member_id":12,"username":"nssk",
+                              "post_title":"求教如何改用户名","created_at":"2026-07-26 09:56:03"}]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            val item = NotificationRepository(source).notifications(NotificationCategory.MENTIONS).single()
+
+            assertEquals("2026-07-26 09:56:03", item.createdAtText)
+            assertEquals(
+                io.github.nsreader.core.TimeFormat.parseTimestamp("2026-07-26 09:56:03"),
+                item.createdAtMillis,
+            )
+            assertEquals("https://www.nodeseek.com/avatar/12.png", item.avatarUrl)
+        }
+
     @Test
     fun `viewed notification is not unread`() =
         runTest {

--- a/app/src/test/java/io/github/nsreader/data/NotificationRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/NotificationRepositoryTest.kt
@@ -1,6 +1,6 @@
 package io.github.nsreader.data
 
-import io.github.nsreader.core.net.JsonSource
+import io.github.nsreader.core.net.JsonApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -87,6 +87,17 @@ class NotificationRepositoryTest {
             assertEquals("https://www.nodeseek.com/avatar/12.png", item.avatarUrl)
         }
 
+    /** 全部已读 used to be local-only, so the badge came back on the next refresh. */
+    @Test
+    fun `mark all read posts to the group's own endpoint`() =
+        runTest {
+            val source = FakeJsonSource(emptyMap())
+
+            NotificationRepository(source).markAllRead(NotificationCategory.MENTIONS)
+
+            assertEquals(listOf("/api/notification/at-me/markViewed?all=true"), source.postedPaths)
+        }
+
     @Test
     fun `viewed notification is not unread`() =
         runTest {
@@ -101,7 +112,14 @@ class NotificationRepositoryTest {
 
 private class FakeJsonSource(
     private val responses: Map<String, String>,
-) : JsonSource {
+) : JsonApi {
+    val postedPaths = mutableListOf<String>()
+
     override suspend fun getJson(path: String, referer: String): String =
         requireNotNull(responses[path]) { "No response for $path" }
+
+    override suspend fun postJson(path: String, body: String, referer: String): String {
+        postedPaths += path
+        return """{"success":true}"""
+    }
 }

--- a/app/src/test/java/io/github/nsreader/ui/messages/MessageThreadViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/messages/MessageThreadViewModelTest.kt
@@ -142,6 +142,8 @@ private class FakeMessageRepository(
 
     override suspend fun conversations() = emptyList<io.github.nsreader.data.MessageConversation>()
 
+    override suspend fun markAllRead() = Unit
+
     override suspend fun thread(uid: Long) =
         MessageThread(
             uid = uid,
@@ -154,9 +156,9 @@ private class FakeMessageRepository(
                     id = "1",
                     isMine = false,
                     content = "改名的事我问过管理",
+                    isMarkdown = true,
                     sentAtMillis = 1_784_999_000_000L,
                     sentAtText = null,
-                    isEdited = false,
                 ),
             ),
         )
@@ -173,9 +175,9 @@ private class FakeMessageRepository(
             id = "sent-$sendCount",
             isMine = true,
             content = content,
+            isMarkdown = markdown,
             sentAtMillis = 1_785_000_000_000L,
             sentAtText = null,
-            isEdited = false,
         )
     }
 }

--- a/app/src/test/java/io/github/nsreader/ui/messages/MessageThreadViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/messages/MessageThreadViewModelTest.kt
@@ -1,0 +1,181 @@
+package io.github.nsreader.ui.messages
+
+import android.webkit.CookieManager
+import io.github.nsreader.core.AppClock
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.net.WebViewCookieJar
+import io.github.nsreader.data.DirectMessage
+import io.github.nsreader.data.MessageRepository
+import io.github.nsreader.data.MessageThread
+import io.github.nsreader.data.session.SessionRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class MessageThreadViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val cookieManager = CookieManager.getInstance()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        cookieManager.removeAllCookies(null)
+        cookieManager.setCookie(NodeSeekSite.BASE_URL, "session=test")
+    }
+
+    @After
+    fun tearDown() {
+        cookieManager.removeAllCookies(null)
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a sent message appears immediately and settles once accepted`() =
+        runTest(dispatcher) {
+            val repository = FakeMessageRepository()
+            val viewModel = viewModel(repository)
+            advanceUntilIdle()
+
+            viewModel.updateDraft("行，我发个投票试试")
+            viewModel.send()
+
+            // The bubble is on screen before the network answers, and the field is already clear.
+            assertEquals(SendStatus.SENDING, viewModel.uiState.value.messages.last().status)
+            assertEquals("", viewModel.uiState.value.draft)
+
+            advanceUntilIdle()
+            assertEquals(SendStatus.SENT, viewModel.uiState.value.messages.last().status)
+        }
+
+    @Test
+    fun `a failed send keeps the text and can be retried`() =
+        runTest(dispatcher) {
+            val repository = FakeMessageRepository(sendError = NodeSeekException(NodeSeekError.Network))
+            val viewModel = viewModel(repository)
+            advanceUntilIdle()
+
+            viewModel.updateDraft("顺便问下星辰能转账吗")
+            viewModel.send()
+            advanceUntilIdle()
+
+            val failed = viewModel.uiState.value.messages.last()
+            assertEquals(SendStatus.FAILED, failed.status)
+            assertEquals("顺便问下星辰能转账吗", failed.content)
+
+            repository.sendError = null
+            viewModel.retry(failed.id)
+            advanceUntilIdle()
+
+            assertEquals(SendStatus.SENT, viewModel.uiState.value.messages.last().status)
+            assertEquals(2, repository.sendCount)
+        }
+
+    /** A refresh mid-flight must not drop the bubble the user is still waiting on. */
+    @Test
+    fun `reloading the thread keeps a message that has not been delivered`() =
+        runTest(dispatcher) {
+            val repository = FakeMessageRepository(sendError = NodeSeekException(NodeSeekError.Network))
+            val viewModel = viewModel(repository)
+            advanceUntilIdle()
+
+            viewModel.updateDraft("在吗")
+            viewModel.send()
+            advanceUntilIdle()
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            val messages = viewModel.uiState.value.messages
+            assertEquals(2, messages.size)
+            assertTrue(messages.any { it.status == SendStatus.FAILED && it.content == "在吗" })
+        }
+
+    @Test
+    fun `the markdown switch travels with the send`() =
+        runTest(dispatcher) {
+            val repository = FakeMessageRepository()
+            val viewModel = viewModel(repository)
+            advanceUntilIdle()
+
+            viewModel.toggleMarkdown()
+            viewModel.updateDraft("**不要加粗**")
+            viewModel.send()
+            advanceUntilIdle()
+
+            assertEquals(false, repository.lastMarkdown)
+        }
+
+    private fun viewModel(repository: MessageRepository) =
+        MessageThreadViewModel(
+            repository = repository,
+            session = SessionRepository(WebViewCookieJar(cookieManager)),
+            clock = AppClock { NOW },
+            uid = 4471,
+            userName = "iwil",
+        )
+
+    private companion object {
+        const val NOW = 1_785_000_000_000L
+    }
+}
+
+private class FakeMessageRepository(
+    var sendError: Throwable? = null,
+) : MessageRepository {
+    var sendCount = 0
+    var lastMarkdown: Boolean? = null
+
+    override suspend fun conversations() = emptyList<io.github.nsreader.data.MessageConversation>()
+
+    override suspend fun thread(uid: Long) =
+        MessageThread(
+            uid = uid,
+            userName = "iwil",
+            avatarUrl = null,
+            level = 4,
+            messages =
+            listOf(
+                DirectMessage(
+                    id = "1",
+                    isMine = false,
+                    content = "改名的事我问过管理",
+                    sentAtMillis = 1_784_999_000_000L,
+                    sentAtText = null,
+                    isEdited = false,
+                ),
+            ),
+        )
+
+    override suspend fun send(
+        uid: Long,
+        content: String,
+        markdown: Boolean,
+    ): DirectMessage? {
+        sendCount++
+        lastMarkdown = markdown
+        sendError?.let { throw it }
+        return DirectMessage(
+            id = "sent-$sendCount",
+            isMine = true,
+            content = content,
+            sentAtMillis = 1_785_000_000_000L,
+            sentAtText = null,
+            isEdited = false,
+        )
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/messages/ThreadRowsTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/messages/ThreadRowsTest.kt
@@ -1,0 +1,59 @@
+package io.github.nsreader.ui.messages
+
+import io.github.nsreader.core.TimeFormat
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThreadRowsTest {
+    private val now = TimeFormat.parseTimestamp("2026-07-26 10:22:03")!!
+
+    /**
+     * Regression for a thread that opened part-scrolled: the separators are list items too, so the
+     * last message sits at `rows.lastIndex`, several positions past `messages.lastIndex`.
+     */
+    @Test
+    fun `a separator per day means more rows than messages`() {
+        val rows =
+            threadRows(
+                listOf(
+                    bubble("1", daysAgo = 2),
+                    bubble("2", daysAgo = 1),
+                    bubble("3", daysAgo = 0),
+                ),
+                now,
+            )
+
+        assertEquals(6, rows.size)
+        assertEquals(ThreadRow.Bubble::class, rows.last()::class)
+        assertEquals("3", (rows.last() as ThreadRow.Bubble).message.id)
+    }
+
+    @Test
+    fun `messages sharing a day share one separator`() {
+        val rows = threadRows(List(4) { bubble(it.toString(), daysAgo = 0) }, now)
+
+        assertEquals(1, rows.count { it is ThreadRow.Day })
+        assertEquals(5, rows.size)
+    }
+
+    /** A message the server sent no timestamp for cannot open a day, and must not be dropped. */
+    @Test
+    fun `an undated message still gets a row`() {
+        val rows = threadRows(listOf(bubble("1", daysAgo = null)), now)
+
+        assertEquals(listOf<Any>(ThreadRow.Bubble::class), rows.map { it::class })
+    }
+
+    private fun bubble(
+        id: String,
+        daysAgo: Int?,
+    ) = MessageBubble(
+        id = id,
+        isMine = false,
+        content = "内容 $id",
+        isMarkdown = true,
+        sentAtMillis = daysAgo?.let { now - it * 24L * 60 * 60 * 1000 },
+        sentAtText = null,
+        status = SendStatus.SENT,
+    )
+}

--- a/app/src/test/java/io/github/nsreader/ui/notifications/NotificationsScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/notifications/NotificationsScreenTest.kt
@@ -1,0 +1,161 @@
+package io.github.nsreader.ui.notifications
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.github.nsreader.data.ForumNotification
+import io.github.nsreader.data.MessageConversation
+import io.github.nsreader.data.NotificationCategory
+import io.github.nsreader.data.NotificationCounts
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class NotificationsScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    /** Board 7d: three groups, and no 「系统」 — the site has never had one. */
+    @Test
+    fun `offers exactly the three groups the site has`() {
+        setContent(state(items = listOf(mention())))
+
+        composeRule.onNodeWithText("@我").assertIsDisplayed()
+        composeRule.onNodeWithText("回复主题").assertIsDisplayed()
+        composeRule.onNodeWithText("私信").assertIsDisplayed()
+        assertEquals(0, composeRule.onAllNodesWithText("系统").fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun `renders the mention sentence and both halves of the timestamp`() {
+        setContent(state(items = listOf(mention())))
+
+        composeRule.onNodeWithText("nssk 在帖子 求教如何改用户名 中@了我").assertIsDisplayed()
+        composeRule.onNodeWithText("26 分钟前 · 2026/7/26 09:56:03", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `an unread conversation counts towards mark all read`() {
+        var markedAllRead = false
+        composeRule.setContent {
+            NodeSeekTheme {
+                NotificationsScreen(
+                    state =
+                    state(
+                        category = NotificationCategory.MESSAGES,
+                        conversations = listOf(systemConversation()),
+                    ),
+                    onSignIn = {},
+                    onVerify = {},
+                    onCategoryChange = {},
+                    onRetry = {},
+                    onMarkAllRead = { markedAllRead = true },
+                    onNotificationClick = {},
+                    onConversationClick = {},
+                    onNewConversation = {},
+                    onNewConversationQueryChange = {},
+                    onNewConversationSearch = {},
+                    onNewConversationDismiss = {},
+                    onRecipientClick = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("全部已读").performClick()
+
+        assertEquals(true, markedAllRead)
+    }
+
+    /** Board 7e: the pinned system conversation shows its Markdown as text, never as syntax. */
+    @Test
+    fun `system conversation snippet drops its markdown syntax`() {
+        setContent(
+            state(
+                category = NotificationCategory.MESSAGES,
+                conversations = listOf(systemConversation()),
+            ),
+        )
+
+        composeRule.onNodeWithText("系统通知").assertIsDisplayed()
+        composeRule.onNodeWithText("您的评论被用户iwil投喂鸡腿").assertIsDisplayed()
+    }
+
+    private fun setContent(state: NotificationsUiState) {
+        composeRule.setContent {
+            NodeSeekTheme {
+                NotificationsScreen(
+                    state = state,
+                    onSignIn = {},
+                    onVerify = {},
+                    onCategoryChange = {},
+                    onRetry = {},
+                    onMarkAllRead = {},
+                    onNotificationClick = {},
+                    onConversationClick = {},
+                    onNewConversation = {},
+                    onNewConversationQueryChange = {},
+                    onNewConversationSearch = {},
+                    onNewConversationDismiss = {},
+                    onRecipientClick = {},
+                )
+            }
+        }
+    }
+
+    private fun state(
+        category: NotificationCategory = NotificationCategory.MENTIONS,
+        items: List<ForumNotification> = emptyList(),
+        conversations: List<MessageConversation> = emptyList(),
+    ) = NotificationsUiState(
+        isSignedIn = true,
+        selectedCategory = category,
+        counts = NotificationCounts(replies = 5, mentions = 2, messages = 3),
+        items = items,
+        conversations = conversations,
+        nowMillis = NOW,
+    )
+
+    private fun mention() =
+        ForumNotification(
+            id = "1",
+            category = NotificationCategory.MENTIONS,
+            postId = 1,
+            floor = null,
+            actorUid = 12,
+            actorName = "nssk",
+            avatarUrl = null,
+            excerpt = null,
+            threadTitle = "求教如何改用户名",
+            createdAtMillis = NOW - 26 * 60_000L,
+            createdAtText = null,
+            isUnread = true,
+        )
+
+    private fun systemConversation() =
+        MessageConversation(
+            uid = 1,
+            userName = MessageConversation.SYSTEM_NAME,
+            avatarUrl = null,
+            snippet = "您的[评论](/post-1-1)被用户[iwil](/space/4471)投喂鸡腿",
+            isSnippetMine = false,
+            updatedAtMillis = NOW - 70 * 60_000L,
+            updatedAtText = null,
+            unreadCount = 1,
+            isSystem = true,
+        )
+
+    private companion object {
+        /** 2026-07-26 10:22:03 in the JVM default zone the test runs in. */
+        val NOW = io.github.nsreader.core.TimeFormat.parseTimestamp("2026-07-26 10:22:03")!!
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/notifications/NotificationsScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/notifications/NotificationsScreenTest.kt
@@ -76,6 +76,34 @@ class NotificationsScreenTest {
         assertEquals(true, markedAllRead)
     }
 
+    /**
+     * The stamps form a column, so every row's must end at the same x. They drifted when the name
+     * and a spacer both carried weight and split the slack between them.
+     */
+    @Test
+    fun `conversation stamps share one right edge`() {
+        setContent(
+            state(
+                category = NotificationCategory.MESSAGES,
+                conversations =
+                listOf(
+                    systemConversation(),
+                    conversation(uid = 2, name = "a", stamp = NOW - 26 * 60 * 60_000L),
+                    conversation(uid = 3, name = "一个很长的用户名字", stamp = NOW - 40L * 24 * 60 * 60_000L),
+                ),
+            ),
+        )
+
+        // The row is clickable, so its semantics are merged: asking the merged tree for a stamp
+        // hands back the whole row, whose width is the screen's and always matches.
+        val rightEdges =
+            listOf("09:12", "昨天", "6月16日")
+                .map { composeRule.onNodeWithText(it, useUnmergedTree = true).fetchSemanticsNode() }
+                .map { it.positionInRoot.x + it.size.width }
+
+        rightEdges.forEach { assertEquals(rightEdges.first(), it, 1f) }
+    }
+
     /** Board 7e: the pinned system conversation shows its Markdown as text, never as syntax. */
     @Test
     fun `system conversation snippet drops its markdown syntax`() {
@@ -140,6 +168,22 @@ class NotificationsScreenTest {
             createdAtText = null,
             isUnread = true,
         )
+
+    private fun conversation(
+        uid: Long,
+        name: String,
+        stamp: Long,
+    ) = MessageConversation(
+        uid = uid,
+        userName = name,
+        avatarUrl = null,
+        snippet = "摘要",
+        isSnippetMine = false,
+        updatedAtMillis = stamp,
+        updatedAtText = null,
+        unreadCount = 0,
+        isSystem = false,
+    )
 
     private fun systemConversation() =
         MessageConversation(


### PR DESCRIPTION
落地设计稿 7d / 7e / 7f 三张画板。

## 问题

通知页按早期设计稿做了四个分组（回复我的 / @我的 / 私信 / 系统），但实测确认站点只有三组：`#/atMe`、`#/reply`、`#/message`。所谓「系统通知」其实是私信里一个置顶的会话账号，不是独立分组。私信本身此前完全没有实现——私信分段点进去是一串「给你发来私信」的空壳通知行，既打不开会话也发不了消息。

## 改了什么

**7D 通知 · 三分组**
- `NotificationCategory` 删掉 `SYSTEM`，顺序改为 @我 / 回复主题 / 私信
- 行文案不再由 data 层拼成一句话，改为 actor + 帖子标题两个字段，由 UI 用字符串模板组装 `AnnotatedString`。模板按占位符切分而非 `indexOf`，用户名恰好出现在帖子标题里时高亮不会错位
- 时间改成「26 分钟前 · 2026/7/26 09:56:03」两段式
- chip 计数用等宽数字而不是 `Badge`（默认的红胶囊和石墨青 chip 冲突）
- 「全部已读」接上真实端点。此前只在本地置灰，刷新后角标就回来了

**7E 私信列表**
- 私信分段渲染会话列表：系统通知置顶（primaryContainer 铃铛 + pin + Markdown 摘要，链接段走 primary 色）、未读计数、右下新建会话 FAB
- FAB 打开的选人 sheet 复用现有 `/api/account/find` 用户搜索。站点没有「新建会话」入口，画板上标注为「App 增强」

**7F 私信会话**
- 新增全屏会话页：日期分隔 chip、Markdown On/Off 开关、发送中 / 发送失败·重试
- 失败的气泡保留原文，刷新线程时不会被服务端列表冲掉
- 每条消息按自己的 `is_markdown` 渲染，输入框的开关只决定发送

**支撑改动**
- 新增 `core/TimeFormat`：解析 ISO / epoch 时间戳，输出相对时间、完整时间戳、会话列表时间和日期分隔标签。接口回的若是服务端已渲染的「5分钟前」，原样透传而不是编一个时间出来
- `JsonSource` 拆成读（`JsonSource`）/ 写（`JsonWriteSource`）两个接口，`JsonApi` 合并两者。只读的仓库拿不到 POST，六个只读测试替身一行没改

## 接口：从推断到实测

初版三个私信端点是照站点 hash 路由推断的。真机验证推翻了其中两个，于是把站点自己的 `notification.js` 通过 App 已认证的 OkHttp 拉下来读源码，现在**三个端点都来自站点自身的调用**：

| 端点 | 事实 |
|---|---|
| `message/list` | **每个会话一行**，只带最新一条消息。初版当成「逐条消息平铺」，据此把会话页做成列表切片，结果每个对话只显示一条 |
| `message/with/{uid}` | 真正的会话历史，另带 `talkTo` 头（昵称 / 等级）。此前推断的 `message/talk/{uid}` 不存在，404 |
| `message/send` | 收件人字段是驼峰 `receiverUid`，而这个 API 其它字段全是 snake_case。初版写的 `receiver_id` 发不出去 |

另外发现每条消息自带 `is_markdown`，以及三个分组各有自己的 `markViewed?all=true`。

解析仍走多字段名探测（与 `NotificationRepository` 一致），字段改名只丢一个字段而不是整页失败；会话页顶栏保留「在网页中打开」兜底。

## Reviewer 需要知道的

**「我是谁」是推断出来的。** 会话行只给 `sender_id` / `receiver_id`，不标注哪个是对方。取各行两端的**交集**——我方必在每一行，对方不可能——两个会话以上即可确定。只有一个会话时天然无解（新账号只有系统通知会话就是这种情况，且系统账号永远是发送方，会稳定认错），此时查一次真实 uid 兜底，查不到再退到发送方。这是本 PR 唯一的结构性推断点，有针对性的回归测试。

其余注意点：
- `NotificationCounts.all` 由三组之和计算，不再读接口的 `all` 字段
- 列表只取第 1 页，超长收件箱会被截断（与现有通知列表行为一致），已在代码注释留痕
- `TimeFormat` 在 core 层硬编码中文；单语言应用下无害，KDoc 里写明了这个假设与将来本地化的代价
- 顺带对齐了两处既有不一致：`getJson` 的挑战判序（此前 403 + 挑战页会被当成 HTTP 错误）、`SearchRepository` 手拼头像 URL
- 无 Room schema、依赖锁、scraping selector 变更

## 验证

- `./gradlew spotlessCheck :app:lintDebug :app:testDebugUnitTest` 全绿，**204 项测试**
- 三层测试：Repository（会话折叠、方向推导、发送字段名、拒绝原因、markViewed 路径）、ViewModel（乐观发送、失败重试、刷新不丢未送达气泡）、Screen（三分组无「系统」、句子与时间戳、系统摘要不露 Markdown 语法、时间戳右对齐）
- **真机验证**：Galaxy S24（Android 15）+ Xperia 1（Android 10，21:9 窄屏）两台，7D/7E/7F 全部正常，无崩溃；用 App 成功发出私信并确认服务端收下

过程中真机发现并修复的缺陷：会话列表崩溃（`Key … was already used`）、会话页无历史、发送字段名错误、单会话收件箱认错自己、会话页打不到底、拒绝原因不显示、时间戳未右对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
