### PR TITLE
实现账号设置 8g 与二级页 d6

### DIFF
--- a/app/src/main/java/io/github/nsreader/Navigation.kt
+++ b/app/src/main/java/io/github/nsreader/Navigation.kt
@@ -248,8 +248,12 @@ fun MainNavigation(container: AppContainer) {
                         viewModel = viewModel,
                         onBack = { backStack.removeLastOrNull() },
                         // `otpauth://` belongs to whichever authenticator app registered for it, so it
-                        // leaves the app rather than being rendered here — the app never holds the secret.
-                        onOpenEnrolmentUri = { uri -> runCatching { uriHandler.openUri(uri) } },
+                        // leaves the app rather than being rendered here — the app never holds the
+                        // secret. Returns false when nothing claims the scheme, so the screen can say so
+                        // instead of appearing to do nothing.
+                        onOpenEnrolmentUri = { uri ->
+                            runCatching { uriHandler.openUri(uri) }.isSuccess
+                        },
                     )
                 }
 

--- a/app/src/main/java/io/github/nsreader/Navigation.kt
+++ b/app/src/main/java/io/github/nsreader/Navigation.kt
@@ -24,6 +24,16 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import io.github.nsreader.core.NodeSeekSite
 import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.account.AccountSettingsRoute
+import io.github.nsreader.ui.account.AccountSettingsViewModel
+import io.github.nsreader.ui.account.ContactBlockRoute
+import io.github.nsreader.ui.account.ContactBlockViewModel
+import io.github.nsreader.ui.account.HomeBoardsRoute
+import io.github.nsreader.ui.account.HomeBoardsViewModel
+import io.github.nsreader.ui.account.ProfileFieldsRoute
+import io.github.nsreader.ui.account.ProfileFieldsViewModel
+import io.github.nsreader.ui.account.SecurityRoute
+import io.github.nsreader.ui.account.SecurityViewModel
 import io.github.nsreader.ui.composer.PostComposerRoute
 import io.github.nsreader.ui.composer.PostComposerViewModel
 import io.github.nsreader.ui.login.WebViewGoal
@@ -191,10 +201,9 @@ fun MainNavigation(container: AppContainer) {
                         viewModel = viewModel,
                         onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
                         onSettings = { backStack.add(SettingsKey) },
+                        onAccountSettings = { backStack.add(AccountSettingsKey) },
                         onOpenWebsite = { openExternalUrl(NodeSeekSite.BASE_URL) },
-                        onEditProfile = { uid ->
-                            openExternalUrl(NodeSeekSite.BASE_URL + NodeSeekSite.spacePath(uid))
-                        },
+                        onEditProfile = { backStack.add(AccountProfileFieldsKey) },
                     )
                 }
 
@@ -202,6 +211,61 @@ fun MainNavigation(container: AppContainer) {
                     val viewModel: SettingsViewModel =
                         viewModel(factory = SettingsViewModel.factory(container))
                     SettingsRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                    )
+                }
+
+                entry<AccountSettingsKey> {
+                    val viewModel: AccountSettingsViewModel =
+                        viewModel(factory = AccountSettingsViewModel.factory(container))
+                    AccountSettingsRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onOpenProfileFields = { backStack.add(AccountProfileFieldsKey) },
+                        onOpenSecurity = { backStack.add(AccountSecurityKey) },
+                        onOpenContactAndBlock = { backStack.add(AccountContactBlockKey) },
+                        // 常用偏好 is this app's own settings screen rather than a copy of it: the site's
+                        // `#preference` group covers the website's layout, which the app does not render.
+                        onOpenDisplayPreferences = { backStack.add(SettingsKey) },
+                        onOpenHomeBoards = { backStack.add(HomeBoardsKey) },
+                    )
+                }
+
+                entry<AccountProfileFieldsKey> {
+                    val viewModel: ProfileFieldsViewModel =
+                        viewModel(factory = ProfileFieldsViewModel.factory(container))
+                    ProfileFieldsRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                    )
+                }
+
+                entry<AccountSecurityKey> {
+                    val viewModel: SecurityViewModel =
+                        viewModel(factory = SecurityViewModel.factory(container))
+                    SecurityRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        // `otpauth://` belongs to whichever authenticator app registered for it, so it
+                        // leaves the app rather than being rendered here — the app never holds the secret.
+                        onOpenEnrolmentUri = { uri -> runCatching { uriHandler.openUri(uri) } },
+                    )
+                }
+
+                entry<AccountContactBlockKey> {
+                    val viewModel: ContactBlockViewModel =
+                        viewModel(factory = ContactBlockViewModel.factory(container))
+                    ContactBlockRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                    )
+                }
+
+                entry<HomeBoardsKey> {
+                    val viewModel: HomeBoardsViewModel =
+                        viewModel(factory = HomeBoardsViewModel.factory(container))
+                    HomeBoardsRoute(
                         viewModel = viewModel,
                         onBack = { backStack.removeLastOrNull() },
                     )

--- a/app/src/main/java/io/github/nsreader/NavigationKeys.kt
+++ b/app/src/main/java/io/github/nsreader/NavigationKeys.kt
@@ -20,6 +20,28 @@ data object ProfileKey : NavKey
 @Serializable
 data object SettingsKey : NavKey
 
+/**
+ * 账号设置 (8g) and its four sub-pages (d6).
+ *
+ * Separate from [SettingsKey], which is the app's own display preferences. The two are different
+ * things that happen to share a word: one is what the site knows about the account, the other is how
+ * this app draws it. 8g's 常用偏好 row is the link between them.
+ */
+@Serializable
+data object AccountSettingsKey : NavKey
+
+@Serializable
+data object AccountProfileFieldsKey : NavKey
+
+@Serializable
+data object AccountSecurityKey : NavKey
+
+@Serializable
+data object AccountContactBlockKey : NavKey
+
+@Serializable
+data object HomeBoardsKey : NavKey
+
 @Serializable
 data object PostComposerKey : NavKey
 

--- a/app/src/main/java/io/github/nsreader/data/account/AccountSettingsRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/account/AccountSettingsRepository.kt
@@ -1,0 +1,151 @@
+package io.github.nsreader.data.account
+
+/** 个人信息 · `/setting#introduction`. Every field is Markdown except [bio], which is one plain line. */
+data class AccountProfileFields(
+    val bio: String = "",
+    val signature: String = "",
+    val readme: String = "",
+)
+
+/** 联系方式 · `/setting#contact`. The backup address is optional and starts out unverified. */
+data class AccountContact(
+    val email: String = "",
+    val emailVerified: Boolean = false,
+    val backupEmail: String = "",
+    val backupEmailVerified: Boolean = false,
+)
+
+/** 双因素验证 · `/setting#2fa`. TOTP is the only second factor the site offers. */
+data class TwoFactorState(
+    val enabled: Boolean = false,
+)
+
+/** 屏蔽用户 · `/setting#block`. */
+data class BlockedUser(
+    val uid: Long,
+    val name: String,
+    val avatarUrl: String? = null,
+)
+
+/** An avatar chosen on the device, already downscaled by the picker. */
+data class AvatarUpload(
+    val bytes: ByteArray,
+    val mimeType: String,
+) {
+    // Data classes compare arrays by identity, which would make two reads of the same image unequal
+    // and defeat any `distinctUntilChanged` this ever passes through.
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (other is AvatarUpload && mimeType == other.mimeType && bytes.contentEquals(other.bytes))
+
+    override fun hashCode(): Int = 31 * bytes.contentHashCode() + mimeType.hashCode()
+}
+
+/**
+ * The seven groups of NodeSeek's own `/setting` page.
+ *
+ * Split out from [io.github.nsreader.data.ProfileRepository] because the two answer different
+ * questions: that one reads the account the *forum* shows (name, avatar, chicken legs) and every
+ * screen in the app uses it, while this one is the read/write surface for the settings page and is
+ * touched by five screens only.
+ *
+ * 常用偏好 (`#preference`) and 首页版块 (`#homepage`) are deliberately absent. Both are presentation
+ * choices the app already owns locally — see [io.github.nsreader.data.settings.SettingsRepository] —
+ * and round-tripping them through the site would make the app's own settings screen lie whenever the
+ * network was down.
+ */
+interface AccountSettingsRepository {
+    suspend fun profileFields(): AccountProfileFields
+
+    suspend fun saveProfileFields(fields: AccountProfileFields)
+
+    suspend fun uploadAvatar(upload: AvatarUpload)
+
+    suspend fun removeAvatar()
+
+    suspend fun changePassword(currentPassword: String, newPassword: String)
+
+    suspend fun twoFactor(): TwoFactorState
+
+    /** Starts TOTP enrolment; returns the `otpauth://` URI the authenticator app scans. */
+    suspend fun beginTwoFactorEnrolment(): String
+
+    suspend fun contact(): AccountContact
+
+    suspend fun saveContact(email: String, backupEmail: String)
+
+    suspend fun resendVerification(email: String)
+
+    suspend fun blockedUsers(): List<BlockedUser>
+
+    suspend fun unblock(uid: Long)
+}
+
+/**
+ * Thrown for every operation whose NodeSeek endpoint has not been observed yet.
+ *
+ * NodeSeek has no public API and `/setting` is a client-rendered page whose writes go out as XHRs, so
+ * the request shapes cannot be read off the HTML the way the list and detail parsers were written.
+ * They have to be captured from a signed-in session on a device — this sandbox gets a Cloudflare 403
+ * for anything authenticated.
+ *
+ * Guessing was the alternative and was rejected: `/api/account/…` is plausible enough that a wrong
+ * guess would most likely return a cheerful `{"success":false}` that reads as "saved" to a caller
+ * that only checks for exceptions, and the operations here include changing a password and an email
+ * address — the two places where silently doing nothing, or silently doing the wrong thing, costs the
+ * user their account.
+ *
+ * Filling this in is one file's work. The probe checklist is in the KDoc of each
+ * [NetworkAccountSettingsRepository] member.
+ */
+class EndpointNotVerifiedException(
+    val operation: String,
+) : Exception("NodeSeek endpoint for `$operation` has not been verified yet")
+
+/**
+ * The real implementation, pending endpoint capture.
+ *
+ * Every member documents what to look for in the network log of a signed-in `/setting` session, so
+ * the person holding the device does not have to re-derive the list. Replace a `notVerified` call
+ * with the request as soon as its shape is known; the screens need no change, and the pending banner
+ * they show is driven by this exception, so it disappears on its own.
+ */
+class NetworkAccountSettingsRepository : AccountSettingsRepository {
+
+    /** Probe: open `/setting#introduction` — the page must GET bio/signature/readme from somewhere. */
+    override suspend fun profileFields(): AccountProfileFields = notVerified("profileFields")
+
+    /** Probe: edit Bio and press save; expect one POST carrying all three fields. */
+    override suspend fun saveProfileFields(fields: AccountProfileFields): Unit =
+        notVerified("saveProfileFields")
+
+    /** Probe: upload an avatar; expect `multipart/form-data`. Note the field name and any size cap. */
+    override suspend fun uploadAvatar(upload: AvatarUpload): Unit = notVerified("uploadAvatar")
+
+    override suspend fun removeAvatar(): Unit = notVerified("removeAvatar")
+
+    /** Probe: `/setting#security`. Watch for a 2FA code field appearing once TOTP is bound. */
+    override suspend fun changePassword(currentPassword: String, newPassword: String): Unit =
+        notVerified("changePassword")
+
+    /** Probe: `/setting#2fa` on load. */
+    override suspend fun twoFactor(): TwoFactorState = notVerified("twoFactor")
+
+    /** Probe: press 绑定验证器; the response should carry the secret or a full `otpauth://` URI. */
+    override suspend fun beginTwoFactorEnrolment(): String = notVerified("beginTwoFactorEnrolment")
+
+    /** Probe: `/setting#contact` on load; note how the verified flag is spelled. */
+    override suspend fun contact(): AccountContact = notVerified("contact")
+
+    override suspend fun saveContact(email: String, backupEmail: String): Unit =
+        notVerified("saveContact")
+
+    override suspend fun resendVerification(email: String): Unit = notVerified("resendVerification")
+
+    /** Probe: `/setting#block` on load; check whether it pages once the list is long. */
+    override suspend fun blockedUsers(): List<BlockedUser> = notVerified("blockedUsers")
+
+    override suspend fun unblock(uid: Long): Unit = notVerified("unblock")
+
+    private fun notVerified(operation: String): Nothing = throw EndpointNotVerifiedException(operation)
+}

--- a/app/src/main/java/io/github/nsreader/data/settings/HomeBoards.kt
+++ b/app/src/main/java/io/github/nsreader/data/settings/HomeBoards.kt
@@ -1,0 +1,20 @@
+package io.github.nsreader.data.settings
+
+import io.github.nsreader.data.Board
+
+/**
+ * Narrows a board list to the user's home-strip preference.
+ *
+ * Lives beside the preference it interprets rather than next to the screen that edits it: the home
+ * feed applies this on every emission and has nothing else to do with 账号设置, and a UI package
+ * importing another UI package is the first edge that has to be cut when features become modules.
+ *
+ * Callers pass only the real boards — 综合 is not one, has no slug, and is prepended by whoever draws
+ * the strip. An empty preference means unrestricted. A preference that no longer matches anything, as
+ * happens when every chosen board is renamed server-side, also falls back to unrestricted rather than
+ * to nothing: an empty strip is indistinguishable from a broken one.
+ */
+fun visibleHomeBoards(boards: List<Board>, preference: Set<String>): List<Board> {
+    if (preference.isEmpty()) return boards
+    return boards.filter { it.slug in preference }.ifEmpty { boards }
+}

--- a/app/src/main/java/io/github/nsreader/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/settings/SettingsRepository.kt
@@ -42,6 +42,7 @@ class SettingsRepository(
                 imagesOnWifiOnly = preferences[KEY_IMAGES_WIFI_ONLY] ?: false,
                 searchHistory = decodeSearchHistory(preferences),
                 recentBoards = decodeValues(preferences[KEY_RECENT_BOARDS]),
+                homeBoards = decodeValues(preferences[KEY_HOME_BOARDS]).toSet(),
             )
         }
 
@@ -90,6 +91,18 @@ class SettingsRepository(
         }
     }
 
+    /**
+     * Which boards the home strip shows. An empty set means "all of them" and is the default.
+     *
+     * Empty rather than a snapshot of every slug on first run, because the board list is owned by the
+     * server: seeding the preference would silently pin the user to whatever thirteen boards existed
+     * the day they installed the app, and a board added later would never show up.
+     */
+    suspend fun setHomeBoards(slugs: Set<String>) =
+        edit { it[KEY_HOME_BOARDS] = encodeValues(slugs.toList(), MAX_HOME_BOARDS) }
+
+    suspend fun clearHomeBoards() = edit { it.remove(KEY_HOME_BOARDS) }
+
     suspend fun recordRecentBoards(boards: Set<String>) {
         if (boards.isEmpty()) return
         dataStore.edit { preferences ->
@@ -116,10 +129,14 @@ class SettingsRepository(
         private val KEY_RECENT_SEARCHES = stringPreferencesKey("recent_searches")
         private val KEY_SEARCH_HISTORY = stringPreferencesKey("search_history_v3")
         private val KEY_RECENT_BOARDS = stringPreferencesKey("recent_boards")
+        private val KEY_HOME_BOARDS = stringPreferencesKey("home_boards")
 
         private const val RECENT_SEARCH_SEPARATOR = '\u001F'
         private const val MAX_RECENT_SEARCHES = 8
         private const val MAX_RECENT_BOARDS = 6
+
+        /** Generous ceiling on a list the server currently caps at thirteen; a runaway guard, not a rule. */
+        private const val MAX_HOME_BOARDS = 64
 
         private fun decodeRecentSearches(value: String?): List<String> =
             value.orEmpty().split(RECENT_SEARCH_SEPARATOR).filter(String::isNotBlank)
@@ -160,6 +177,8 @@ data class UserSettings(
     val imagesOnWifiOnly: Boolean = false,
     val searchHistory: List<SearchHistoryEntry> = emptyList(),
     val recentBoards: List<String> = emptyList(),
+    /** Slugs the home strip is limited to. Empty means unrestricted — see `setHomeBoards`. */
+    val homeBoards: Set<String> = emptySet(),
 )
 
 enum class ThemeMode { SYSTEM, LIGHT, DARK }

--- a/app/src/main/java/io/github/nsreader/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nsreader/di/AppContainer.kt
@@ -21,6 +21,8 @@ import io.github.nsreader.data.OfflineFirstPostRepository
 import io.github.nsreader.data.PostRepository
 import io.github.nsreader.data.ProfileRepository
 import io.github.nsreader.data.SearchRepository
+import io.github.nsreader.data.account.AccountSettingsRepository
+import io.github.nsreader.data.account.NetworkAccountSettingsRepository
 import io.github.nsreader.data.composer.DefaultPostComposerRepository
 import io.github.nsreader.data.composer.PostComposerRepository
 import io.github.nsreader.data.local.NodeSeekDatabase
@@ -50,6 +52,7 @@ interface AppContainer {
     val profileRepository: ProfileRepository
     val searchRepository: SearchRepository
     val postComposerRepository: PostComposerRepository
+    val accountSettingsRepository: AccountSettingsRepository
     val sessionRepository: SessionRepository
 
     /**
@@ -130,6 +133,10 @@ class DefaultAppContainer(
 
     override val postComposerRepository: PostComposerRepository by lazy {
         DefaultPostComposerRepository(appContext, okHttpClient, dispatchers, clock)
+    }
+
+    override val accountSettingsRepository: AccountSettingsRepository by lazy {
+        NetworkAccountSettingsRepository()
     }
 
     /**

--- a/app/src/main/java/io/github/nsreader/ui/account/AccountComponents.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/AccountComponents.kt
@@ -1,0 +1,203 @@
+package io.github.nsreader.ui.account
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.R
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.account.EndpointNotVerifiedException
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import io.github.nsreader.ui.theme.Spacing
+
+/** The radius every field, card and sheet on these screens rounds to. */
+internal val AccountFieldShape = RoundedCornerShape(14.dp)
+
+/**
+ * Something a sub-page needs to tell the user once, in a snackbar.
+ *
+ * [EndpointPending] carries a string resource rather than the repository's operation name: that name
+ * is a Kotlin identifier meant for whoever fills the endpoint in, and putting `saveProfileFields` in
+ * front of a reader is worse than saying nothing.
+ */
+sealed interface AccountMessage {
+    data class EndpointPending(@StringRes val labelRes: Int) : AccountMessage
+
+    data class Info(@StringRes val textRes: Int) : AccountMessage
+
+    data class Failure(val error: NodeSeekError) : AccountMessage
+}
+
+/** Turns a thrown load/save failure into either the pending seam or a real network error. */
+fun Throwable.toAccountMessage(@StringRes labelRes: Int): AccountMessage =
+    if (this is EndpointNotVerifiedException) {
+        AccountMessage.EndpointPending(labelRes)
+    } else {
+        AccountMessage.Failure(toNodeSeekError())
+    }
+
+@Composable
+internal fun accountMessageText(message: AccountMessage): String =
+    when (message) {
+        is AccountMessage.EndpointPending ->
+            stringResource(R.string.account_endpoint_pending_toast, stringResource(message.labelRes))
+
+        is AccountMessage.Info -> stringResource(message.textRes)
+
+        is AccountMessage.Failure -> stringResource(message.error.messageRes())
+    }
+
+@Composable
+private fun NodeSeekError.messageRes(): Int =
+    when (this) {
+        NodeSeekError.Cloudflare -> R.string.status_challenge_title
+        NodeSeekError.LoginRequired -> R.string.status_sign_in_title
+        NodeSeekError.Network -> R.string.status_network_title
+        NodeSeekError.Unparsable -> R.string.status_unparsable_title
+        is NodeSeekError.Http, NodeSeekError.Unknown -> R.string.status_unknown_title
+    }
+
+/**
+ * Says out loud that a group's site plumbing is not connected yet.
+ *
+ * A banner rather than an error state, because the screen is not broken — the layout, validation and
+ * confirmations all work and are worth showing. What does not work is the one request at the end, and
+ * the honest thing is to say so before the user types a new password rather than after.
+ */
+@Composable
+internal fun EndpointPendingBanner(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = AccountFieldShape,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(Spacing.md),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            Icon(Icons.Default.Info, contentDescription = null, modifier = Modifier.size(20.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    stringResource(R.string.account_endpoint_pending_title),
+                    style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+                )
+                Text(
+                    stringResource(R.string.account_endpoint_pending_body),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+
+/** The group heading inside a sub-page — same weight and colour as 8g's, without the list around it. */
+@Composable
+internal fun AccountSectionLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier.padding(start = Spacing.xs),
+    )
+}
+
+/** Helper text under a field — the site's own wording, where it has any. */
+@Composable
+internal fun AccountFieldHelper(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.padding(horizontal = Spacing.xs),
+    )
+}
+
+/**
+ * The second confirmation every high-risk action on these screens goes through.
+ *
+ * 8g deliberately gives none of these a switch: a mis-tapped toggle that rebinds two-factor auth or
+ * changes a password is unrecoverable from inside the app, so each one is a page you have to reach and
+ * then a dialog you have to read. [destructive] tints the confirm action for the ones that delete.
+ */
+@Composable
+internal fun HighRiskDialog(
+    icon: ImageVector,
+    title: String,
+    body: String,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    destructive: Boolean = false,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        // AlertDialog centres both icon and title on its own once an icon is present, which is the
+        // layout the design shows; there is nothing to override here.
+        icon = { Icon(icon, contentDescription = null) },
+        title = { Text(title) },
+        text = { Text(body, style = MaterialTheme.typography.bodyMedium) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(
+                    confirmLabel,
+                    color =
+                    if (destructive) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    },
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
+        shape = MaterialTheme.shapes.extraLarge,
+    )
+}
+
+/** A row of trailing actions pinned to the bottom of a sub-page, above the navigation bar. */
+@Composable
+internal fun AccountBottomBar(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(color = MaterialTheme.colorScheme.surface) {
+        Row(
+            modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            content()
+        }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/AccountComponents.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/AccountComponents.kt
@@ -4,9 +4,12 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
@@ -182,7 +185,15 @@ internal fun HighRiskDialog(
     )
 }
 
-/** A row of trailing actions pinned to the bottom of a sub-page, above the navigation bar. */
+/**
+ * A row of trailing actions pinned to the bottom of a sub-page, above the navigation bar.
+ *
+ * The navigation-bar inset is applied here rather than left to the caller. `Scaffold` dispatches no
+ * insets to its `bottomBar` slot — `NavigationBar` and `BottomAppBar` only look like it does because
+ * they carry their own `windowInsets` defaults — so an edge-to-edge app puts a bare `Surface` under
+ * the gesture pill, and under the whole bar on a three-button device. Owning it in the component
+ * means every caller is correct by construction.
+ */
 @Composable
 internal fun AccountBottomBar(
     modifier: Modifier = Modifier,
@@ -193,6 +204,7 @@ internal fun AccountBottomBar(
             modifier =
             modifier
                 .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.navigationBars)
                 .padding(horizontal = Spacing.lg, vertical = Spacing.md),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Spacing.sm),

--- a/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -53,6 +54,13 @@ fun AccountSettingsRoute(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // Signing out unmakes this screen: leaving it on the stack would show the account settings of an
+    // account nobody is signed in to.
+    LaunchedEffect(state.signedOut) {
+        if (state.signedOut) onBack()
+    }
+
     AccountSettingsScreen(
         state = state,
         onBack = onBack,
@@ -61,9 +69,7 @@ fun AccountSettingsRoute(
         onOpenContactAndBlock = onOpenContactAndBlock,
         onOpenDisplayPreferences = onOpenDisplayPreferences,
         onOpenHomeBoards = onOpenHomeBoards,
-        // Signing out unmakes this screen: leaving it on the stack would show the account settings of
-        // an account nobody is signed in to.
-        onSignOut = { viewModel.signOut(onSignedOut = onBack) },
+        onSignOut = viewModel::signOut,
         modifier = modifier,
     )
 }

--- a/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsScreen.kt
@@ -1,0 +1,338 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.data.account.AccountProfileFields
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.settings.SettingsGroup
+import io.github.nsreader.ui.settings.SettingsRow
+import io.github.nsreader.ui.settings.SettingsSectionTitle
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun AccountSettingsRoute(
+    viewModel: AccountSettingsViewModel,
+    onBack: () -> Unit,
+    onOpenProfileFields: () -> Unit,
+    onOpenSecurity: () -> Unit,
+    onOpenContactAndBlock: () -> Unit,
+    onOpenDisplayPreferences: () -> Unit,
+    onOpenHomeBoards: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    AccountSettingsScreen(
+        state = state,
+        onBack = onBack,
+        onOpenProfileFields = onOpenProfileFields,
+        onOpenSecurity = onOpenSecurity,
+        onOpenContactAndBlock = onOpenContactAndBlock,
+        onOpenDisplayPreferences = onOpenDisplayPreferences,
+        onOpenHomeBoards = onOpenHomeBoards,
+        // Signing out unmakes this screen: leaving it on the stack would show the account settings of
+        // an account nobody is signed in to.
+        onSignOut = { viewModel.signOut(onSignedOut = onBack) },
+        modifier = modifier,
+    )
+}
+
+/**
+ * 账号设置 (8g) — the seven groups NodeSeek's own `/setting` page is split into.
+ *
+ * Every group is a link to a page, and none of the high-risk ones gets a switch. That is the whole
+ * design: 修改密码, 两步验证 and 邮箱 are one mis-tap away from locking the user out of their own
+ * account, so each is a page you have to travel to and a dialog you have to read. The subtitle on
+ * each row is the current value, which the site's own page does not show — it is a plain list of
+ * anchors — and is the one thing this screen adds over opening `/setting` in a browser.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountSettingsScreen(
+    state: AccountSettingsUiState,
+    onBack: () -> Unit,
+    onOpenProfileFields: () -> Unit,
+    onOpenSecurity: () -> Unit,
+    onOpenContactAndBlock: () -> Unit,
+    onOpenDisplayPreferences: () -> Unit,
+    onOpenHomeBoards: () -> Unit,
+    onSignOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.account_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier =
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            SettingsSectionTitle(stringResource(R.string.account_group_introduction))
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.account_avatar),
+                    top = true,
+                    onClick = onOpenProfileFields,
+                    leading = { RowIcon(Icons.Default.AccountCircle) },
+                    trailing = {
+                        UserAvatar(
+                            url = state.avatarUrl,
+                            name = state.displayName,
+                            size = 30.dp,
+                        )
+                        Chevron()
+                    },
+                )
+                SettingsRow(
+                    title = stringResource(R.string.account_bio),
+                    subtitle = state.fields?.bio?.ifBlank { stringResource(R.string.account_bio_empty) },
+                    onClick = onOpenProfileFields,
+                    leading = { RowIcon(NodeSeekIcons.Badge) },
+                    trailing = { Chevron() },
+                )
+                SettingsRow(
+                    title = stringResource(R.string.account_signature),
+                    subtitle =
+                    state.fields?.let {
+                        stringResource(R.string.account_signature_lines, it.signature.lineCount())
+                    },
+                    onClick = onOpenProfileFields,
+                    leading = { RowIcon(NodeSeekIcons.Edit) },
+                    trailing = { Chevron() },
+                )
+                SettingsRow(
+                    title = stringResource(R.string.account_readme),
+                    subtitle =
+                    state.fields?.let {
+                        stringResource(R.string.account_readme_chars, it.readme.length)
+                    },
+                    bottom = true,
+                    onClick = onOpenProfileFields,
+                    leading = { RowIcon(NodeSeekIcons.Article) },
+                    trailing = { Chevron() },
+                )
+            }
+
+            SettingsSectionTitle(stringResource(R.string.account_group_security))
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.account_change_password),
+                    top = true,
+                    bottom = true,
+                    onClick = onOpenSecurity,
+                    leading = { RowIcon(Icons.Default.Lock) },
+                    trailing = { Chevron() },
+                )
+            }
+
+            SettingsSectionTitle(stringResource(R.string.account_group_2fa))
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.account_two_factor),
+                    subtitle =
+                    state.twoFactorEnabled?.let {
+                        stringResource(
+                            if (it) R.string.account_two_factor_on else R.string.account_two_factor_off,
+                        )
+                    },
+                    top = true,
+                    bottom = true,
+                    onClick = onOpenSecurity,
+                    leading = { RowIcon(NodeSeekIcons.Shield) },
+                    trailing = { Chevron() },
+                )
+            }
+
+            SettingsSectionTitle(stringResource(R.string.account_group_contact))
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.account_email),
+                    subtitle = state.email?.maskEmail(),
+                    top = true,
+                    bottom = true,
+                    onClick = onOpenContactAndBlock,
+                    leading = { RowIcon(Icons.Default.Email) },
+                    trailing = { Chevron() },
+                )
+            }
+
+            SettingsSectionTitle(stringResource(R.string.account_group_block))
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.account_blocked_list),
+                    subtitle =
+                    state.blockedCount?.let { stringResource(R.string.account_blocked_count, it) },
+                    top = true,
+                    bottom = true,
+                    onClick = onOpenContactAndBlock,
+                    leading = { RowIcon(NodeSeekIcons.Block) },
+                    trailing = { Chevron() },
+                )
+            }
+
+            SettingsSectionTitle(stringResource(R.string.account_group_preference))
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.account_display_preferences),
+                    top = true,
+                    bottom = true,
+                    onClick = onOpenDisplayPreferences,
+                    leading = { RowIcon(Icons.Default.Settings) },
+                    trailing = { Chevron() },
+                )
+            }
+
+            SettingsSectionTitle(stringResource(R.string.account_group_homepage))
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.account_home_boards),
+                    subtitle =
+                    if (state.homeBoardsRestricted) {
+                        stringResource(R.string.account_home_boards_selected, state.homeBoardCount)
+                    } else {
+                        stringResource(R.string.account_home_boards_all, state.totalBoardCount)
+                    },
+                    top = true,
+                    bottom = true,
+                    onClick = onOpenHomeBoards,
+                    leading = { RowIcon(NodeSeekIcons.DashboardCustomize) },
+                    trailing = { Chevron() },
+                )
+            }
+
+            SettingsGroup {
+                SettingsRow(
+                    title = stringResource(R.string.action_sign_out),
+                    top = true,
+                    bottom = true,
+                    onClick = onSignOut,
+                    contentColor = MaterialTheme.colorScheme.error,
+                    leading = {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ExitToApp,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowIcon(icon: ImageVector) {
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(20.dp),
+    )
+}
+
+@Composable
+private fun Chevron() {
+    Icon(
+        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(20.dp),
+    )
+}
+
+/** A signature is stored as Markdown; the row reports how many lines it renders as, not its length. */
+private fun String.lineCount(): Int = if (isBlank()) 0 else count { it == '\n' } + 1
+
+/**
+ * `hikari.zhg@gmail.com` becomes `h***@gmail.com`.
+ *
+ * The subtitle is enough to recognise which address is on file without printing it in full on a screen
+ * that gets handed around or screenshotted; the sub-page shows the whole thing.
+ */
+private fun String.maskEmail(): String {
+    val at = indexOf('@')
+    if (at <= 0) return this
+    return "${first()}***${substring(at)}"
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun AccountSettingsPreview() {
+    NodeSeekTheme {
+        AccountSettingsScreen(
+            state =
+            AccountSettingsUiState(
+                displayName = "花间一壶酒",
+                fields =
+                AccountProfileFields(
+                    bio = "常驻杭州",
+                    signature = "**出杭州腾讯云轻量** · 长期收闲置小鸡",
+                    readme = "### 关于我\n爱折腾的 MJJ 一枚，主力小鸡在 HK。",
+                ),
+                twoFactorEnabled = false,
+                email = "hikari.zhg@gmail.com",
+                blockedCount = 3,
+                homeBoardCount = 6,
+                totalBoardCount = 13,
+                homeBoardsRestricted = true,
+            ),
+            onBack = {},
+            onOpenProfileFields = {},
+            onOpenSecurity = {},
+            onOpenContactAndBlock = {},
+            onOpenDisplayPreferences = {},
+            onOpenHomeBoards = {},
+            onSignOut = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import io.github.nsreader.core.runCatchingExceptCancellation
-import io.github.nsreader.data.Board
 import io.github.nsreader.data.CategoryRepository
 import io.github.nsreader.data.PostRepository
 import io.github.nsreader.data.ProfileRepository
@@ -14,6 +13,7 @@ import io.github.nsreader.data.account.AccountProfileFields
 import io.github.nsreader.data.account.AccountSettingsRepository
 import io.github.nsreader.data.session.SessionRepository
 import io.github.nsreader.data.settings.SettingsRepository
+import io.github.nsreader.data.settings.visibleHomeBoards
 import io.github.nsreader.di.AppContainer
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -44,11 +44,17 @@ class AccountSettingsViewModel(
     private val session: SessionRepository,
 ) : ViewModel() {
     private val remote = MutableStateFlow(RemoteAccountState())
+    private val signedOut = MutableStateFlow(false)
     private var loadJob: Job? = null
     private var signOutJob: Job? = null
 
     val uiState: StateFlow<AccountSettingsUiState> =
-        combine(remote, settings.settings, categories.boards) { site, preferences, boards ->
+        combine(
+            remote,
+            settings.settings,
+            categories.boards,
+            signedOut,
+        ) { site, preferences, boards, isSignedOut ->
             val selectable = boards.filter { it.slug != null }
             AccountSettingsUiState(
                 avatarUrl = site.avatarUrl,
@@ -60,6 +66,7 @@ class AccountSettingsViewModel(
                 homeBoardCount = visibleHomeBoards(selectable, preferences.homeBoards).size,
                 totalBoardCount = selectable.size,
                 homeBoardsRestricted = preferences.homeBoards.isNotEmpty(),
+                signedOut = isSignedOut,
             )
         }.stateIn(
             scope = viewModelScope,
@@ -92,7 +99,14 @@ class AccountSettingsViewModel(
             }
     }
 
-    fun signOut(onSignedOut: () -> Unit) {
+    /**
+     * Signs out, then reports it through [AccountSettingsUiState.signedOut].
+     *
+     * A flag rather than a completion callback, for the same reason as `HomeBoardsViewModel.save`: a
+     * lambda captured across the suspend point would navigate a back stack that a configuration change
+     * has already replaced, leaving the user on the account settings of an account nobody is in.
+     */
+    fun signOut() {
         if (signOutJob?.isActive == true) return
         signOutJob =
             viewModelScope.launch {
@@ -100,7 +114,7 @@ class AccountSettingsViewModel(
                 // or the tabs still holding a Navigation 3 entry keep showing what they already drew.
                 posts.clearSessionData()
                 session.signOut()
-                onSignedOut()
+                signedOut.value = true
             }
     }
 
@@ -143,17 +157,6 @@ data class AccountSettingsUiState(
     val homeBoardCount: Int = 0,
     val totalBoardCount: Int = 0,
     val homeBoardsRestricted: Boolean = false,
+    /** Set once sign-out has committed; the screen pops itself on it. See `signOut`. */
+    val signedOut: Boolean = false,
 )
-
-/**
- * Narrows a board list to the user's home-strip preference.
- *
- * Callers pass only the real boards — 综合 is not one, has no slug, and is prepended by whoever draws
- * the strip. An empty preference means unrestricted. A preference that no longer matches anything, as
- * happens when every chosen board is renamed server-side, also falls back to unrestricted rather than
- * to nothing: an empty strip is indistinguishable from a broken one.
- */
-internal fun visibleHomeBoards(boards: List<Board>, preference: Set<String>): List<Board> {
-    if (preference.isEmpty()) return boards
-    return boards.filter { it.slug in preference }.ifEmpty { boards }
-}

--- a/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/AccountSettingsViewModel.kt
@@ -1,0 +1,159 @@
+package io.github.nsreader.ui.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.Board
+import io.github.nsreader.data.CategoryRepository
+import io.github.nsreader.data.PostRepository
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.account.AccountProfileFields
+import io.github.nsreader.data.account.AccountSettingsRepository
+import io.github.nsreader.data.session.SessionRepository
+import io.github.nsreader.data.settings.SettingsRepository
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * State holder for 账号设置 (8g).
+ *
+ * The screen is a hub, and the only thing that makes it more than a list of links is the current-value
+ * subtitle on each row. Those come from three different places — the forum profile, the site's setting
+ * page, and the app's own preferences — so the merge happens here rather than in the composable.
+ *
+ * A failure to read the site half is not an error state. The rows still navigate, and 8g showing an
+ * error screen because the blocked-user count could not be fetched would block access to 首页版块,
+ * which is entirely local and always works.
+ */
+class AccountSettingsViewModel(
+    private val account: AccountSettingsRepository,
+    private val profiles: ProfileRepository,
+    private val settings: SettingsRepository,
+    categories: CategoryRepository,
+    private val posts: PostRepository,
+    private val session: SessionRepository,
+) : ViewModel() {
+    private val remote = MutableStateFlow(RemoteAccountState())
+    private var loadJob: Job? = null
+    private var signOutJob: Job? = null
+
+    val uiState: StateFlow<AccountSettingsUiState> =
+        combine(remote, settings.settings, categories.boards) { site, preferences, boards ->
+            val selectable = boards.filter { it.slug != null }
+            AccountSettingsUiState(
+                avatarUrl = site.avatarUrl,
+                displayName = site.displayName,
+                fields = site.fields,
+                twoFactorEnabled = site.twoFactorEnabled,
+                email = site.email,
+                blockedCount = site.blockedCount,
+                homeBoardCount = visibleHomeBoards(selectable, preferences.homeBoards).size,
+                totalBoardCount = selectable.size,
+                homeBoardsRestricted = preferences.homeBoards.isNotEmpty(),
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
+            initialValue = AccountSettingsUiState(),
+        )
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                // The forum profile is the half that works today, so it is read on its own rather than
+                // inside the same runCatching as the settings-page calls that are still stubbed out.
+                runCatchingExceptCancellation { profiles.profile() }
+                    .onSuccess { profile ->
+                        remote.update { it.copy(avatarUrl = profile.avatarUrl, displayName = profile.name) }
+                    }
+                runCatchingExceptCancellation { account.profileFields() }
+                    .onSuccess { fields -> remote.update { it.copy(fields = fields) } }
+                runCatchingExceptCancellation { account.twoFactor() }
+                    .onSuccess { state -> remote.update { it.copy(twoFactorEnabled = state.enabled) } }
+                runCatchingExceptCancellation { account.contact() }
+                    .onSuccess { contact -> remote.update { it.copy(email = contact.email) } }
+                runCatchingExceptCancellation { account.blockedUsers() }
+                    .onSuccess { blocked -> remote.update { it.copy(blockedCount = blocked.size) } }
+            }
+    }
+
+    fun signOut(onSignedOut: () -> Unit) {
+        if (signOutJob?.isActive == true) return
+        signOutJob =
+            viewModelScope.launch {
+                // Same order as 我的: drop authenticated rows before the signed-out state is published,
+                // or the tabs still holding a Navigation 3 entry keep showing what they already drew.
+                posts.clearSessionData()
+                session.signOut()
+                onSignedOut()
+            }
+    }
+
+    companion object {
+        private const val STOP_TIMEOUT_MILLIS = 5_000L
+
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    AccountSettingsViewModel(
+                        account = container.accountSettingsRepository,
+                        profiles = container.profileRepository,
+                        settings = container.settingsRepository,
+                        categories = container.categoryRepository,
+                        posts = container.postRepository,
+                        session = container.sessionRepository,
+                    )
+                }
+            }
+    }
+}
+
+/** Everything 8g reads off the network, kept apart from the preferences it merges with. */
+private data class RemoteAccountState(
+    val avatarUrl: String? = null,
+    val displayName: String = "",
+    val fields: AccountProfileFields? = null,
+    val twoFactorEnabled: Boolean? = null,
+    val email: String? = null,
+    val blockedCount: Int? = null,
+)
+
+data class AccountSettingsUiState(
+    val avatarUrl: String? = null,
+    val displayName: String = "",
+    val fields: AccountProfileFields? = null,
+    val twoFactorEnabled: Boolean? = null,
+    val email: String? = null,
+    val blockedCount: Int? = null,
+    val homeBoardCount: Int = 0,
+    val totalBoardCount: Int = 0,
+    val homeBoardsRestricted: Boolean = false,
+)
+
+/**
+ * Narrows a board list to the user's home-strip preference.
+ *
+ * Callers pass only the real boards — 综合 is not one, has no slug, and is prepended by whoever draws
+ * the strip. An empty preference means unrestricted. A preference that no longer matches anything, as
+ * happens when every chosen board is renamed server-side, also falls back to unrestricted rather than
+ * to nothing: an empty strip is indistinguishable from a broken one.
+ */
+internal fun visibleHomeBoards(boards: List<Board>, preference: Set<String>): List<Board> {
+    if (preference.isEmpty()) return boards
+    return boards.filter { it.slug in preference }.ifEmpty { boards }
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/AvatarPicker.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/AvatarPicker.kt
@@ -1,0 +1,136 @@
+package io.github.nsreader.ui.account
+
+import android.content.ContentResolver
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.graphics.scale
+import io.github.nsreader.data.account.AvatarUpload
+import java.io.ByteArrayOutputStream
+import kotlin.math.max
+
+/**
+ * An avatar the user has chosen but the server has not accepted yet.
+ *
+ * [preview] is a Compose image rather than a Uri because the two sources disagree about what they
+ * hand back — the photo picker returns a `content://` Uri and the camera returns a Bitmap with no
+ * Uri at all — and normalising towards the Uri would mean writing the camera shot to a cache file
+ * whose lifetime nobody owns. Normalising towards the bitmap costs about a megabyte of state and
+ * nothing else.
+ */
+data class PendingAvatar(
+    val preview: ImageBitmap,
+    val upload: AvatarUpload,
+)
+
+/** The two avatar sources 个人信息 offers, handed to the screen as plain callbacks. */
+internal class AvatarPickerController(
+    val takePhoto: () -> Unit,
+    val pickImage: () -> Unit,
+)
+
+/**
+ * Wires the photo picker and the camera to [onPicked].
+ *
+ * `PickVisualMedia` rather than `GetContent`: it is the system picker, so it needs no storage
+ * permission and shows nothing but the images the user selects. The camera path uses
+ * `TakePicturePreview`, which likewise needs no permission and no `FileProvider` — the trade is that
+ * it returns a thumbnail-resolution bitmap. That is fine for an avatar the site renders at 100px, but
+ * whoever wires the real upload should check the accepted dimensions and move to `TakePicture` with a
+ * cache-file Uri if they turn out to be larger.
+ */
+@Composable
+internal fun rememberAvatarPicker(
+    onPicked: (PendingAvatar) -> Unit,
+    onFailed: () -> Unit,
+): AvatarPickerController {
+    val context = LocalContext.current
+    val resolver = context.contentResolver
+
+    val cameraLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.TakePicturePreview()) { bitmap ->
+            // A null bitmap is the user backing out of the camera, which is not a failure.
+            if (bitmap == null) return@rememberLauncherForActivityResult
+            val prepared = runCatching { bitmap.toPendingAvatar() }.getOrNull()
+            if (prepared == null) onFailed() else onPicked(prepared)
+        }
+
+    val galleryLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.PickVisualMedia(),
+        ) { uri ->
+            if (uri == null) return@rememberLauncherForActivityResult
+            val prepared = resolver.decodeAvatar(uri)
+            if (prepared == null) onFailed() else onPicked(prepared)
+        }
+
+    return remember(cameraLauncher, galleryLauncher) {
+        AvatarPickerController(
+            takePhoto = { cameraLauncher.launch(null) },
+            pickImage = {
+                galleryLauncher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                )
+            },
+        )
+    }
+}
+
+/**
+ * Decodes at a bounded size rather than loading the original.
+ *
+ * A modern camera roll photo is several thousand pixels on a side; decoding one whole so it can be
+ * scaled down to 512 is how a settings screen gets an OutOfMemoryError on a cheap device. The
+ * two-pass `inJustDecodeBounds` read costs one header parse and removes that entirely.
+ */
+private fun ContentResolver.decodeAvatar(uri: Uri): PendingAvatar? =
+    runCatching {
+        val bounds =
+            BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+        val longestEdge = max(bounds.outWidth, bounds.outHeight)
+        if (longestEdge <= 0) return null
+
+        val options =
+            BitmapFactory.Options().apply {
+                inSampleSize = generateSequence(1) { it * 2 }.first { longestEdge / it <= AVATAR_MAX_EDGE_PX }
+            }
+        val decoded = openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
+        decoded?.toPendingAvatar()
+    }.getOrNull()
+
+private fun Bitmap.toPendingAvatar(): PendingAvatar {
+    val scaled = scaledToAvatar()
+    val bytes =
+        ByteArrayOutputStream().use { stream ->
+            scaled.compress(Bitmap.CompressFormat.JPEG, AVATAR_JPEG_QUALITY, stream)
+            stream.toByteArray()
+        }
+    return PendingAvatar(
+        preview = scaled.asImageBitmap(),
+        upload = AvatarUpload(bytes = bytes, mimeType = AVATAR_MIME_TYPE),
+    )
+}
+
+private fun Bitmap.scaledToAvatar(): Bitmap {
+    val longestEdge = max(width, height)
+    if (longestEdge <= AVATAR_MAX_EDGE_PX) return this
+    val ratio = AVATAR_MAX_EDGE_PX.toFloat() / longestEdge
+    return scale(
+        width = (width * ratio).toInt().coerceAtLeast(1),
+        height = (height * ratio).toInt().coerceAtLeast(1),
+    )
+}
+
+/** The site renders avatars small; 512 leaves room for a retina display and nothing is gained above it. */
+private const val AVATAR_MAX_EDGE_PX = 512
+private const val AVATAR_JPEG_QUALITY = 88
+private const val AVATAR_MIME_TYPE = "image/jpeg"

--- a/app/src/main/java/io/github/nsreader/ui/account/ContactBlockScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/ContactBlockScreen.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -35,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -128,6 +131,8 @@ fun ContactBlockScreen(
                 .fillMaxSize()
                 .readableWidth()
                 .verticalScroll(rememberScrollState())
+                // See ProfileFieldsScreen: without this the keyboard hides the backup-address field.
+                .imePadding()
                 .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
             verticalArrangement = Arrangement.spacedBy(Spacing.md),
         ) {
@@ -234,6 +239,7 @@ private fun EmailField(
         label = { Text(label) },
         singleLine = true,
         isError = isError,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
         supportingText =
         if (isError) {
             { Text(stringResource(R.string.account_email_invalid)) }

--- a/app/src/main/java/io/github/nsreader/ui/account/ContactBlockScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/ContactBlockScreen.kt
@@ -1,0 +1,372 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.data.account.AccountContact
+import io.github.nsreader.data.account.BlockedUser
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.theme.LocalNodeSeekExtraColors
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Sizes
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun ContactBlockRoute(
+    viewModel: ContactBlockViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val messageText = state.message?.let { accountMessageText(it) }
+
+    LaunchedEffect(state.message, messageText) {
+        if (messageText == null) return@LaunchedEffect
+        snackbarHostState.showSnackbar(messageText)
+        viewModel.consumeMessage()
+    }
+
+    ContactBlockScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onEmailChange = viewModel::updateEmail,
+        onBackupEmailChange = viewModel::updateBackupEmail,
+        onResend = viewModel::resendVerification,
+        onSave = viewModel::save,
+        onRequestUnblock = viewModel::requestUnblock,
+        onDismissUnblock = viewModel::dismissUnblock,
+        onConfirmUnblock = viewModel::confirmUnblock,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 联系方式与屏蔽 (d6 3/4).
+ *
+ * The verified badge is the load-bearing part: an email address that looks saved but is not verified
+ * cannot recover the account, and the site's own page shows nothing about it. Changing an address
+ * clears the badge immediately rather than after a refresh, so the state on screen is never a claim
+ * the server has not agreed to.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactBlockScreen(
+    state: ContactBlockUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onEmailChange: (String) -> Unit,
+    onBackupEmailChange: (String) -> Unit,
+    onResend: (String) -> Unit,
+    onSave: () -> Unit,
+    onRequestUnblock: (BlockedUser) -> Unit,
+    onDismissUnblock: () -> Unit,
+    onConfirmUnblock: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.account_contact_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier =
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            if (state.endpointPending) EndpointPendingBanner()
+
+            AccountSectionLabel(stringResource(R.string.account_contact_section))
+
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                EmailField(
+                    value = state.email,
+                    onValueChange = onEmailChange,
+                    label = stringResource(R.string.account_email),
+                    verified = state.emailVerified,
+                    isError = state.isEmailMalformed,
+                )
+                AccountFieldHelper(stringResource(R.string.account_email_helper))
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                EmailField(
+                    value = state.backupEmail,
+                    onValueChange = onBackupEmailChange,
+                    label = stringResource(R.string.account_email_backup),
+                    verified = state.backupEmailVerified,
+                    isError = state.isBackupMalformed,
+                )
+                if (state.backupEmail.isNotEmpty() && !state.backupEmailVerified) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        AccountFieldHelper(
+                            text = stringResource(R.string.account_email_verification_sent),
+                            modifier = Modifier.weight(1f),
+                        )
+                        TextButton(onClick = { onResend(state.backupEmail) }) {
+                            Text(stringResource(R.string.account_email_resend))
+                        }
+                    }
+                }
+            }
+
+            Button(
+                onClick = onSave,
+                enabled = state.canSave,
+                shape = RoundedCornerShape(20.dp),
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(stringResource(R.string.account_contact_save))
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                AccountSectionLabel(
+                    text = stringResource(R.string.account_block_section),
+                    modifier = Modifier.weight(1f),
+                )
+                if (state.blocked.isNotEmpty()) {
+                    Text(
+                        stringResource(R.string.account_blocked_count, state.blocked.size),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            if (state.blocked.isEmpty()) {
+                BlockedEmptyState()
+            } else {
+                Column {
+                    state.blocked.forEachIndexed { index, user ->
+                        BlockedRow(user = user, onUnblock = { onRequestUnblock(user) })
+                        if (index != state.blocked.lastIndex) {
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    state.unblocking?.let { target ->
+        HighRiskDialog(
+            icon = NodeSeekIcons.Block,
+            title = stringResource(R.string.account_confirm_unblock_title, target.name),
+            body = stringResource(R.string.account_confirm_unblock_body),
+            confirmLabel = stringResource(R.string.account_confirm_unblock_action),
+            onConfirm = onConfirmUnblock,
+            onDismiss = onDismissUnblock,
+        )
+    }
+}
+
+@Composable
+private fun EmailField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    verified: Boolean,
+    isError: Boolean,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        singleLine = true,
+        isError = isError,
+        supportingText =
+        if (isError) {
+            { Text(stringResource(R.string.account_email_invalid)) }
+        } else {
+            null
+        },
+        shape = AccountFieldShape,
+        trailingIcon = { if (value.isNotEmpty()) VerificationBadge(verified) },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+/** Verified reads as primary, unverified as the warning family — never as an error, since it is not one. */
+@Composable
+private fun VerificationBadge(verified: Boolean) {
+    val extra = LocalNodeSeekExtraColors.current
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = if (verified) MaterialTheme.colorScheme.primaryContainer else extra.warningContainer,
+        contentColor =
+        if (verified) MaterialTheme.colorScheme.onPrimaryContainer else extra.onWarningContainer,
+        modifier = Modifier.padding(end = Spacing.sm),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = Spacing.sm, vertical = 3.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            Icon(
+                imageVector = if (verified) Icons.Default.Check else NodeSeekIcons.Schedule,
+                contentDescription = null,
+                modifier = Modifier.size(14.dp),
+            )
+            Text(
+                stringResource(
+                    if (verified) R.string.account_email_verified else R.string.account_email_unverified,
+                ),
+                style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BlockedRow(
+    user: BlockedUser,
+    onUnblock: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        UserAvatar(url = user.avatarUrl, name = user.name, size = Sizes.avatarList)
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = user.name,
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                stringResource(R.string.account_block_row_hint),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        TextButton(onClick = onUnblock) {
+            Text(stringResource(R.string.account_block_unblock))
+        }
+    }
+}
+
+@Composable
+private fun BlockedEmptyState() {
+    Surface(
+        shape = AccountFieldShape,
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(Spacing.lg),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                NodeSeekIcons.VisibilityOff,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp),
+            )
+            Text(
+                stringResource(R.string.account_block_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun ContactBlockPreview() {
+    NodeSeekTheme {
+        ContactBlockScreen(
+            state =
+            ContactBlockUiState(
+                isLoading = false,
+                email = "hikari.zhg@gmail.com",
+                backupEmail = "ns.backup@outlook.com",
+                saved =
+                AccountContact(
+                    email = "hikari.zhg@gmail.com",
+                    emailVerified = true,
+                    backupEmail = "ns.backup@outlook.com",
+                    backupEmailVerified = false,
+                ),
+                blocked =
+                listOf(
+                    BlockedUser(uid = 1, name = "机场信仰充值中"),
+                    BlockedUser(uid = 2, name = "vps_matthew"),
+                    BlockedUser(uid = 3, name = "白嫖失败选手"),
+                ),
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBack = {},
+            onEmailChange = {},
+            onBackupEmailChange = {},
+            onResend = {},
+            onSave = {},
+            onRequestUnblock = {},
+            onDismissUnblock = {},
+            onConfirmUnblock = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/ContactBlockViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/ContactBlockViewModel.kt
@@ -1,0 +1,201 @@
+package io.github.nsreader.ui.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.R
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.account.AccountContact
+import io.github.nsreader.data.account.AccountSettingsRepository
+import io.github.nsreader.data.account.BlockedUser
+import io.github.nsreader.data.account.EndpointNotVerifiedException
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * State holder for 联系方式与屏蔽 (d6 3/4).
+ *
+ * Two of the site's seven groups on one page, because `#contact` is two fields and `#block` is a list
+ * — separately each is a screen with more chrome than content, and neither has anything to do with
+ * scrolling past the other.
+ */
+class ContactBlockViewModel(
+    private val account: AccountSettingsRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ContactBlockUiState())
+    val uiState: StateFlow<ContactBlockUiState> = _uiState.asStateFlow()
+
+    private var saveJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            runCatchingExceptCancellation { account.contact() }
+                .onSuccess { contact ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            saved = contact,
+                            email = contact.email,
+                            backupEmail = contact.backupEmail,
+                        )
+                    }
+                }.onFailure { throwable ->
+                    val pending = throwable is EndpointNotVerifiedException
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            endpointPending = pending,
+                            message =
+                            if (pending) {
+                                null
+                            } else {
+                                throwable.toAccountMessage(R.string.account_contact_section)
+                            },
+                        )
+                    }
+                }
+
+            runCatchingExceptCancellation { account.blockedUsers() }
+                .onSuccess { blocked -> _uiState.update { it.copy(blocked = blocked) } }
+        }
+    }
+
+    fun updateEmail(value: String) = _uiState.update { it.copy(email = value.trim()) }
+
+    fun updateBackupEmail(value: String) = _uiState.update { it.copy(backupEmail = value.trim()) }
+
+    fun save() {
+        if (saveJob?.isActive == true) return
+        val state = _uiState.value
+        if (!state.canSave) return
+        saveJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isSaving = true, message = null) }
+                runCatchingExceptCancellation { account.saveContact(state.email, state.backupEmail) }
+                    .onSuccess {
+                        // An address that changed is unverified again until the user clicks the mail
+                        // the server just sent; one that did not keeps whatever it already had.
+                        val previous = state.saved
+                        _uiState.update {
+                            it.copy(
+                                isSaving = false,
+                                saved =
+                                AccountContact(
+                                    email = state.email,
+                                    emailVerified =
+                                    previous?.emailVerified == true && previous.email == state.email,
+                                    backupEmail = state.backupEmail,
+                                    backupEmailVerified =
+                                    previous?.backupEmailVerified == true &&
+                                        previous.backupEmail == state.backupEmail,
+                                ),
+                                message = AccountMessage.Info(R.string.account_action_saved),
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(
+                                isSaving = false,
+                                message = throwable.toAccountMessage(R.string.account_contact_save),
+                            )
+                        }
+                    }
+            }
+    }
+
+    fun resendVerification(address: String) {
+        viewModelScope.launch {
+            runCatchingExceptCancellation { account.resendVerification(address) }
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(message = AccountMessage.Info(R.string.account_email_verification_sent))
+                    }
+                }.onFailure { throwable ->
+                    _uiState.update {
+                        it.copy(message = throwable.toAccountMessage(R.string.account_email_resend))
+                    }
+                }
+        }
+    }
+
+    fun requestUnblock(user: BlockedUser) = _uiState.update { it.copy(unblocking = user) }
+
+    fun dismissUnblock() = _uiState.update { it.copy(unblocking = null) }
+
+    fun confirmUnblock() {
+        val target = _uiState.value.unblocking ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(unblocking = null) }
+            runCatchingExceptCancellation { account.unblock(target.uid) }
+                .onSuccess {
+                    _uiState.update { state ->
+                        state.copy(blocked = state.blocked.filterNot { it.uid == target.uid })
+                    }
+                }.onFailure { throwable ->
+                    _uiState.update {
+                        it.copy(message = throwable.toAccountMessage(R.string.account_block_unblock))
+                    }
+                }
+        }
+    }
+
+    fun consumeMessage() = _uiState.update { it.copy(message = null) }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { ContactBlockViewModel(container.accountSettingsRepository) }
+            }
+    }
+}
+
+data class ContactBlockUiState(
+    val isLoading: Boolean = true,
+    val isSaving: Boolean = false,
+    val endpointPending: Boolean = false,
+    val email: String = "",
+    val backupEmail: String = "",
+    val saved: AccountContact? = null,
+    val blocked: List<BlockedUser> = emptyList(),
+    val unblocking: BlockedUser? = null,
+    val message: AccountMessage? = null,
+) {
+    val emailVerified: Boolean
+        get() = saved?.emailVerified == true && email == saved.email
+
+    val backupEmailVerified: Boolean
+        get() = saved?.backupEmailVerified == true && backupEmail == saved.backupEmail
+
+    val isEmailMalformed: Boolean get() = email.isNotEmpty() && !isEmailAddress(email)
+
+    val isBackupMalformed: Boolean
+        get() = backupEmail.isNotEmpty() && !isEmailAddress(backupEmail)
+
+    val canSave: Boolean
+        get() {
+            if (isSaving || isEmailMalformed || isBackupMalformed || email.isEmpty()) return false
+            val baseline = saved ?: AccountContact()
+            return email != baseline.email || backupEmail != baseline.backupEmail
+        }
+}
+
+/**
+ * Enough of a check to catch a typo, and deliberately no more.
+ *
+ * A regex that tries to implement RFC 5322 rejects addresses that work; the server is the only thing
+ * that knows whether an address is deliverable, and this only exists so an obvious slip is caught
+ * before a verification mail goes to nobody.
+ */
+internal fun isEmailAddress(value: String): Boolean {
+    val at = value.indexOf('@')
+    if (at <= 0 || at != value.lastIndexOf('@')) return false
+    val domain = value.substring(at + 1)
+    return domain.length >= 3 && domain.contains('.') && !domain.startsWith('.') && !domain.endsWith('.')
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsScreen.kt
@@ -1,0 +1,297 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.data.Board
+import io.github.nsreader.ui.common.BoardFamily
+import io.github.nsreader.ui.common.boardFamilyColors
+import io.github.nsreader.ui.common.boardFamilyOf
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Sizes
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun HomeBoardsRoute(
+    viewModel: HomeBoardsViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val messageText = state.message?.let { accountMessageText(it) }
+
+    LaunchedEffect(state.message, messageText) {
+        if (messageText == null) return@LaunchedEffect
+        snackbarHostState.showSnackbar(messageText)
+        viewModel.consumeMessage()
+    }
+
+    HomeBoardsScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onToggle = viewModel::toggle,
+        onReset = viewModel::reset,
+        // Saving returns to 账号设置, whose 首页版块 row immediately reads the new count — that is the
+        // confirmation, and it is a truer one than a snackbar because it comes from the stored value.
+        onSave = { viewModel.save(onSaved = onBack) },
+        modifier = modifier,
+    )
+}
+
+/**
+ * 首页版块 (d6 4/4) — which boards appear on the home strip.
+ *
+ * Grouped under the same four headings the board tags are coloured by, so the dot beside each heading
+ * is the colour the reader already associates with those boards from every list row. Thirteen flat
+ * checkboxes would fit; four groups of three or four is what makes them scannable.
+ *
+ * Edits are local until 保存, so leaving without saving changes nothing.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeBoardsScreen(
+    state: HomeBoardsUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onToggle: (String) -> Unit,
+    onReset: () -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val grouped =
+        remember(state.boards) {
+            state.boards.groupBy { boardFamilyOf(it.slug, it.title) }
+        }
+
+    Scaffold(
+        modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.account_home_boards_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+        bottomBar = {
+            Column {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                AccountBottomBar {
+                    TextButton(onClick = onReset) {
+                        Text(stringResource(R.string.account_home_boards_reset))
+                    }
+                    Box(Modifier.weight(1f))
+                    Button(
+                        onClick = onSave,
+                        enabled = state.selected.isNotEmpty(),
+                        shape = RoundedCornerShape(22.dp),
+                    ) {
+                        Text(stringResource(R.string.account_home_boards_save, state.selected.size))
+                    }
+                }
+            }
+        },
+    ) { padding ->
+        if (!state.isLoading && state.boards.isEmpty()) {
+            Box(
+                modifier = Modifier.padding(padding).fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    stringResource(R.string.account_home_boards_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(Spacing.xl),
+                )
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier.padding(padding).fillMaxSize().readableWidth(),
+        ) {
+            item(key = "summary") {
+                Text(
+                    stringResource(
+                        R.string.account_home_boards_summary,
+                        state.selected.size,
+                        state.total,
+                    ),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = Spacing.xl, vertical = Spacing.sm),
+                )
+            }
+
+            BoardFamily.entries.forEach { family ->
+                val boards = grouped[family].orEmpty()
+                if (boards.isEmpty()) return@forEach
+
+                item(key = "family-${family.name}") {
+                    FamilyHeading(family)
+                }
+                items(count = boards.size, key = { boards[it].slug.orEmpty() }) { index ->
+                    val board = boards[index]
+                    val slug = board.slug ?: return@items
+                    BoardCheckRow(
+                        board = board,
+                        checked = slug in state.selected,
+                        onToggle = { onToggle(slug) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FamilyHeading(family: BoardFamily) {
+    val colors = boardFamilyColors(family)
+    Row(
+        modifier = Modifier.padding(start = Spacing.xl, end = Spacing.xl, top = Spacing.md, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        Box(
+            Modifier
+                .size(8.dp)
+                .background(colors.container, CircleShape)
+                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape),
+        )
+        Text(
+            stringResource(family.labelRes),
+            style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun BoardCheckRow(
+    board: Board,
+    checked: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            // The whole row toggles, and the row is the accessibility node — a Checkbox with its own
+            // click handler would announce twice and give a 20dp target inside a 48dp row.
+            .toggleable(value = checked, onValueChange = { onToggle() }, role = Role.Checkbox)
+            .padding(horizontal = Spacing.lg, vertical = Spacing.xs)
+            .heightIn(min = Sizes.minTouchTarget),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        Checkbox(checked = checked, onCheckedChange = null)
+        /*
+         * Two lines rather than title-then-description on one.
+         *
+         * The board list is the live one, and the site's descriptions run to a full sentence — 交易's is
+         * thirty characters. Laid out side by side they squeezed the title to nothing and wrapped back
+         * over it. d6 draws bare single-line rows because it was mocked without descriptions; keeping
+         * them is worth the second line, since "沙盒主要用来测试发帖" is exactly what decides the tick.
+         */
+        Column(Modifier.weight(1f)) {
+            Text(board.title, style = MaterialTheme.typography.bodyLarge)
+            board.description?.takeIf(String::isNotBlank)?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun HomeBoardsPreview() {
+    val boards =
+        listOf(
+            // The site's own descriptions, because their length is what the layout has to survive.
+            Board("daily", "日常", "日常交流板块，通用话题分区"),
+            Board("life", "生活", "聊聊工作、生活、感情，不要阴阳怪气"),
+            Board("photo-share", "贴图", "贴图板块，一般发布日常图片/沙雕图/帅哥美女，禁止NSFW图"),
+            Board("sandbox", "沙盒", "沙盒主要用来测试发帖"),
+            Board("tech", "技术", "分享交流技术相关，比如技术方案分享，科技新闻，技术咨询与交流"),
+            Board("dev", "Dev", "论坛开发及bug反馈区"),
+            Board("review", "测评", "服务器测评，欢迎分享测试跑分及个人评价"),
+            Board("info", "情报", "传递行业新闻，推广好项目好软件，推广个人开发者的创意作品"),
+            Board("trade", "交易", "二手物品交易板块，交易内容不限于vps、电子设备等；禁止插广告；禁止非法交易"),
+            Board("carpool", "拼车", "拼车拼团板块，包括但不限于Netflix，Office 365，Google One"),
+            Board("promotion", "推广", "商家推广专区"),
+            Board("expose", "曝光", "曝光不良商家与用户"),
+            Board("inside", "内版", "内部版块"),
+        )
+    NodeSeekTheme {
+        HomeBoardsScreen(
+            state =
+            HomeBoardsUiState(
+                isLoading = false,
+                boards = boards,
+                selected = setOf("daily", "tech", "dev", "review", "info", "trade"),
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBack = {},
+            onToggle = {},
+            onReset = {},
+            onSave = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsScreen.kt
@@ -70,15 +70,19 @@ fun HomeBoardsRoute(
         viewModel.consumeMessage()
     }
 
+    // Saving returns to 账号设置, whose 首页版块 row immediately reads the new count — that is the
+    // confirmation, and a truer one than a snackbar because it comes from the stored value.
+    LaunchedEffect(state.saved) {
+        if (state.saved) onBack()
+    }
+
     HomeBoardsScreen(
         state = state,
         snackbarHostState = snackbarHostState,
         onBack = onBack,
         onToggle = viewModel::toggle,
         onReset = viewModel::reset,
-        // Saving returns to 账号设置, whose 首页版块 row immediately reads the new count — that is the
-        // confirmation, and it is a truer one than a snackbar because it comes from the stored value.
-        onSave = { viewModel.save(onSaved = onBack) },
+        onSave = viewModel::save,
         modifier = modifier,
     )
 }

--- a/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsViewModel.kt
@@ -9,7 +9,9 @@ import io.github.nsreader.R
 import io.github.nsreader.data.Board
 import io.github.nsreader.data.CategoryRepository
 import io.github.nsreader.data.settings.SettingsRepository
+import io.github.nsreader.data.settings.visibleHomeBoards
 import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,6 +38,8 @@ class HomeBoardsViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(HomeBoardsUiState())
     val uiState: StateFlow<HomeBoardsUiState> = _uiState.asStateFlow()
+
+    private var saveJob: Job? = null
 
     init {
         viewModelScope.launch { categories.refreshIfNeeded() }
@@ -88,20 +92,30 @@ class HomeBoardsViewModel(
         }
     }
 
-    fun save(onSaved: () -> Unit) {
+    /**
+     * Writes the selection and then reports it through [HomeBoardsUiState.saved].
+     *
+     * A flag rather than a completion callback: the ViewModel outlives the composition, so a lambda
+     * captured across the DataStore write acts on the back stack that existed before a configuration
+     * change, and the navigation is silently lost. Observing state means whichever composition is
+     * alive when the write lands is the one that navigates.
+     */
+    fun save() {
+        if (saveJob?.isActive == true) return
         val state = _uiState.value
         if (state.selected.isEmpty()) return
-        viewModelScope.launch {
-            val allSlugs = state.boards.mapNotNull(Board::slug).toSet()
-            // Storing "every board" as an explicit list would pin the strip to today's board list and
-            // silently hide any board the site adds later. Unrestricted is stored as unrestricted.
-            if (state.selected == allSlugs) {
-                settings.clearHomeBoards()
-            } else {
-                settings.setHomeBoards(state.selected)
+        saveJob =
+            viewModelScope.launch {
+                val allSlugs = state.boards.mapNotNull(Board::slug).toSet()
+                // Storing "every board" as an explicit list would pin the strip to today's board list
+                // and silently hide any board the site adds later. Unrestricted stays unrestricted.
+                if (state.selected == allSlugs) {
+                    settings.clearHomeBoards()
+                } else {
+                    settings.setHomeBoards(state.selected)
+                }
+                _uiState.update { it.copy(saved = true) }
             }
-            onSaved()
-        }
     }
 
     fun consumeMessage() = _uiState.update { it.copy(message = null) }
@@ -124,6 +138,8 @@ data class HomeBoardsUiState(
     val boards: List<Board> = emptyList(),
     val selected: Set<String> = emptySet(),
     val message: AccountMessage? = null,
+    /** Set once the selection has been written; the screen navigates back on it. See `save`. */
+    val saved: Boolean = false,
     /** True once [selected] has been derived from the stored preference; see the init block. */
     internal val seeded: Boolean = false,
 ) {

--- a/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/HomeBoardsViewModel.kt
@@ -1,0 +1,131 @@
+package io.github.nsreader.ui.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.R
+import io.github.nsreader.data.Board
+import io.github.nsreader.data.CategoryRepository
+import io.github.nsreader.data.settings.SettingsRepository
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * State holder for 首页版块 (d6 4/4).
+ *
+ * The only sub-page of 账号设置 that works end to end today, because it is not a site setting at all:
+ * which boards the home strip shows is a presentation choice this app owns, stored in DataStore next
+ * to the theme. That is deliberate — routing it through the server would make the strip depend on the
+ * network to draw itself, and the site's `#homepage` group exists for the website's own layout.
+ *
+ * The selection is edited locally and written once on save, so backing out abandons the edit rather
+ * than leaving the home strip half-changed.
+ */
+class HomeBoardsViewModel(
+    private val settings: SettingsRepository,
+    private val categories: CategoryRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(HomeBoardsUiState())
+    val uiState: StateFlow<HomeBoardsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch { categories.refreshIfNeeded() }
+        viewModelScope.launch {
+            val stored = settings.settings.first().homeBoards
+            categories.boards
+                // Observed rather than taken once: on a cold start the board list arrives from Room
+                // before the network refresh lands, and waiting for a populated list would leave the
+                // screen spinning forever if that refresh never succeeded.
+                .onEach { boards ->
+                    // 综合 is not a board — no slug, never returned by the API, always on the strip.
+                    // Offering it as a checkbox would let the user hide the front page.
+                    val selectable = boards.filter { it.slug != null }
+                    _uiState.update { state ->
+                        state.copy(
+                            isLoading = false,
+                            boards = selectable,
+                            // Seeded once, from the first non-empty list. Re-deriving on every emission
+                            // would discard the user's ticks the moment a refresh landed underneath them.
+                            selected =
+                            if (state.seeded || selectable.isEmpty()) {
+                                state.selected
+                            } else {
+                                visibleHomeBoards(selectable, stored).mapNotNull(Board::slug).toSet()
+                            },
+                            seeded = state.seeded || selectable.isNotEmpty(),
+                        )
+                    }
+                }.launchIn(viewModelScope)
+        }
+    }
+
+    fun toggle(slug: String) {
+        _uiState.update { state ->
+            val next = if (slug in state.selected) state.selected - slug else state.selected + slug
+            // The last board cannot be unchecked: an empty strip would be indistinguishable from a
+            // broken one, and the preference already spells "all" as the empty set.
+            if (next.isEmpty()) {
+                state.copy(message = AccountMessage.Info(R.string.account_home_boards_min))
+            } else {
+                state.copy(selected = next)
+            }
+        }
+    }
+
+    /** Back to unrestricted, which is the default rather than "everything ticked". */
+    fun reset() {
+        _uiState.update { state ->
+            state.copy(selected = state.boards.mapNotNull(Board::slug).toSet())
+        }
+    }
+
+    fun save(onSaved: () -> Unit) {
+        val state = _uiState.value
+        if (state.selected.isEmpty()) return
+        viewModelScope.launch {
+            val allSlugs = state.boards.mapNotNull(Board::slug).toSet()
+            // Storing "every board" as an explicit list would pin the strip to today's board list and
+            // silently hide any board the site adds later. Unrestricted is stored as unrestricted.
+            if (state.selected == allSlugs) {
+                settings.clearHomeBoards()
+            } else {
+                settings.setHomeBoards(state.selected)
+            }
+            onSaved()
+        }
+    }
+
+    fun consumeMessage() = _uiState.update { it.copy(message = null) }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    HomeBoardsViewModel(
+                        settings = container.settingsRepository,
+                        categories = container.categoryRepository,
+                    )
+                }
+            }
+    }
+}
+
+data class HomeBoardsUiState(
+    val isLoading: Boolean = true,
+    val boards: List<Board> = emptyList(),
+    val selected: Set<String> = emptySet(),
+    val message: AccountMessage? = null,
+    /** True once [selected] has been derived from the stored preference; see the init block. */
+    internal val seeded: Boolean = false,
+) {
+    val total: Int get() = boards.size
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/PasswordStrength.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/PasswordStrength.kt
@@ -1,0 +1,75 @@
+package io.github.nsreader.ui.account
+
+import androidx.annotation.StringRes
+import io.github.nsreader.R
+
+/**
+ * How strong a candidate password looks, on the four-step meter d6 draws.
+ *
+ * An app-side addition: NodeSeek's own settings page gives no live feedback at all. It is deliberately
+ * a *hint* and never a gate — the meter never blocks the save button, because the server owns the
+ * actual policy and a client-side rule that disagrees with it would reject passwords the site accepts.
+ */
+enum class PasswordStrength(
+    val filledBars: Int,
+    @StringRes val labelRes: Int,
+) {
+    Weak(1, R.string.account_password_strength_weak),
+    Fair(2, R.string.account_password_strength_fair),
+    Strong(3, R.string.account_password_strength_strong),
+    Best(4, R.string.account_password_strength_best),
+    ;
+
+    /** What would move the meter up, or that nothing needs to. */
+    @get:StringRes
+    val hintRes: Int
+        get() =
+            when (this) {
+                Weak -> R.string.account_password_strength_hint_length
+                Fair, Strong -> R.string.account_password_strength_hint_variety
+                Best -> R.string.account_password_strength_hint_done
+            }
+
+    companion object {
+        const val TOTAL_BARS = 4
+    }
+}
+
+/**
+ * Length and character variety, weighted so that length can win.
+ *
+ * Not an entropy estimate and not a dictionary check: those need a wordlist this app has no reason to
+ * ship, and the meter's job is to stop `qwerty123` reading the same as a passphrase, which two cheap
+ * signals already do.
+ *
+ * Length is worth one more step than variety, deliberately. Weighting them equally scored a
+ * twenty-five character passphrase the same as `aB1!`, which inverts the advice the meter exists to
+ * give — the four-character one is trivially brute-forced and the passphrase is not.
+ */
+fun passwordStrength(password: String): PasswordStrength? {
+    if (password.isEmpty()) return null
+
+    val classes =
+        listOf(
+            password.any { it.isLowerCase() },
+            password.any { it.isUpperCase() },
+            password.any { it.isDigit() },
+            password.any { !it.isLetterOrDigit() && !it.isWhitespace() },
+        ).count { it }
+
+    val lengthPoints = LENGTH_STEPS.count { password.length >= it }
+    val varietyPoints = classes - 1
+
+    return when (lengthPoints + varietyPoints) {
+        in 6..MAX_SCORE -> PasswordStrength.Best
+        in 4..5 -> PasswordStrength.Strong
+        in 2..3 -> PasswordStrength.Fair
+        else -> PasswordStrength.Weak
+    }
+}
+
+/** The one rule the app does enforce, so an obviously-doomed request is not sent at all. */
+const val MIN_PASSWORD_LENGTH = 8
+
+private val LENGTH_STEPS = listOf(8, 12, 16, 20)
+private const val MAX_SCORE = 7

--- a/app/src/main/java/io/github/nsreader/ui/account/ProfileFieldsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/ProfileFieldsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -45,14 +46,17 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nsreader.R
+import io.github.nsreader.ui.common.MARKDOWN_LINK_CARET
+import io.github.nsreader.ui.common.MARKDOWN_LINK_SUFFIX
+import io.github.nsreader.ui.common.MarkdownInsertion
 import io.github.nsreader.ui.common.NodeSeekIcons
 import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.common.applyMarkdown
 import io.github.nsreader.ui.theme.NodeSeekTheme
 import io.github.nsreader.ui.theme.Spacing
 import io.github.nsreader.ui.theme.readableWidth
@@ -142,6 +146,10 @@ fun ProfileFieldsScreen(
                 .fillMaxSize()
                 .readableWidth()
                 .verticalScroll(rememberScrollState())
+                // Edge-to-edge makes API 30+ ignore the manifest's adjustResize, and Scaffold's
+                // default insets exclude the IME, so without this the keyboard covers Readme with
+                // no way to scroll it back into view. Same call the post composer makes.
+                .imePadding()
                 .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
             verticalArrangement = Arrangement.spacedBy(Spacing.lg),
         ) {
@@ -358,7 +366,7 @@ private fun MarkdownField(
                     val description = stringResource(format.descriptionRes)
                     IconButton(
                         onClick = {
-                            fieldValue = applySignatureFormat(fieldValue, format)
+                            fieldValue = fieldValue.applyMarkdown(format.insertion)
                             onValueChange(fieldValue.text)
                         },
                         modifier = Modifier.semantics { contentDescription = description },
@@ -371,38 +379,32 @@ private fun MarkdownField(
     }
 }
 
-/** Bold, italic, strikethrough, link, inline code — and deliberately nothing else. */
-private enum class SignatureFormat(val glyph: String, val descriptionRes: Int) {
-    Bold("B", R.string.account_format_bold),
-    Italic("I", R.string.account_format_italic),
-    Strikethrough("S", R.string.account_format_strikethrough),
-    Link("↗", R.string.account_format_link),
-    Code("</>", R.string.account_format_code),
-}
-
-private fun applySignatureFormat(value: TextFieldValue, format: SignatureFormat): TextFieldValue {
-    val start = value.selection.min.coerceIn(0, value.text.length)
-    val end = value.selection.max.coerceIn(0, value.text.length)
-    val selected = value.text.substring(start, end)
-    val (replacement, cursorOffset) =
-        when (format) {
-            SignatureFormat.Bold ->
-                "**${selected.ifEmpty { "加粗文字" }}**" to if (selected.isEmpty()) 2 else selected.length + 4
-
-            SignatureFormat.Italic ->
-                "*${selected.ifEmpty { "斜体文字" }}*" to if (selected.isEmpty()) 1 else selected.length + 2
-
-            SignatureFormat.Strikethrough ->
-                "~~${selected.ifEmpty { "删除线" }}~~" to if (selected.isEmpty()) 2 else selected.length + 4
-
-            SignatureFormat.Link ->
-                "[${selected.ifEmpty { "链接文字" }}](https://)" to if (selected.isEmpty()) 1 else selected.length + 3
-
-            SignatureFormat.Code ->
-                "`${selected.ifEmpty { "code" }}`" to if (selected.isEmpty()) 1 else selected.length + 2
-        }
-    val text = value.text.replaceRange(start, end, replacement)
-    return TextFieldValue(text, TextRange((start + cursorOffset).coerceIn(0, text.length)))
+/**
+ * Bold, italic, strikethrough, link, inline code — and deliberately nothing else.
+ *
+ * The absent actions are the point: NodeSeek's own helper text says a signature supports neither
+ * images nor quotes. The insertion mechanics come from [applyMarkdown], shared with the post
+ * composer, so only the *set* differs between the two editors.
+ */
+private enum class SignatureFormat(
+    val glyph: String,
+    val descriptionRes: Int,
+    val insertion: MarkdownInsertion,
+) {
+    Bold("B", R.string.account_format_bold, MarkdownInsertion("**", "**", "加粗文字")),
+    Italic("I", R.string.account_format_italic, MarkdownInsertion("*", "*", "斜体文字")),
+    Strikethrough("S", R.string.account_format_strikethrough, MarkdownInsertion("~~", "~~", "删除线")),
+    Link(
+        "↗",
+        R.string.account_format_link,
+        MarkdownInsertion(
+            prefix = "[",
+            suffix = MARKDOWN_LINK_SUFFIX,
+            placeholder = "链接文字",
+            caretInSuffix = MARKDOWN_LINK_CARET,
+        ),
+    ),
+    Code("</>", R.string.account_format_code, MarkdownInsertion("`", "`", "code")),
 }
 
 private val AVATAR_SIZE = 84.dp

--- a/app/src/main/java/io/github/nsreader/ui/account/ProfileFieldsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/ProfileFieldsScreen.kt
@@ -1,0 +1,441 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun ProfileFieldsRoute(
+    viewModel: ProfileFieldsViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val messageText = state.message?.let { accountMessageText(it) }
+
+    LaunchedEffect(state.message, messageText) {
+        if (messageText == null) return@LaunchedEffect
+        snackbarHostState.showSnackbar(messageText)
+        viewModel.consumeMessage()
+    }
+
+    ProfileFieldsScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onBioChange = viewModel::updateBio,
+        onSignatureChange = viewModel::updateSignature,
+        onReadmeChange = viewModel::updateReadme,
+        onAvatarPicked = viewModel::setPendingAvatar,
+        onAvatarFailed = viewModel::reportAvatarFailure,
+        onAvatarRemove = viewModel::removeAvatar,
+        onSave = viewModel::save,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 个人信息 (d6 1/4).
+ *
+ * The signature editor's toolbar is the detail worth protecting: five actions, no image and no quote,
+ * because NodeSeek's own helper text says signatures do not support either. Offering the buttons and
+ * letting the server drop the markup is the failure mode this screen exists to avoid — the reduced
+ * toolbar *is* the documentation.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileFieldsScreen(
+    state: ProfileFieldsUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onBioChange: (String) -> Unit,
+    onSignatureChange: (String) -> Unit,
+    onReadmeChange: (String) -> Unit,
+    onAvatarPicked: (PendingAvatar) -> Unit,
+    onAvatarFailed: () -> Unit,
+    onAvatarRemove: () -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var confirmingAvatarRemoval by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.account_profile_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(onClick = onSave, enabled = state.canSave) {
+                        Text(stringResource(R.string.account_action_save))
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier =
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.lg),
+        ) {
+            if (state.endpointPending) EndpointPendingBanner()
+
+            AvatarEditor(
+                state = state,
+                onPicked = onAvatarPicked,
+                onFailed = onAvatarFailed,
+                onRemoveRequested = { confirmingAvatarRemoval = true },
+            )
+
+            OutlinedTextField(
+                value = state.bio,
+                onValueChange = onBioChange,
+                label = { Text(stringResource(R.string.account_bio)) },
+                placeholder = { Text(stringResource(R.string.account_bio_hint)) },
+                singleLine = true,
+                shape = AccountFieldShape,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                MarkdownField(
+                    value = state.signature,
+                    onValueChange = onSignatureChange,
+                    label = stringResource(R.string.account_signature),
+                    minLines = SIGNATURE_MIN_LINES,
+                )
+                AccountFieldHelper(stringResource(R.string.account_signature_helper))
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                OutlinedTextField(
+                    value = state.readme,
+                    onValueChange = onReadmeChange,
+                    label = { Text(stringResource(R.string.account_readme)) },
+                    minLines = README_MIN_LINES,
+                    shape = AccountFieldShape,
+                    textStyle = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                AccountFieldHelper(stringResource(R.string.account_readme_helper))
+            }
+        }
+    }
+
+    if (confirmingAvatarRemoval) {
+        HighRiskDialog(
+            icon = Icons.Default.Delete,
+            title = stringResource(R.string.account_confirm_avatar_remove_title),
+            body = stringResource(R.string.account_confirm_avatar_remove_body),
+            confirmLabel = stringResource(R.string.account_confirm_avatar_remove_action),
+            destructive = true,
+            onConfirm = {
+                confirmingAvatarRemoval = false
+                onAvatarRemove()
+            },
+            onDismiss = { confirmingAvatarRemoval = false },
+        )
+    }
+}
+
+/**
+ * The avatar, its camera badge, and the menu the badge opens.
+ *
+ * A menu rather than a bottom sheet: three items, one of which is destructive, anchored to the thing
+ * they act on. A sheet would cover the avatar the user is trying to change.
+ */
+@Composable
+private fun AvatarEditor(
+    state: ProfileFieldsUiState,
+    onPicked: (PendingAvatar) -> Unit,
+    onFailed: () -> Unit,
+    onRemoveRequested: () -> Unit,
+) {
+    var menuOpen by remember { mutableStateOf(false) }
+    val picker = rememberAvatarPicker(onPicked = onPicked, onFailed = onFailed)
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.lg),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(contentAlignment = Alignment.BottomEnd) {
+            val pending = state.pendingAvatar
+            if (pending == null) {
+                UserAvatar(
+                    url = state.avatarUrl,
+                    name = state.displayName,
+                    size = AVATAR_SIZE,
+                )
+            } else {
+                Image(
+                    bitmap = pending.preview,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.size(AVATAR_SIZE).clip(CircleShape),
+                )
+            }
+            Box(Modifier.offset(x = AVATAR_BADGE_OVERHANG, y = AVATAR_BADGE_OVERHANG)) {
+                Surface(
+                    onClick = { menuOpen = true },
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    // The ring is the page background, so the badge reads as sitting on top of the
+                    // avatar rather than being a hole punched in it.
+                    modifier =
+                    Modifier
+                        .size(AVATAR_BADGE_SIZE)
+                        .background(MaterialTheme.colorScheme.surface, CircleShape)
+                        .padding(3.dp),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            NodeSeekIcons.PhotoCamera,
+                            contentDescription = stringResource(R.string.account_avatar_change),
+                            modifier = Modifier.size(15.dp),
+                        )
+                    }
+                }
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.account_avatar_take_photo)) },
+                        leadingIcon = { Icon(NodeSeekIcons.PhotoCamera, contentDescription = null) },
+                        onClick = {
+                            menuOpen = false
+                            picker.takePhoto()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.account_avatar_pick)) },
+                        leadingIcon = { Icon(NodeSeekIcons.Image, contentDescription = null) },
+                        onClick = {
+                            menuOpen = false
+                            picker.pickImage()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = {
+                            Text(
+                                stringResource(R.string.account_avatar_remove),
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        leadingIcon = {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        onClick = {
+                            menuOpen = false
+                            onRemoveRequested()
+                        },
+                    )
+                }
+            }
+        }
+
+        if (state.pendingAvatar != null) {
+            Text(
+                stringResource(R.string.account_avatar_pending),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+/**
+ * A Markdown field with the five formatting actions a signature is allowed.
+ *
+ * The glyph labels rather than icons match the post composer's toolbar, which made the same call for
+ * the same reason: `material-icons-core` ships none of `format_bold`, `format_italic` or
+ * `strikethrough_s`, and hand-drawing three vectors to say what "B" and "I" already say is a poor
+ * trade. Each button still carries a spoken description.
+ */
+@Composable
+private fun MarkdownField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    minLines: Int,
+) {
+    // Held here rather than in the ViewModel: the selection is a property of this text field, and the
+    // formatting buttons are the only thing that reads it.
+    var fieldValue by remember { mutableStateOf(TextFieldValue(value)) }
+    if (fieldValue.text != value) {
+        fieldValue = fieldValue.copy(text = value)
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        OutlinedTextField(
+            value = fieldValue,
+            onValueChange = {
+                fieldValue = it
+                onValueChange(it.text)
+            },
+            label = { Text(label) },
+            minLines = minLines,
+            shape = AccountFieldShape,
+            textStyle = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
+        ) {
+            Row(Modifier.padding(2.dp)) {
+                SignatureFormat.entries.forEach { format ->
+                    val description = stringResource(format.descriptionRes)
+                    IconButton(
+                        onClick = {
+                            fieldValue = applySignatureFormat(fieldValue, format)
+                            onValueChange(fieldValue.text)
+                        },
+                        modifier = Modifier.semantics { contentDescription = description },
+                    ) {
+                        Text(format.glyph, style = MaterialTheme.typography.labelLarge)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Bold, italic, strikethrough, link, inline code — and deliberately nothing else. */
+private enum class SignatureFormat(val glyph: String, val descriptionRes: Int) {
+    Bold("B", R.string.account_format_bold),
+    Italic("I", R.string.account_format_italic),
+    Strikethrough("S", R.string.account_format_strikethrough),
+    Link("↗", R.string.account_format_link),
+    Code("</>", R.string.account_format_code),
+}
+
+private fun applySignatureFormat(value: TextFieldValue, format: SignatureFormat): TextFieldValue {
+    val start = value.selection.min.coerceIn(0, value.text.length)
+    val end = value.selection.max.coerceIn(0, value.text.length)
+    val selected = value.text.substring(start, end)
+    val (replacement, cursorOffset) =
+        when (format) {
+            SignatureFormat.Bold ->
+                "**${selected.ifEmpty { "加粗文字" }}**" to if (selected.isEmpty()) 2 else selected.length + 4
+
+            SignatureFormat.Italic ->
+                "*${selected.ifEmpty { "斜体文字" }}*" to if (selected.isEmpty()) 1 else selected.length + 2
+
+            SignatureFormat.Strikethrough ->
+                "~~${selected.ifEmpty { "删除线" }}~~" to if (selected.isEmpty()) 2 else selected.length + 4
+
+            SignatureFormat.Link ->
+                "[${selected.ifEmpty { "链接文字" }}](https://)" to if (selected.isEmpty()) 1 else selected.length + 3
+
+            SignatureFormat.Code ->
+                "`${selected.ifEmpty { "code" }}`" to if (selected.isEmpty()) 1 else selected.length + 2
+        }
+    val text = value.text.replaceRange(start, end, replacement)
+    return TextFieldValue(text, TextRange((start + cursorOffset).coerceIn(0, text.length)))
+}
+
+private val AVATAR_SIZE = 84.dp
+private val AVATAR_BADGE_SIZE = 30.dp
+
+/** The badge straddles the avatar's edge rather than sitting inside it, as the design shows. */
+private val AVATAR_BADGE_OVERHANG = 4.dp
+private const val SIGNATURE_MIN_LINES = 3
+private const val README_MIN_LINES = 5
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun ProfileFieldsPreview() {
+    NodeSeekTheme {
+        ProfileFieldsScreen(
+            state =
+            ProfileFieldsUiState(
+                isLoading = false,
+                endpointPending = true,
+                displayName = "花间一壶酒",
+                bio = "常驻杭州",
+                signature = "**出杭州腾讯云轻量** · 长期收闲置小鸡 · 交易走 [星辰担保](https://ns.run/dan)",
+                readme = "### 关于我\n爱折腾的 MJJ 一枚，主力小鸡在 HK。\n- 交易一律走星辰担保，勿私",
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBack = {},
+            onBioChange = {},
+            onSignatureChange = {},
+            onReadmeChange = {},
+            onAvatarPicked = {},
+            onAvatarFailed = {},
+            onAvatarRemove = {},
+            onSave = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/ProfileFieldsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/ProfileFieldsViewModel.kt
@@ -1,0 +1,197 @@
+package io.github.nsreader.ui.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.R
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.account.AccountProfileFields
+import io.github.nsreader.data.account.AccountSettingsRepository
+import io.github.nsreader.data.account.EndpointNotVerifiedException
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * State holder for 个人信息 (d6 1/4) — avatar, Bio, 签名 and Readme.
+ *
+ * The three text fields are one form with one save button because the site treats them as one group,
+ * and splitting them would mean three chances to half-save. The avatar is separate: it is uploaded as
+ * its own request and removed as its own request, so it gets its own confirmation and its own result.
+ */
+class ProfileFieldsViewModel(
+    private val account: AccountSettingsRepository,
+    private val profiles: ProfileRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ProfileFieldsUiState())
+    val uiState: StateFlow<ProfileFieldsUiState> = _uiState.asStateFlow()
+
+    private var saveJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            runCatchingExceptCancellation { profiles.profile() }
+                .onSuccess { profile ->
+                    _uiState.update {
+                        it.copy(avatarUrl = profile.avatarUrl, displayName = profile.name)
+                    }
+                }
+
+            runCatchingExceptCancellation { account.profileFields() }
+                .onSuccess { fields ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            saved = fields,
+                            bio = fields.bio,
+                            signature = fields.signature,
+                            readme = fields.readme,
+                        )
+                    }
+                }.onFailure { throwable ->
+                    // A pending endpoint is stated once, by the banner. Raising a snackbar for it as
+                    // well would fire on every entry to the screen and say the same thing worse.
+                    val pending = throwable is EndpointNotVerifiedException
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            endpointPending = pending,
+                            message =
+                            if (pending) {
+                                null
+                            } else {
+                                throwable.toAccountMessage(R.string.account_profile_title)
+                            },
+                        )
+                    }
+                }
+        }
+    }
+
+    fun updateBio(value: String) {
+        // Bio is one line on the site; a pasted paragraph would be silently truncated server-side.
+        _uiState.update { it.copy(bio = value.replace('\n', ' ')) }
+    }
+
+    fun updateSignature(value: String) = _uiState.update { it.copy(signature = value) }
+
+    fun updateReadme(value: String) = _uiState.update { it.copy(readme = value) }
+
+    fun setPendingAvatar(avatar: PendingAvatar) =
+        _uiState.update { it.copy(pendingAvatar = avatar, message = null) }
+
+    fun reportAvatarFailure() =
+        _uiState.update { it.copy(message = AccountMessage.Info(R.string.account_avatar_failed)) }
+
+    fun removeAvatar() {
+        viewModelScope.launch {
+            runCatchingExceptCancellation { account.removeAvatar() }
+                .onSuccess {
+                    _uiState.update { it.copy(pendingAvatar = null, avatarUrl = null) }
+                }.onFailure { throwable ->
+                    _uiState.update {
+                        it.copy(message = throwable.toAccountMessage(R.string.account_avatar_remove))
+                    }
+                }
+        }
+    }
+
+    fun save() {
+        if (saveJob?.isActive == true) return
+        saveJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isSaving = true, message = null) }
+                val current = _uiState.value
+                val fields =
+                    AccountProfileFields(
+                        bio = current.bio.trim(),
+                        signature = current.signature.trim(),
+                        readme = current.readme.trim(),
+                    )
+
+                // The avatar goes first: if it fails there is no point writing the text fields and
+                // reporting success, and if the text fields fail the avatar is still worth keeping.
+                val avatarResult =
+                    current.pendingAvatar?.let { pending ->
+                        runCatchingExceptCancellation { account.uploadAvatar(pending.upload) }
+                    }
+                if (avatarResult?.isFailure == true) {
+                    _uiState.update {
+                        it.copy(
+                            isSaving = false,
+                            message =
+                            avatarResult.exceptionOrNull()!!
+                                .toAccountMessage(R.string.account_avatar_change),
+                        )
+                    }
+                    return@launch
+                }
+
+                runCatchingExceptCancellation { account.saveProfileFields(fields) }
+                    .onSuccess {
+                        _uiState.update {
+                            it.copy(
+                                isSaving = false,
+                                saved = fields,
+                                pendingAvatar = null,
+                                message = AccountMessage.Info(R.string.account_action_saved),
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(
+                                isSaving = false,
+                                message = throwable.toAccountMessage(R.string.account_profile_title),
+                            )
+                        }
+                    }
+            }
+    }
+
+    fun consumeMessage() = _uiState.update { it.copy(message = null) }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    ProfileFieldsViewModel(
+                        account = container.accountSettingsRepository,
+                        profiles = container.profileRepository,
+                    )
+                }
+            }
+    }
+}
+
+data class ProfileFieldsUiState(
+    val isLoading: Boolean = true,
+    val isSaving: Boolean = false,
+    val endpointPending: Boolean = false,
+    val avatarUrl: String? = null,
+    val displayName: String = "",
+    val pendingAvatar: PendingAvatar? = null,
+    val bio: String = "",
+    val signature: String = "",
+    val readme: String = "",
+    /** What the server last confirmed, so the save button knows whether anything actually changed. */
+    val saved: AccountProfileFields? = null,
+    val message: AccountMessage? = null,
+) {
+    val isDirty: Boolean
+        get() {
+            if (pendingAvatar != null) return true
+            val baseline = saved ?: AccountProfileFields()
+            return bio.trim() != baseline.bio ||
+                signature.trim() != baseline.signature ||
+                readme.trim() != baseline.readme
+        }
+
+    val canSave: Boolean get() = isDirty && !isSaving
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/SecurityScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/SecurityScreen.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -38,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,7 +56,7 @@ import io.github.nsreader.ui.theme.readableWidth
 fun SecurityRoute(
     viewModel: SecurityViewModel,
     onBack: () -> Unit,
-    onOpenEnrolmentUri: (String) -> Unit,
+    onOpenEnrolmentUri: (String) -> Boolean,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -70,8 +73,9 @@ fun SecurityRoute(
     // secret, which is the entire reason to pass the URI straight through rather than render the code.
     LaunchedEffect(state.enrolmentUri) {
         val uri = state.enrolmentUri ?: return@LaunchedEffect
-        onOpenEnrolmentUri(uri)
+        val opened = onOpenEnrolmentUri(uri)
         viewModel.consumeEnrolmentUri()
+        if (!opened) viewModel.reportMissingAuthenticatorApp()
     }
 
     SecurityScreen(
@@ -143,6 +147,9 @@ fun SecurityScreen(
                 .fillMaxSize()
                 .readableWidth()
                 .verticalScroll(rememberScrollState())
+                // See ProfileFieldsScreen: edge-to-edge plus Scaffold's IME-free insets would leave
+                // 确认新密码 under the keyboard and unreachable.
+                .imePadding()
                 .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
             verticalArrangement = Arrangement.spacedBy(Spacing.md),
         ) {
@@ -253,6 +260,11 @@ private fun PasswordField(
         singleLine = true,
         isError = isError,
         supportingText = supportingText?.let { { Text(it) } },
+        // `PasswordVisualTransformation` only masks what is drawn. Without the password keyboard type
+        // a third-party IME — which on this forum's audience is essentially everyone — keeps
+        // autocorrecting and learning, so a new password can end up in the IME's personal dictionary
+        // and be suggested elsewhere. That would undo the point of this screen.
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
         visualTransformation =
         if (visible) VisualTransformation.None else PasswordVisualTransformation(),
         shape = AccountFieldShape,

--- a/app/src/main/java/io/github/nsreader/ui/account/SecurityScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/SecurityScreen.kt
@@ -1,0 +1,412 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun SecurityRoute(
+    viewModel: SecurityViewModel,
+    onBack: () -> Unit,
+    onOpenEnrolmentUri: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val messageText = state.message?.let { accountMessageText(it) }
+
+    LaunchedEffect(state.message, messageText) {
+        if (messageText == null) return@LaunchedEffect
+        snackbarHostState.showSnackbar(messageText)
+        viewModel.consumeMessage()
+    }
+
+    // Enrolment hands off to whichever authenticator app claims `otpauth://`; the app never stores the
+    // secret, which is the entire reason to pass the URI straight through rather than render the code.
+    LaunchedEffect(state.enrolmentUri) {
+        val uri = state.enrolmentUri ?: return@LaunchedEffect
+        onOpenEnrolmentUri(uri)
+        viewModel.consumeEnrolmentUri()
+    }
+
+    SecurityScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        onBack = onBack,
+        onCurrentPasswordChange = viewModel::updateCurrentPassword,
+        onNewPasswordChange = viewModel::updateNewPassword,
+        onRepeatPasswordChange = viewModel::updateConfirmPassword,
+        onToggleCurrentVisible = viewModel::toggleCurrentVisible,
+        onToggleNewVisible = viewModel::toggleNewVisible,
+        onToggleConfirmVisible = viewModel::toggleConfirmVisible,
+        onRequestPasswordChange = viewModel::requestPasswordChange,
+        onRequestTwoFactor = viewModel::requestTwoFactorEnrolment,
+        onDismissConfirmation = viewModel::dismissConfirmation,
+        onConfirmPasswordChange = viewModel::confirmPasswordChange,
+        onConfirmTwoFactor = viewModel::confirmTwoFactorEnrolment,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 安全 (d6 2/4) — 修改密码 and 两步验证.
+ *
+ * Both actions confirm twice by design. Changing a password signs every other device out and binding
+ * a second factor can lock the account if the authenticator is lost, and neither is undoable from
+ * inside this app; a dialog that names the consequence is cheap next to that.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SecurityScreen(
+    state: SecurityUiState,
+    snackbarHostState: SnackbarHostState,
+    onBack: () -> Unit,
+    onCurrentPasswordChange: (String) -> Unit,
+    onNewPasswordChange: (String) -> Unit,
+    onRepeatPasswordChange: (String) -> Unit,
+    onToggleCurrentVisible: () -> Unit,
+    onToggleNewVisible: () -> Unit,
+    onToggleConfirmVisible: () -> Unit,
+    onRequestPasswordChange: () -> Unit,
+    onRequestTwoFactor: () -> Unit,
+    onDismissConfirmation: () -> Unit,
+    onConfirmPasswordChange: () -> Unit,
+    onConfirmTwoFactor: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.account_security_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier =
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            if (state.endpointPending) EndpointPendingBanner()
+
+            AccountSectionLabel(stringResource(R.string.account_change_password))
+
+            PasswordField(
+                value = state.currentPassword,
+                onValueChange = onCurrentPasswordChange,
+                label = stringResource(R.string.account_password_current),
+                visible = state.currentVisible,
+                onToggleVisible = onToggleCurrentVisible,
+            )
+
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                PasswordField(
+                    value = state.newPassword,
+                    onValueChange = onNewPasswordChange,
+                    label = stringResource(R.string.account_password_new),
+                    visible = state.newVisible,
+                    onToggleVisible = onToggleNewVisible,
+                    isError = state.isTooShort,
+                    supportingText =
+                    if (state.isTooShort) {
+                        stringResource(R.string.account_password_too_short, MIN_PASSWORD_LENGTH)
+                    } else {
+                        null
+                    },
+                )
+                state.strength?.let { StrengthMeter(it) }
+            }
+
+            PasswordField(
+                value = state.confirmPassword,
+                onValueChange = onRepeatPasswordChange,
+                label = stringResource(R.string.account_password_confirm),
+                placeholder = stringResource(R.string.account_password_confirm_hint),
+                visible = state.confirmVisible,
+                onToggleVisible = onToggleConfirmVisible,
+                isError = state.isMismatched,
+                supportingText =
+                if (state.isMismatched) stringResource(R.string.account_password_mismatch) else null,
+            )
+
+            Button(
+                onClick = onRequestPasswordChange,
+                enabled = state.canSubmitPassword,
+                shape = RoundedCornerShape(23.dp),
+                modifier = Modifier.fillMaxWidth().height(46.dp),
+            ) {
+                Text(stringResource(R.string.account_password_update))
+            }
+
+            AccountSectionLabel(
+                text = stringResource(R.string.account_two_factor_section),
+                modifier = Modifier.padding(top = Spacing.sm),
+            )
+            TwoFactorCard(
+                enabled = state.twoFactorEnabled,
+                busy = state.isSubmitting,
+                onBind = onRequestTwoFactor,
+            )
+        }
+    }
+
+    when (state.confirming) {
+        SecurityConfirmation.Password ->
+            HighRiskDialog(
+                icon = Icons.Default.Lock,
+                title = stringResource(R.string.account_confirm_password_title),
+                body = stringResource(R.string.account_confirm_password_body),
+                confirmLabel = stringResource(R.string.account_confirm_password_action),
+                onConfirm = onConfirmPasswordChange,
+                onDismiss = onDismissConfirmation,
+            )
+
+        SecurityConfirmation.TwoFactor ->
+            HighRiskDialog(
+                icon = NodeSeekIcons.Shield,
+                title = stringResource(R.string.account_confirm_2fa_title),
+                body = stringResource(R.string.account_confirm_2fa_body),
+                confirmLabel = stringResource(R.string.account_confirm_2fa_action),
+                onConfirm = onConfirmTwoFactor,
+                onDismiss = onDismissConfirmation,
+            )
+
+        null -> Unit
+    }
+}
+
+@Composable
+private fun PasswordField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    visible: Boolean,
+    onToggleVisible: () -> Unit,
+    placeholder: String? = null,
+    isError: Boolean = false,
+    supportingText: String? = null,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        placeholder = placeholder?.let { { Text(it) } },
+        singleLine = true,
+        isError = isError,
+        supportingText = supportingText?.let { { Text(it) } },
+        visualTransformation =
+        if (visible) VisualTransformation.None else PasswordVisualTransformation(),
+        shape = AccountFieldShape,
+        trailingIcon = {
+            IconButton(onClick = onToggleVisible) {
+                Icon(
+                    imageVector = if (visible) NodeSeekIcons.VisibilityOff else NodeSeekIcons.Visibility,
+                    contentDescription =
+                    stringResource(
+                        if (visible) R.string.account_password_hide else R.string.account_password_show,
+                    ),
+                )
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+/** Four bars and one line of advice — the meter is guidance, never a gate. See [passwordStrength]. */
+@Composable
+private fun StrengthMeter(strength: PasswordStrength) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            modifier = Modifier.padding(horizontal = Spacing.xs),
+        ) {
+            repeat(PasswordStrength.TOTAL_BARS) { index ->
+                val color by animateColorAsState(
+                    targetValue =
+                    if (index < strength.filledBars) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerHighest
+                    },
+                    label = "strength_bar_$index",
+                )
+                Box(
+                    Modifier
+                        .weight(1f)
+                        .height(6.dp)
+                        .clip(RoundedCornerShape(3.dp))
+                        .background(color),
+                )
+            }
+        }
+        Text(
+            text =
+            stringResource(R.string.account_password_strength, stringResource(strength.labelRes)) +
+                " · " + stringResource(strength.hintRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = Spacing.xs),
+        )
+    }
+}
+
+@Composable
+private fun TwoFactorCard(
+    enabled: Boolean?,
+    busy: Boolean,
+    onBind: () -> Unit,
+) {
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+            ) {
+                Icon(
+                    NodeSeekIcons.Shield,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(24.dp),
+                )
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        stringResource(R.string.account_two_factor_totp),
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                    )
+                    Text(
+                        text =
+                        stringResource(
+                            when (enabled) {
+                                true -> R.string.account_two_factor_on_hint
+                                false -> R.string.account_two_factor_off_hint
+                                null -> R.string.account_value_unknown
+                            },
+                        ),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Text(
+                stringResource(R.string.account_two_factor_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Button(
+                onClick = onBind,
+                enabled = !busy,
+                shape = RoundedCornerShape(20.dp),
+            ) {
+                Icon(NodeSeekIcons.QrCode, contentDescription = null, modifier = Modifier.size(17.dp))
+                Text(
+                    text =
+                    stringResource(
+                        if (enabled == true) {
+                            R.string.account_two_factor_rebind
+                        } else {
+                            R.string.account_two_factor_bind
+                        },
+                    ),
+                    modifier = Modifier.padding(start = Spacing.sm),
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun SecurityPreview() {
+    NodeSeekTheme {
+        SecurityScreen(
+            state =
+            SecurityUiState(
+                isLoading = false,
+                endpointPending = true,
+                twoFactorEnabled = false,
+                currentPassword = "hunter2hunter2",
+                newPassword = "Correct-Horse-9",
+                confirmPassword = "Correct-Horse-9",
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBack = {},
+            onCurrentPasswordChange = {},
+            onNewPasswordChange = {},
+            onRepeatPasswordChange = {},
+            onToggleCurrentVisible = {},
+            onToggleNewVisible = {},
+            onToggleConfirmVisible = {},
+            onRequestPasswordChange = {},
+            onRequestTwoFactor = {},
+            onDismissConfirmation = {},
+            onConfirmPasswordChange = {},
+            onConfirmTwoFactor = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/SecurityViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/SecurityViewModel.kt
@@ -1,0 +1,172 @@
+package io.github.nsreader.ui.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.R
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.account.AccountSettingsRepository
+import io.github.nsreader.data.account.EndpointNotVerifiedException
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * State holder for 安全 (d6 2/4) — password changes and two-factor enrolment.
+ *
+ * The two riskiest writes in the app live here, so both are two-step: the button only opens a dialog,
+ * and only the dialog's confirm actually calls the repository. Nothing on this screen is a switch.
+ */
+class SecurityViewModel(
+    private val account: AccountSettingsRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(SecurityUiState())
+    val uiState: StateFlow<SecurityUiState> = _uiState.asStateFlow()
+
+    private var submitJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            runCatchingExceptCancellation { account.twoFactor() }
+                .onSuccess { two ->
+                    _uiState.update { it.copy(isLoading = false, twoFactorEnabled = two.enabled) }
+                }.onFailure { throwable ->
+                    val pending = throwable is EndpointNotVerifiedException
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            endpointPending = pending,
+                            message =
+                            if (pending) {
+                                null
+                            } else {
+                                throwable.toAccountMessage(R.string.account_security_title)
+                            },
+                        )
+                    }
+                }
+        }
+    }
+
+    fun updateCurrentPassword(value: String) = _uiState.update { it.copy(currentPassword = value) }
+
+    fun updateNewPassword(value: String) = _uiState.update { it.copy(newPassword = value) }
+
+    fun updateConfirmPassword(value: String) = _uiState.update { it.copy(confirmPassword = value) }
+
+    fun toggleCurrentVisible() = _uiState.update { it.copy(currentVisible = !it.currentVisible) }
+
+    fun toggleNewVisible() = _uiState.update { it.copy(newVisible = !it.newVisible) }
+
+    fun toggleConfirmVisible() = _uiState.update { it.copy(confirmVisible = !it.confirmVisible) }
+
+    fun requestPasswordChange() = _uiState.update { it.copy(confirming = SecurityConfirmation.Password) }
+
+    fun requestTwoFactorEnrolment() = _uiState.update { it.copy(confirming = SecurityConfirmation.TwoFactor) }
+
+    fun dismissConfirmation() = _uiState.update { it.copy(confirming = null) }
+
+    fun confirmPasswordChange() {
+        if (submitJob?.isActive == true) return
+        val state = _uiState.value
+        if (!state.canSubmitPassword) return
+        submitJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(confirming = null, isSubmitting = true, message = null) }
+                runCatchingExceptCancellation {
+                    account.changePassword(state.currentPassword, state.newPassword)
+                }.onSuccess {
+                    // The fields are cleared on success and only on success: a failed attempt that
+                    // wipes what the user typed makes them re-enter three passwords to retry.
+                    _uiState.update {
+                        it.copy(
+                            isSubmitting = false,
+                            currentPassword = "",
+                            newPassword = "",
+                            confirmPassword = "",
+                            message = AccountMessage.Info(R.string.account_action_saved),
+                        )
+                    }
+                }.onFailure { throwable ->
+                    _uiState.update {
+                        it.copy(
+                            isSubmitting = false,
+                            message = throwable.toAccountMessage(R.string.account_change_password),
+                        )
+                    }
+                }
+            }
+    }
+
+    fun confirmTwoFactorEnrolment() {
+        if (submitJob?.isActive == true) return
+        submitJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(confirming = null, isSubmitting = true, message = null) }
+                runCatchingExceptCancellation { account.beginTwoFactorEnrolment() }
+                    .onSuccess { uri ->
+                        _uiState.update { it.copy(isSubmitting = false, enrolmentUri = uri) }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(
+                                isSubmitting = false,
+                                message = throwable.toAccountMessage(R.string.account_two_factor_bind),
+                            )
+                        }
+                    }
+            }
+    }
+
+    fun consumeEnrolmentUri() = _uiState.update { it.copy(enrolmentUri = null) }
+
+    fun consumeMessage() = _uiState.update { it.copy(message = null) }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { SecurityViewModel(container.accountSettingsRepository) }
+            }
+    }
+}
+
+/** Which high-risk dialog is open, if any. */
+enum class SecurityConfirmation { Password, TwoFactor }
+
+data class SecurityUiState(
+    val isLoading: Boolean = true,
+    val isSubmitting: Boolean = false,
+    val endpointPending: Boolean = false,
+    val twoFactorEnabled: Boolean? = null,
+    val currentPassword: String = "",
+    val newPassword: String = "",
+    val confirmPassword: String = "",
+    val currentVisible: Boolean = false,
+    val newVisible: Boolean = false,
+    val confirmVisible: Boolean = false,
+    val confirming: SecurityConfirmation? = null,
+    /** The `otpauth://` URI returned by enrolment, handed to whatever authenticator app claims it. */
+    val enrolmentUri: String? = null,
+    val message: AccountMessage? = null,
+) {
+    val strength: PasswordStrength? get() = passwordStrength(newPassword)
+
+    val isTooShort: Boolean
+        get() = newPassword.isNotEmpty() && newPassword.length < MIN_PASSWORD_LENGTH
+
+    /** Only once the user has actually typed a confirmation — nagging from the first keystroke is noise. */
+    val isMismatched: Boolean
+        get() = confirmPassword.isNotEmpty() && confirmPassword != newPassword
+
+    val canSubmitPassword: Boolean
+        get() =
+            !isSubmitting &&
+                currentPassword.isNotEmpty() &&
+                newPassword.length >= MIN_PASSWORD_LENGTH &&
+                confirmPassword == newPassword
+}

--- a/app/src/main/java/io/github/nsreader/ui/account/SecurityViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/account/SecurityViewModel.kt
@@ -125,6 +125,17 @@ class SecurityViewModel(
 
     fun consumeEnrolmentUri() = _uiState.update { it.copy(enrolmentUri = null) }
 
+    /**
+     * No installed app claims `otpauth://`.
+     *
+     * Worth saying out loud: the user pressed 开始绑定 and, without this, absolutely nothing happened —
+     * which reads as the app being broken rather than as a missing authenticator.
+     */
+    fun reportMissingAuthenticatorApp() =
+        _uiState.update {
+            it.copy(message = AccountMessage.Info(R.string.account_two_factor_no_app))
+        }
+
     fun consumeMessage() = _uiState.update { it.copy(message = null) }
 
     companion object {

--- a/app/src/main/java/io/github/nsreader/ui/common/BoardTag.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/BoardTag.kt
@@ -1,5 +1,6 @@
 package io.github.nsreader.ui.common
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -13,6 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.nsreader.R
 import io.github.nsreader.ui.theme.LocalNodeSeekExtraColors
 
 /**
@@ -24,20 +26,28 @@ import io.github.nsreader.ui.theme.LocalNodeSeekExtraColors
  * costs nothing in scanability.
  */
 @Immutable
-private data class TagColors(val container: Color, val content: Color)
+internal data class BoardFamilyColors(val container: Color, val content: Color)
 
-private enum class BoardFamily {
+/**
+ * Declaration order is the order the families are *shown* in, not an accident.
+ *
+ * The home-board picker lists all thirteen boards under these four headings and iterates
+ * [BoardFamily.entries] to do it, so reordering this enum reorders that screen.
+ */
+internal enum class BoardFamily(
+    @StringRes val labelRes: Int,
+) {
+    /** 日常 / 生活 / 贴图 / 无意义 / 沙盒 — everything else. */
+    Everyday(R.string.board_family_everyday),
+
     /** 技术 / Dev / 测评 / 情报 — the reason most people are here. */
-    Technical,
+    Technical(R.string.board_family_technical),
 
     /** 交易 / 拼车 / 推广 — money is changing hands. */
-    Trade,
-
-    /** 日常 / 生活 / 贴图 / 无意义 / 沙盒 — everything else. */
-    Everyday,
+    Trade(R.string.board_family_trade),
 
     /** 曝光 / 内版 — read these with more care than the rest. */
-    Flagged,
+    Flagged(R.string.board_family_flagged),
 }
 
 private val FAMILY_BY_SLUG =
@@ -78,15 +88,21 @@ private val FAMILY_BY_TITLE =
         "内版" to BoardFamily.Flagged,
     )
 
+/** The family a board belongs to; slug first, since the site renames boards more often than it re-keys them. */
+internal fun boardFamilyOf(slug: String?, title: String?): BoardFamily =
+    FAMILY_BY_SLUG[slug]
+        ?: FAMILY_BY_TITLE[title]
+        ?: BoardFamily.Everyday
+
 @Composable
-private fun colorsFor(family: BoardFamily): TagColors {
+internal fun boardFamilyColors(family: BoardFamily): BoardFamilyColors {
     val scheme = MaterialTheme.colorScheme
     val extra = LocalNodeSeekExtraColors.current
     return when (family) {
-        BoardFamily.Technical -> TagColors(scheme.primaryContainer, scheme.onPrimaryContainer)
-        BoardFamily.Trade -> TagColors(scheme.tertiaryContainer, scheme.onTertiaryContainer)
-        BoardFamily.Everyday -> TagColors(scheme.secondaryContainer, scheme.onSecondaryContainer)
-        BoardFamily.Flagged -> TagColors(extra.warningContainer, extra.onWarningContainer)
+        BoardFamily.Technical -> BoardFamilyColors(scheme.primaryContainer, scheme.onPrimaryContainer)
+        BoardFamily.Trade -> BoardFamilyColors(scheme.tertiaryContainer, scheme.onTertiaryContainer)
+        BoardFamily.Everyday -> BoardFamilyColors(scheme.secondaryContainer, scheme.onSecondaryContainer)
+        BoardFamily.Flagged -> BoardFamilyColors(extra.warningContainer, extra.onWarningContainer)
     }
 }
 
@@ -105,11 +121,7 @@ fun BoardTag(
 ) {
     if (title.isNullOrBlank()) return
 
-    val family =
-        FAMILY_BY_SLUG[slug]
-            ?: FAMILY_BY_TITLE[title]
-            ?: BoardFamily.Everyday
-    val colors = colorsFor(family)
+    val colors = boardFamilyColors(boardFamilyOf(slug, title))
 
     Text(
         text = title,

--- a/app/src/main/java/io/github/nsreader/ui/common/MarkdownFormatting.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/MarkdownFormatting.kt
@@ -1,0 +1,55 @@
+package io.github.nsreader.ui.common
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+
+/**
+ * One Markdown formatting action, described rather than implemented.
+ *
+ * Every editor in the app offers a different *set* of actions — the post composer has images and
+ * quotes, a signature is not allowed either — but they all insert text the same way, and the caret
+ * arithmetic is the part that silently rots when it is copied. Editors declare their own actions and
+ * share [applyMarkdown].
+ */
+internal data class MarkdownInsertion(
+    val prefix: String,
+    val suffix: String = "",
+    /** Inserted when nothing is selected, so the result is never a pair of bare delimiters. */
+    val placeholder: String,
+    /**
+     * Where the caret lands inside [suffix] once text was selected.
+     *
+     * Usually the end of the insertion, which is `suffix.length`. Link and image are the exceptions:
+     * they point at the URL slot, because with the text already written that is the only thing left
+     * to type.
+     */
+    val caretInSuffix: Int = suffix.length,
+)
+
+/**
+ * Applies [insertion] to the current selection and places the caret where typing continues.
+ *
+ * With nothing selected the caret goes just after the prefix, so the placeholder is sitting right
+ * there to be typed over. With a selection it goes to [MarkdownInsertion.caretInSuffix].
+ */
+internal fun TextFieldValue.applyMarkdown(insertion: MarkdownInsertion): TextFieldValue {
+    val start = selection.min.coerceIn(0, text.length)
+    val end = selection.max.coerceIn(0, text.length)
+    val selected = text.substring(start, end)
+
+    val body = selected.ifEmpty { insertion.placeholder }
+    val replacement = insertion.prefix + body + insertion.suffix
+    val caretOffset =
+        if (selected.isEmpty()) {
+            insertion.prefix.length
+        } else {
+            insertion.prefix.length + selected.length + insertion.caretInSuffix
+        }
+
+    val updated = text.replaceRange(start, end, replacement)
+    return TextFieldValue(updated, TextRange((start + caretOffset).coerceIn(0, updated.length)))
+}
+
+/** The URL slot in `](https://)`, i.e. just past the `](`. Shared by the link and image actions. */
+internal const val MARKDOWN_LINK_SUFFIX = "](https://)"
+internal const val MARKDOWN_LINK_CARET = 2

--- a/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
@@ -7,11 +7,15 @@ import androidx.compose.ui.graphics.vector.addPathNodes
 import androidx.compose.ui.unit.dp
 
 /**
- * The four Material Symbols the design uses that `material-icons-core` does not ship.
+ * The Material Symbols the design uses that `material-icons-core` does not ship.
  *
  * Declared here rather than pulling in `material-icons-extended`, which would add roughly two
  * thousand unused vectors — and, more to the point, a dependency-graph change that this project's
  * strict lockfile makes a separate, deliberate operation.
+ *
+ * The bar for adding one: the icon has to carry meaning a core icon cannot. 账号设置's `tune` became
+ * `Icons.Default.Settings` and `logout` became `ExitToApp` for exactly that reason, and the signature
+ * editor's format toolbar uses the same text glyphs the post composer already does.
  */
 object NodeSeekIcons {
     val History: ImageVector by lazy {
@@ -111,6 +115,116 @@ object NodeSeekIcons {
             "M15,3H6c-0.8,0 -1.5,0.5 -1.8,1.2L1.1,11.3C0.6,12.6 1.5,14 3,14h5.7" +
                 "l-1,4.6C7.5,19.4 8.1,20 8.8,20h0.4c0.4,0 0.8,-0.2 1.1,-0.5L16,13.8V5" +
                 "c0,-1.1 -0.9,-2 -2,-2zM18,3v11h4V3z",
+        )
+    }
+
+    /** Bio — the one-line self-introduction, on the 账号设置 list. */
+    val Badge: ImageVector by lazy {
+        materialIcon(
+            name = "Badge",
+            pathData =
+            "M20,7h-5V4c0,-1.1 -0.9,-2 -2,-2h-2c-1.1,0 -2,0.9 -2,2v3H4C2.9,7 2,7.9 2,9v11" +
+                "c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V9C22,7.9 21.1,7 20,7zM11,4h2v3h-2V4z" +
+                "M12,12.5c0.83,0 1.5,0.67 1.5,1.5s-0.67,1.5 -1.5,1.5s-1.5,-0.67 -1.5,-1.5" +
+                "S11.17,12.5 12,12.5zM15,18H9v-0.75c0,-1 1.34,-1.81 3,-1.81s3,0.81 3,1.81V18z",
+        )
+    }
+
+    /** Readme — the long Markdown block shown on a user's page. */
+    val Article: ImageVector by lazy {
+        materialIcon(
+            name = "Article",
+            pathData =
+            "M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3z" +
+                "M14,17H7v-2h7V17zM17,13H7v-2h10V13zM17,9H7V7h10V9z",
+        )
+    }
+
+    /** Two-factor authentication. */
+    val Shield: ImageVector by lazy {
+        materialIcon(
+            name = "Shield",
+            pathData = "M12,1L3,5v6c0,5.55 3.84,10.74 9,12c5.16,-1.26 9,-6.45 9,-12V5L12,1z",
+        )
+    }
+
+    /** The blocked-user list, and the empty state that goes with it. */
+    val Block: ImageVector by lazy {
+        materialIcon(
+            name = "Block",
+            pathData =
+            "M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10s10,-4.48 10,-10S17.52,2 12,2z" +
+                "M4,12c0,-4.42 3.58,-8 8,-8c1.85,0 3.55,0.63 4.9,1.69L5.69,16.9C4.63,15.55 4,13.85 4,12z" +
+                "M12,20c-1.85,0 -3.55,-0.63 -4.9,-1.69L18.31,7.1C19.37,8.45 20,10.15 20,12C20,16.42 16.42,20 12,20z",
+        )
+    }
+
+    /** Which boards the home strip shows. */
+    val DashboardCustomize: ImageVector by lazy {
+        materialIcon(
+            name = "DashboardCustomize",
+            pathData =
+            "M3,11h8V3H3V11zM5,5h4v4H5V5zM13,3v8h8V3H13zM19,9h-4V5h4V9zM3,21h8v-8H3V21z" +
+                "M5,15h4v4H5V15zM18,13h-2v3h-3v2h3v3h2v-3h3v-2h-3V13z",
+        )
+    }
+
+    /** The struck-through eye on a password field. Pairs with [Visibility]. */
+    val VisibilityOff: ImageVector by lazy {
+        materialIcon(
+            name = "VisibilityOff",
+            pathData =
+            "M12,7c2.76,0 5,2.24 5,5c0,0.65 -0.13,1.26 -0.36,1.83l2.92,2.92" +
+                "c1.51,-1.26 2.7,-2.89 3.43,-4.75c-1.73,-4.39 -6,-7.5 -11,-7.5c-1.4,0 -2.74,0.25 -3.98,0.7" +
+                "l2.16,2.16C10.74,7.13 11.35,7 12,7zM2,4.27l2.28,2.28l0.46,0.46C3.08,8.3 1.78,10.02 1,12" +
+                "c1.73,4.39 6,7.5 11,7.5c1.55,0 3.03,-0.3 4.38,-0.84l0.42,0.42L19.73,22L21,20.73L3.27,3L2,4.27z" +
+                "M7.53,9.8l1.55,1.55c-0.05,0.21 -0.08,0.43 -0.08,0.65c0,1.66 1.34,3 3,3c0.22,0 0.44,-0.03 0.65,-0.08" +
+                "l1.55,1.55c-0.67,0.33 -1.41,0.53 -2.2,0.53c-2.76,0 -5,-2.24 -5,-5C7,11.21 7.2,10.47 7.53,9.8z" +
+                "M11.84,9.02l3.15,3.15l0.02,-0.16c0,-1.66 -1.34,-3 -3,-3L11.84,9.02z",
+        )
+    }
+
+    /** Take a new avatar photo. */
+    val PhotoCamera: ImageVector by lazy {
+        materialIcon(
+            name = "PhotoCamera",
+            pathData =
+            "M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0" +
+                "M9,2L7.17,4H4C2.9,4 2,4.9 2,6v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6" +
+                "c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2H9zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5" +
+                "s5,2.24 5,5S14.76,17 12,17z",
+        )
+    }
+
+    /** Pick an avatar from the photo library. */
+    val Image: ImageVector by lazy {
+        materialIcon(
+            name = "Image",
+            pathData =
+            "M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2z" +
+                "M8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z",
+        )
+    }
+
+    /** "Awaiting verification" on a freshly changed email address. */
+    val Schedule: ImageVector by lazy {
+        materialIcon(
+            name = "Schedule",
+            pathData =
+            "M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2z" +
+                "M12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8s8,3.58 8,8S16.42,20 12,20z" +
+                "M12.5,7H11v6l5.25,3.15l0.75,-1.23l-4.5,-2.67z",
+        )
+    }
+
+    /** Bind an authenticator app by scanning a code. */
+    val QrCode: ImageVector by lazy {
+        materialIcon(
+            name = "QrCode",
+            pathData =
+            "M3,11h8V3H3V11zM5,5h4v4H5V5zM3,21h8v-8H3V21zM5,15h4v4H5V15zM13,3v8h8V3H13z" +
+                "M19,9h-4V5h4V9zM19,19h2v2h-2V19zM13,13h2v2h-2V13zM15,15h2v2h-2V15z" +
+                "M13,17h2v2h-2V17zM15,19h2v2h-2V19zM17,17h2v2h-2V17zM17,13h2v2h-2V13zM19,15h2v2h-2V15z",
         )
     }
 }

--- a/app/src/main/java/io/github/nsreader/ui/composer/PostComposerScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/composer/PostComposerScreen.kt
@@ -69,7 +69,11 @@ import io.github.nsreader.core.net.NodeSeekError
 import io.github.nsreader.data.Board
 import io.github.nsreader.data.composer.PostDraft
 import io.github.nsreader.data.composer.PostPermission
+import io.github.nsreader.ui.common.MARKDOWN_LINK_CARET
+import io.github.nsreader.ui.common.MARKDOWN_LINK_SUFFIX
+import io.github.nsreader.ui.common.MarkdownInsertion
 import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.applyMarkdown
 import io.github.nsreader.ui.richtext.RichContent
 import io.github.nsreader.ui.theme.PostBody
 import io.github.nsreader.ui.theme.Spacing
@@ -618,25 +622,36 @@ private fun publishErrorMessage(error: NodeSeekError, detail: String?): String {
     return stringResource(R.string.composer_publish_failed, reason)
 }
 
-private enum class MarkdownFormat { BOLD, HEADING, CODE, LIST, LINK, IMAGE, EMOJI }
-
-private fun applyFormat(value: TextFieldValue, format: MarkdownFormat): TextFieldValue {
-    val start = value.selection.min.coerceIn(0, value.text.length)
-    val end = value.selection.max.coerceIn(0, value.text.length)
-    val selected = value.text.substring(start, end)
-    val (replacement, cursorOffset) = when (format) {
-        MarkdownFormat.BOLD -> "**${selected.ifEmpty { "加粗文字" }}**" to if (selected.isEmpty()) 2 else selected.length + 4
-        MarkdownFormat.HEADING -> "## ${selected.ifEmpty { "标题" }}" to if (selected.isEmpty()) 3 else selected.length + 3
-        MarkdownFormat.CODE -> "`${selected.ifEmpty { "code" }}`" to if (selected.isEmpty()) 1 else selected.length + 2
-        MarkdownFormat.LIST -> "- ${selected.ifEmpty { "列表项" }}" to if (selected.isEmpty()) 2 else selected.length + 2
-        MarkdownFormat.LINK -> "[${selected.ifEmpty { "链接文字" }}](https://)" to if (selected.isEmpty()) 1 else selected.length + 3
-        MarkdownFormat.IMAGE -> "![${selected.ifEmpty { "图片说明" }}](https://)" to if (selected.isEmpty()) 2 else selected.length + 4
-        MarkdownFormat.EMOJI -> "$selected🙂" to selected.length + 2
-    }
-    val text = value.text.replaceRange(start, end, replacement)
-    val cursor = (start + cursorOffset).coerceIn(0, text.length)
-    return TextFieldValue(text, TextRange(cursor))
+/**
+ * The composer's full set. The signature editor declares a deliberately smaller one; both insert
+ * through [applyMarkdown], so the caret arithmetic exists once.
+ */
+private enum class MarkdownFormat(val insertion: MarkdownInsertion) {
+    BOLD(MarkdownInsertion(prefix = "**", suffix = "**", placeholder = "加粗文字")),
+    HEADING(MarkdownInsertion(prefix = "## ", placeholder = "标题")),
+    CODE(MarkdownInsertion(prefix = "`", suffix = "`", placeholder = "code")),
+    LIST(MarkdownInsertion(prefix = "- ", placeholder = "列表项")),
+    LINK(
+        MarkdownInsertion(
+            prefix = "[",
+            suffix = MARKDOWN_LINK_SUFFIX,
+            placeholder = "链接文字",
+            caretInSuffix = MARKDOWN_LINK_CARET,
+        ),
+    ),
+    IMAGE(
+        MarkdownInsertion(
+            prefix = "![",
+            suffix = MARKDOWN_LINK_SUFFIX,
+            placeholder = "图片说明",
+            caretInSuffix = MARKDOWN_LINK_CARET,
+        ),
+    ),
+    EMOJI(MarkdownInsertion(prefix = "", suffix = "🙂", placeholder = "")),
 }
+
+private fun applyFormat(value: TextFieldValue, format: MarkdownFormat): TextFieldValue =
+    value.applyMarkdown(format.insertion)
 
 private fun formatTime(timestamp: Long): String =
     DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(timestamp))

--- a/app/src/main/java/io/github/nsreader/ui/postlist/PostListViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/postlist/PostListViewModel.kt
@@ -17,9 +17,9 @@ import io.github.nsreader.data.PostRepository
 import io.github.nsreader.data.session.SessionRepository
 import io.github.nsreader.data.session.SessionState
 import io.github.nsreader.data.settings.SettingsRepository
+import io.github.nsreader.data.settings.visibleHomeBoards
 import io.github.nsreader.di.AppContainer
 import io.github.nsreader.model.FeedSort
-import io.github.nsreader.ui.account.visibleHomeBoards
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/io/github/nsreader/ui/postlist/PostListViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/postlist/PostListViewModel.kt
@@ -16,8 +16,10 @@ import io.github.nsreader.data.FeedPost
 import io.github.nsreader.data.PostRepository
 import io.github.nsreader.data.session.SessionRepository
 import io.github.nsreader.data.session.SessionState
+import io.github.nsreader.data.settings.SettingsRepository
 import io.github.nsreader.di.AppContainer
 import io.github.nsreader.model.FeedSort
+import io.github.nsreader.ui.account.visibleHomeBoards
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,6 +49,7 @@ import kotlinx.coroutines.launch
 class PostListViewModel(
     private val repository: PostRepository,
     private val categoryRepository: CategoryRepository,
+    settingsRepository: SettingsRepository,
     session: StateFlow<SessionState> = MutableStateFlow(SessionState()),
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PostListUiState())
@@ -80,11 +83,29 @@ class PostListViewModel(
             .cachedIn(viewModelScope)
 
     init {
-        // Boards are owned by the repository; the ViewModel mirrors them into UiState but never
-        // becomes their source of truth.
-        categoryRepository.boards
-            .onEach { boards -> _uiState.update { it.copy(boards = boards) } }
-            .launchIn(viewModelScope)
+        /*
+         * Boards are owned by the repository; the ViewModel mirrors them into UiState but never
+         * becomes their source of truth. The 首页版块 preference narrows what the strip shows without
+         * touching that list — 综合 is always kept, since it is the front page rather than a board.
+         *
+         * Hiding the board the user is currently reading would leave a selected pill with no pill,
+         * so the selection falls back to the front page when its board goes away.
+         */
+        combine(
+            categoryRepository.boards,
+            settingsRepository.settings.map { it.homeBoards }.distinctUntilChanged(),
+        ) { boards, homeBoards ->
+            val (frontPage, real) = boards.partition { it.slug == null }
+            frontPage + visibleHomeBoards(real, homeBoards)
+        }.onEach { visible ->
+            _uiState.update { state ->
+                val stillVisible = visible.any { it.slug == state.categorySlug }
+                state.copy(
+                    boards = visible,
+                    categorySlug = if (stillVisible) state.categorySlug else null,
+                )
+            }
+        }.launchIn(viewModelScope)
 
         // Reconcile the first cookie snapshot before opening a Pager. Later generations either
         // invalidate authenticated data or clear it when the user becomes signed out.
@@ -142,6 +163,7 @@ class PostListViewModel(
                     PostListViewModel(
                         container.postRepository,
                         container.categoryRepository,
+                        container.settingsRepository,
                         container.sessionRepository.state,
                     )
                 }

--- a/app/src/main/java/io/github/nsreader/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/profile/ProfileScreen.kt
@@ -56,8 +56,9 @@ fun ProfileRoute(
     viewModel: ProfileViewModel,
     onSignIn: () -> Unit,
     onSettings: () -> Unit,
+    onAccountSettings: () -> Unit,
     onOpenWebsite: () -> Unit,
-    onEditProfile: (Long) -> Unit,
+    onEditProfile: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -67,8 +68,9 @@ fun ProfileRoute(
         onSignOut = viewModel::signOut,
         onRetry = viewModel::refresh,
         onSettings = onSettings,
+        onAccountSettings = onAccountSettings,
         onOpenWebsite = onOpenWebsite,
-        onEditProfile = { state.uid?.let(onEditProfile) },
+        onEditProfile = onEditProfile,
         modifier = modifier,
     )
 }
@@ -80,6 +82,7 @@ fun ProfileScreen(
     onSignOut: () -> Unit,
     onRetry: () -> Unit,
     onSettings: () -> Unit,
+    onAccountSettings: () -> Unit,
     onOpenWebsite: () -> Unit,
     onEditProfile: () -> Unit,
     modifier: Modifier = Modifier,
@@ -164,6 +167,11 @@ fun ProfileScreen(
                 ProfileMenuGroup(
                     items =
                     listOf(
+                        ProfileMenuItem(
+                            R.string.profile_account_settings,
+                            NodeSeekIcons.Badge,
+                            onAccountSettings,
+                        ),
                         ProfileMenuItem(R.string.settings_title, Icons.Default.Settings, onSettings),
                         ProfileMenuItem(
                             R.string.profile_open_web,
@@ -351,6 +359,7 @@ private fun ProfileSignedInPreview() {
             onSignOut = {},
             onRetry = {},
             onSettings = {},
+            onAccountSettings = {},
             onOpenWebsite = {},
             onEditProfile = {},
         )
@@ -367,6 +376,7 @@ private fun ProfileSignedOutPreview() {
             onSignOut = {},
             onRetry = {},
             onSettings = {},
+            onAccountSettings = {},
             onOpenWebsite = {},
             onEditProfile = {},
         )

--- a/app/src/main/java/io/github/nsreader/ui/settings/SettingsListItems.kt
+++ b/app/src/main/java/io/github/nsreader/ui/settings/SettingsListItems.kt
@@ -1,0 +1,140 @@
+package io.github.nsreader.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.ui.theme.Spacing
+
+/**
+ * The grouped-list vocabulary both settings screens are built from.
+ *
+ * Shared rather than copied because the corner rhythm is the point: 18dp on a group's outer corners,
+ * 5dp on the inner ones, 2dp of gap between rows. That is what makes a group read as one object
+ * instead of a stack of cards, and two screens rounding their groups differently is exactly the kind
+ * of drift nobody notices in review and everybody notices side by side.
+ */
+@Composable
+internal fun SettingsSectionTitle(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier.padding(start = Spacing.xs, top = Spacing.xs),
+    )
+}
+
+@Composable
+internal fun SettingsGroup(content: @Composable ColumnScope.() -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(GROUP_SEAM), content = content)
+}
+
+/** A row whose control needs its own line — a slider, a segmented button, a preview block. */
+@Composable
+internal fun SettingsBlock(
+    title: String,
+    top: Boolean = false,
+    bottom: Boolean = false,
+    icon: (@Composable () -> Unit)? = null,
+    subtitle: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = expressiveGroupShape(top, bottom),
+    ) {
+        Column(
+            modifier = Modifier.padding(Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                icon?.invoke()
+                Column(
+                    modifier = Modifier.weight(1f).padding(start = if (icon == null) 0.dp else Spacing.md),
+                ) {
+                    Text(title, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
+                    subtitle?.let {
+                        Text(
+                            it,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            content()
+        }
+    }
+}
+
+/**
+ * A single-line row: leading icon, title, optional current value, optional trailing control.
+ *
+ * [contentColor] exists for the one destructive row in the family (退出登录), which is the same shape
+ * as its neighbours and differs only in colour — a separate composable for it would duplicate the
+ * layout to change two tints.
+ */
+@Composable
+internal fun SettingsRow(
+    title: String,
+    top: Boolean = false,
+    bottom: Boolean = false,
+    subtitle: String? = null,
+    onClick: (() -> Unit)? = null,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    leading: (@Composable () -> Unit)? = null,
+    trailing: @Composable () -> Unit = {},
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = contentColor,
+        shape = expressiveGroupShape(top, bottom),
+        modifier = if (onClick == null) Modifier else Modifier.clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg, vertical = Spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            leading?.invoke()
+            Column(Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
+                subtitle?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            trailing()
+        }
+    }
+}
+
+/** 2dp: wide enough to read as a seam, narrow enough that the group stays one object. */
+private val GROUP_SEAM = 2.dp
+
+internal fun expressiveGroupShape(top: Boolean, bottom: Boolean) =
+    RoundedCornerShape(
+        topStart = if (top) 18.dp else 5.dp,
+        topEnd = if (top) 18.dp else 5.dp,
+        bottomEnd = if (bottom) 18.dp else 5.dp,
+        bottomStart = if (bottom) 18.dp else 5.dp,
+    )

--- a/app/src/main/java/io/github/nsreader/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/settings/SettingsScreen.kt
@@ -9,13 +9,10 @@ import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -49,7 +46,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -312,102 +308,6 @@ private fun <T> connectedButtonSpring() =
     spring<T>(
         dampingRatio = Spring.DampingRatioNoBouncy,
         stiffness = Spring.StiffnessMediumLow,
-    )
-
-@Composable
-private fun SettingsSectionTitle(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(start = Spacing.xs, top = Spacing.xs),
-    )
-}
-
-@Composable
-private fun SettingsGroup(content: @Composable ColumnScope.() -> Unit) {
-    Column(verticalArrangement = Arrangement.spacedBy(2.dp), content = content)
-}
-
-@Composable
-private fun SettingsBlock(
-    title: String,
-    top: Boolean = false,
-    bottom: Boolean = false,
-    icon: (@Composable () -> Unit)? = null,
-    subtitle: String? = null,
-    content: @Composable ColumnScope.() -> Unit,
-) {
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = expressiveGroupShape(top, bottom),
-    ) {
-        Column(
-            modifier = Modifier.padding(Spacing.lg),
-            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                icon?.invoke()
-                Column(
-                    modifier = Modifier.weight(1f).padding(start = if (icon == null) 0.dp else Spacing.md),
-                ) {
-                    Text(title, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
-                    subtitle?.let {
-                        Text(
-                            it,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
-            content()
-        }
-    }
-}
-
-@Composable
-private fun SettingsRow(
-    title: String,
-    top: Boolean = false,
-    bottom: Boolean = false,
-    subtitle: String? = null,
-    onClick: (() -> Unit)? = null,
-    leading: (@Composable () -> Unit)? = null,
-    trailing: @Composable () -> Unit = {},
-) {
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceContainer,
-        shape = expressiveGroupShape(top, bottom),
-        modifier = if (onClick == null) Modifier else Modifier.clickable(onClick = onClick),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg, vertical = Spacing.md),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
-        ) {
-            leading?.invoke()
-            Column(Modifier.weight(1f)) {
-                Text(title, style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium))
-                subtitle?.let {
-                    Text(
-                        it,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            trailing()
-        }
-    }
-}
-
-private fun expressiveGroupShape(top: Boolean, bottom: Boolean) =
-    RoundedCornerShape(
-        topStart = if (top) 18.dp else 5.dp,
-        topEnd = if (top) 18.dp else 5.dp,
-        bottomEnd = if (bottom) 18.dp else 5.dp,
-        bottomStart = if (bottom) 18.dp else 5.dp,
     )
 
 @Preview(showBackground = true, widthDp = 360, heightDp = 800)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,7 @@
     <string name="account_two_factor_body">绑定后，登录与修改密码等高风险操作需输入验证器生成的 6 位动态码。</string>
     <string name="account_two_factor_bind">绑定验证器</string>
     <string name="account_two_factor_rebind">重新绑定</string>
+    <string name="account_two_factor_no_app">没找到验证器应用，先装一个（如 Google Authenticator / Aegis）再绑定</string>
 
     <!-- High-risk confirmations: the design gives these their own dialog rather than a switch -->
     <string name="account_confirm_password_title">确认修改密码？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,12 @@
     <!-- Screen-reader description for the lock on a board only admins can open -->
     <string name="board_admin_only">仅管理员可见</string>
 
+    <!-- The four kinds every board falls into; the tag colour and the picker's headings share them -->
+    <string name="board_family_everyday">日常类</string>
+    <string name="board_family_technical">技术类</string>
+    <string name="board_family_trade">交易类</string>
+    <string name="board_family_flagged">警示类</string>
+
     <!-- Post list -->
     <string name="post_reply_count">%1$d 回复</string>
     <string name="post_new_reply_count">%1$d 条新回复</string>
@@ -156,6 +162,7 @@
     <string name="profile_comments">我的评论</string>
     <string name="profile_bookmarks">我的收藏</string>
     <string name="profile_open_web">在网页中打开个人主页</string>
+    <string name="profile_account_settings">账号设置</string>
 
     <!-- Settings -->
     <string name="settings_title">设置</string>
@@ -175,6 +182,128 @@
     <string name="settings_about_app">关于 NSReader</string>
     <string name="settings_version">v1.0.0</string>
     <string name="settings_licenses">开源许可</string>
+
+    <!-- Account settings (8g): the seven groups NodeSeek's own /setting page is split into -->
+    <string name="account_title">账号设置</string>
+    <string name="account_group_introduction">个人信息</string>
+    <string name="account_group_security">安全</string>
+    <string name="account_group_2fa">双因素验证</string>
+    <string name="account_group_contact">联系方式</string>
+    <string name="account_group_block">屏蔽用户</string>
+    <string name="account_group_preference">常用偏好</string>
+    <string name="account_group_homepage">首页版块</string>
+
+    <string name="account_avatar">头像</string>
+    <string name="account_bio">Bio</string>
+    <string name="account_signature">签名</string>
+    <string name="account_readme">Readme</string>
+    <string name="account_change_password">修改密码</string>
+    <string name="account_two_factor">两步验证（2FA）</string>
+    <string name="account_two_factor_on">已开启</string>
+    <string name="account_two_factor_off">未开启</string>
+    <string name="account_email">邮箱</string>
+    <string name="account_blocked_list">已屏蔽列表</string>
+    <string name="account_blocked_count">%1$d 人</string>
+    <string name="account_display_preferences">浏览与显示偏好</string>
+    <string name="account_home_boards">首页显示的版块</string>
+    <string name="account_home_boards_all">全部 %1$d 个版块</string>
+    <string name="account_home_boards_selected">已选 %1$d 个</string>
+
+    <!-- Current-value subtitles. App additions: the site's own page is a plain list of group links. -->
+    <string name="account_value_unknown">—</string>
+    <string name="account_bio_empty">未填写</string>
+    <string name="account_signature_lines">%1$d 行 · Markdown</string>
+    <string name="account_readme_chars">%1$d 字</string>
+
+    <!-- The endpoint seam. Shown wherever a group's requests have not been captured from a device yet. -->
+    <string name="account_endpoint_pending_title">这一组还没接入站点接口</string>
+    <string name="account_endpoint_pending_body">NodeSeek 没有公开 API，/setting 的读写请求要在真机登录后抓一遍才能对接。表单可以照常填，但读不到当前值、保存也不会生效。</string>
+    <string name="account_endpoint_pending_toast">「%1$s」的站点接口尚未接入，本次未保存</string>
+
+    <!-- 个人信息 (d6 1/4) -->
+    <string name="account_profile_title">个人信息</string>
+    <string name="account_action_save">保存</string>
+    <string name="account_action_saved">已保存</string>
+    <string name="account_avatar_change">更换头像</string>
+    <string name="account_avatar_take_photo">拍照</string>
+    <string name="account_avatar_pick">从相册选择</string>
+    <string name="account_avatar_remove">移除头像</string>
+    <string name="account_avatar_pending">新头像待保存</string>
+    <string name="account_avatar_failed">读取图片失败，换一张试试</string>
+    <string name="account_bio_hint">请用一句话介绍自己</string>
+    <string name="account_signature_helper">帖子内容下显示 · 支持 Markdown · 不支持图片和引用</string>
+    <string name="account_readme_helper">用户主页中显示 · 支持 Markdown</string>
+    <string name="account_format_bold">加粗</string>
+    <string name="account_format_italic">斜体</string>
+    <string name="account_format_strikethrough">删除线</string>
+    <string name="account_format_link">链接</string>
+    <string name="account_format_code">行内代码</string>
+
+    <!-- 安全 (d6 2/4) -->
+    <string name="account_security_title">安全</string>
+    <string name="account_password_current">当前密码</string>
+    <string name="account_password_new">新密码</string>
+    <string name="account_password_confirm">确认新密码</string>
+    <string name="account_password_confirm_hint">再输入一次新密码</string>
+    <string name="account_password_show">显示密码</string>
+    <string name="account_password_hide">隐藏密码</string>
+    <string name="account_password_update">更新密码</string>
+    <string name="account_password_mismatch">两次输入的新密码不一致</string>
+    <string name="account_password_too_short">新密码至少 %1$d 位</string>
+    <!-- App addition: the site gives no live strength feedback -->
+    <string name="account_password_strength">强度：%1$s</string>
+    <string name="account_password_strength_weak">较弱</string>
+    <string name="account_password_strength_fair">一般</string>
+    <string name="account_password_strength_strong">较强</string>
+    <string name="account_password_strength_best">很强</string>
+    <string name="account_password_strength_hint_length">再长一些会明显更安全</string>
+    <string name="account_password_strength_hint_variety">混入大小写、数字与符号可达到最高强度</string>
+    <string name="account_password_strength_hint_done">已经足够强了</string>
+    <string name="account_two_factor_section">两步验证</string>
+    <string name="account_two_factor_totp">验证器动态码（TOTP）</string>
+    <string name="account_two_factor_off_hint">未开启 · 建议开启以保护账号</string>
+    <string name="account_two_factor_on_hint">已开启 · 登录时需要输入动态码</string>
+    <string name="account_two_factor_body">绑定后，登录与修改密码等高风险操作需输入验证器生成的 6 位动态码。</string>
+    <string name="account_two_factor_bind">绑定验证器</string>
+    <string name="account_two_factor_rebind">重新绑定</string>
+
+    <!-- High-risk confirmations: the design gives these their own dialog rather than a switch -->
+    <string name="account_confirm_password_title">确认修改密码？</string>
+    <string name="account_confirm_password_body">修改后除当前设备外，其他已登录设备将全部退出，需要用新密码重新登录。</string>
+    <string name="account_confirm_password_action">确认修改</string>
+    <string name="account_confirm_2fa_title">确认绑定验证器？</string>
+    <string name="account_confirm_2fa_body">绑定后每次登录都需要验证器动态码。请先确保验证器 App 已装好，并妥善保存恢复码。</string>
+    <string name="account_confirm_2fa_action">开始绑定</string>
+    <string name="account_confirm_avatar_remove_title">移除头像？</string>
+    <string name="account_confirm_avatar_remove_body">移除后将显示默认头像，之前上传的图片无法恢复。</string>
+    <string name="account_confirm_avatar_remove_action">移除</string>
+    <string name="account_confirm_unblock_title">解除对 %1$s 的屏蔽？</string>
+    <string name="account_confirm_unblock_body">解除后你会重新看到 TA 的帖子与评论。</string>
+    <string name="account_confirm_unblock_action">解除屏蔽</string>
+
+    <!-- 联系方式 · 屏蔽 (d6 3/4) -->
+    <string name="account_contact_title">联系方式与屏蔽</string>
+    <string name="account_contact_section">联系方式</string>
+    <string name="account_email_backup">备用邮箱 · 选填</string>
+    <string name="account_email_verified">已验证</string>
+    <string name="account_email_unverified">未验证</string>
+    <string name="account_email_helper">用于登录与找回密码 · 更换后需重新验证</string>
+    <string name="account_email_invalid">邮箱格式不正确</string>
+    <string name="account_email_verification_sent">验证邮件已发送，10 分钟内有效</string>
+    <string name="account_email_resend">重新发送</string>
+    <string name="account_contact_save">保存修改</string>
+    <string name="account_block_section">屏蔽用户</string>
+    <string name="account_block_row_hint">已屏蔽 · 不再显示其帖子与评论</string>
+    <string name="account_block_unblock">解除屏蔽</string>
+    <string name="account_block_empty">你还没有屏蔽任何用户</string>
+
+    <!-- 首页版块 (d6 4/4) -->
+    <string name="account_home_boards_title">首页版块</string>
+    <string name="account_home_boards_summary">勾选的版块会出现在首页版块条 · 已选 %1$d / %2$d</string>
+    <string name="account_home_boards_reset">重置</string>
+    <string name="account_home_boards_save">保存 %1$d 个版块</string>
+    <string name="account_home_boards_min">至少要保留一个版块</string>
+    <string name="account_home_boards_empty">版块列表还没载入，回到首页刷新一下再来</string>
 
     <!-- Status and empty states: say what happened, then offer something to press -->
     <string name="status_empty_feed_title">这里还没有帖子</string>

--- a/app/src/test/java/io/github/nsreader/data/TestDoubles.kt
+++ b/app/src/test/java/io/github/nsreader/data/TestDoubles.kt
@@ -1,10 +1,12 @@
 package io.github.nsreader.data
 
 import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import io.github.nsreader.core.AppClock
 import io.github.nsreader.data.local.NodeSeekDatabase
+import io.github.nsreader.data.settings.SettingsRepository
 import io.github.nsreader.model.FeedSort
 import io.github.nsreader.model.PostContent
 import io.github.nsreader.model.PostDetail
@@ -13,7 +15,10 @@ import io.github.nsreader.model.PostSummary
 import io.github.nsreader.model.RichNode
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asExecutor
+import java.io.File
+import java.nio.file.Files
 
 /**
  * An in-memory database on the real Room implementation.
@@ -170,4 +175,20 @@ internal class FakePostRemoteDataSource : PostRemoteDataSource {
                 nodes = listOf(RichNode.CodeBlock(text, language = null)),
             )
     }
+}
+
+/**
+ * A [SettingsRepository] on a real DataStore in a throwaway directory.
+ *
+ * The real store rather than an interface fake, for the same reason [inMemoryDatabase] uses real
+ * Room: the behaviour worth testing is the encoding — a set that round-trips through one delimited
+ * string — and a fake would only prove the fake encodes correctly.
+ *
+ * [scope] should be a test's `backgroundScope` so the store's collector is cancelled with the test.
+ */
+internal fun testSettingsRepository(scope: CoroutineScope): SettingsRepository {
+    val directory = Files.createTempDirectory("nsreader-settings").toFile().apply { deleteOnExit() }
+    return SettingsRepository(
+        PreferenceDataStoreFactory.create(scope = scope) { File(directory, "settings.preferences_pb") },
+    )
 }

--- a/app/src/test/java/io/github/nsreader/ui/account/AccountLogicTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/AccountLogicTest.kt
@@ -1,6 +1,7 @@
 package io.github.nsreader.ui.account
 
 import io.github.nsreader.data.Board
+import io.github.nsreader.data.settings.visibleHomeBoards
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull

--- a/app/src/test/java/io/github/nsreader/ui/account/AccountLogicTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/AccountLogicTest.kt
@@ -1,0 +1,85 @@
+package io.github.nsreader.ui.account
+
+import io.github.nsreader.data.Board
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The pure decisions behind 8g and d6, tested without a Compose tree or a database. */
+class AccountLogicTest {
+
+    private val boards =
+        listOf(
+            Board("daily", "日常", null),
+            Board("tech", "技术", null),
+            Board("trade", "交易", null),
+        )
+
+    @Test
+    fun `an empty home-board preference means every board`() {
+        assertEquals(boards, visibleHomeBoards(boards, emptySet()))
+    }
+
+    @Test
+    fun `a home-board preference keeps only the chosen boards, in the server's order`() {
+        assertEquals(
+            listOf(boards[0], boards[2]),
+            visibleHomeBoards(boards, setOf("trade", "daily")),
+        )
+    }
+
+    /**
+     * The case that matters after the site renames a board: the stored slugs match nothing, and
+     * honouring the preference literally would leave the home strip empty and looking broken.
+     */
+    @Test
+    fun `a home-board preference matching nothing falls back to every board`() {
+        assertEquals(boards, visibleHomeBoards(boards, setOf("gone", "also-gone")))
+    }
+
+    @Test
+    fun `an empty password has no strength at all`() {
+        assertNull(passwordStrength(""))
+    }
+
+    @Test
+    fun `strength rises with length and with character variety`() {
+        assertEquals(PasswordStrength.Weak, passwordStrength("abc"))
+        assertEquals(PasswordStrength.Weak, passwordStrength("abcdefgh"))
+        assertEquals(PasswordStrength.Fair, passwordStrength("abcdefgh1"))
+        assertEquals(PasswordStrength.Strong, passwordStrength("Abcdefgh1234"))
+        assertEquals(PasswordStrength.Best, passwordStrength("Abcdefgh1234!@#\$"))
+    }
+
+    /** The inversion the weighting exists to prevent: `aB1!` is not a stronger password than a passphrase. */
+    @Test
+    fun `a long single-class password beats a short varied one`() {
+        val longPassphrase = passwordStrength("correcthorsebatterystaple")!!
+        val shortMixed = passwordStrength("aB1!")!!
+        assertTrue(longPassphrase.filledBars > shortMixed.filledBars)
+    }
+
+    @Test
+    fun `the strength meter never fills more bars than it has`() {
+        PasswordStrength.entries.forEach { strength ->
+            assertTrue(strength.filledBars in 1..PasswordStrength.TOTAL_BARS)
+        }
+    }
+
+    @Test
+    fun `email validation accepts ordinary addresses`() {
+        assertTrue(isEmailAddress("hikari.zhg@gmail.com"))
+        assertTrue(isEmailAddress("ns+tag@outlook.co.uk"))
+    }
+
+    @Test
+    fun `email validation rejects the mistakes it exists to catch`() {
+        assertFalse(isEmailAddress("hikari.zhg"))
+        assertFalse(isEmailAddress("@gmail.com"))
+        assertFalse(isEmailAddress("a@b"))
+        assertFalse(isEmailAddress("two@at@signs.com"))
+        assertFalse(isEmailAddress("trailing@dot."))
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/AccountSettingsScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/AccountSettingsScreenTest.kt
@@ -1,0 +1,147 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import io.github.nsreader.data.account.AccountProfileFields
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class AccountSettingsScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val populated =
+        AccountSettingsUiState(
+            displayName = "花间一壶酒",
+            fields =
+            AccountProfileFields(
+                bio = "常驻杭州",
+                signature = "第一行\n第二行",
+                readme = "1234567890",
+            ),
+            twoFactorEnabled = false,
+            email = "hikari.zhg@gmail.com",
+            blockedCount = 3,
+            homeBoardCount = 6,
+            totalBoardCount = 13,
+            homeBoardsRestricted = true,
+        )
+
+    private fun setContent(
+        state: AccountSettingsUiState = populated,
+        onOpenProfileFields: () -> Unit = {},
+        onOpenSecurity: () -> Unit = {},
+        onOpenContactAndBlock: () -> Unit = {},
+        onOpenDisplayPreferences: () -> Unit = {},
+        onOpenHomeBoards: () -> Unit = {},
+        onSignOut: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            NodeSeekTheme {
+                AccountSettingsScreen(
+                    state = state,
+                    onBack = {},
+                    onOpenProfileFields = onOpenProfileFields,
+                    onOpenSecurity = onOpenSecurity,
+                    onOpenContactAndBlock = onOpenContactAndBlock,
+                    onOpenDisplayPreferences = onOpenDisplayPreferences,
+                    onOpenHomeBoards = onOpenHomeBoards,
+                    onSignOut = onSignOut,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `shows all seven groups from the site's own settings page`() {
+        setContent()
+
+        listOf("个人信息", "安全", "双因素验证", "联系方式", "屏蔽用户", "常用偏好", "首页版块").forEach { group ->
+            composeRule.onNodeWithText(group).performScrollTo().assertExists()
+        }
+    }
+
+    /** The subtitles are the reason this screen exists rather than a link to `/setting` in a browser. */
+    @Test
+    fun `each row summarises its current value`() {
+        setContent()
+
+        composeRule.onNodeWithText("常驻杭州").assertExists()
+        composeRule.onNodeWithText("2 行 · Markdown").assertExists()
+        composeRule.onNodeWithText("10 字").assertExists()
+        composeRule.onNodeWithText("未开启").assertExists()
+        composeRule.onNodeWithText("3 人").performScrollTo().assertExists()
+        composeRule.onNodeWithText("已选 6 个").performScrollTo().assertExists()
+    }
+
+    /** An address on a screen that gets screenshotted; the sub-page shows it in full. */
+    @Test
+    fun `the email row is masked`() {
+        setContent()
+
+        composeRule.onNodeWithText("h***@gmail.com").performScrollTo().assertExists()
+        composeRule.onNodeWithText("hikari.zhg@gmail.com").assertDoesNotExist()
+    }
+
+    @Test
+    fun `an unrestricted home-board preference reads as all boards rather than a count`() {
+        setContent(populated.copy(homeBoardsRestricted = false))
+
+        composeRule.onNodeWithText("全部 13 个版块").performScrollTo().assertExists()
+    }
+
+    /** Values the site has not answered for yet are left blank, never guessed at. */
+    @Test
+    fun `rows carry no subtitle before the account has loaded`() {
+        setContent(AccountSettingsUiState(totalBoardCount = 13))
+
+        composeRule.onNodeWithText("未开启").assertDoesNotExist()
+        composeRule.onNodeWithText("已选 0 个").assertDoesNotExist()
+    }
+
+    @Test
+    fun `every group routes somewhere`() {
+        val opened = mutableListOf<String>()
+        setContent(
+            onOpenProfileFields = { opened += "profile" },
+            onOpenSecurity = { opened += "security" },
+            onOpenContactAndBlock = { opened += "contact" },
+            onOpenDisplayPreferences = { opened += "preferences" },
+            onOpenHomeBoards = { opened += "boards" },
+        )
+
+        composeRule.onNodeWithText("Bio").performScrollTo().performClick()
+        composeRule.onNodeWithText("修改密码").performScrollTo().performClick()
+        composeRule.onNodeWithText("两步验证（2FA）").performScrollTo().performClick()
+        composeRule.onNodeWithText("已屏蔽列表").performScrollTo().performClick()
+        composeRule.onNodeWithText("浏览与显示偏好").performScrollTo().performClick()
+        composeRule.onNodeWithText("首页显示的版块").performScrollTo().performClick()
+
+        assertEquals(
+            listOf("profile", "security", "security", "contact", "preferences", "boards"),
+            opened,
+        )
+    }
+
+    @Test
+    fun `signing out is reachable from the bottom of the list`() {
+        var signedOut = false
+        setContent(onSignOut = { signedOut = true })
+
+        composeRule.onNodeWithText("退出登录").performScrollTo().performClick()
+
+        assertTrue(signedOut)
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/ContactBlockViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/ContactBlockViewModelTest.kt
@@ -1,0 +1,180 @@
+package io.github.nsreader.ui.account
+
+import io.github.nsreader.data.account.AccountContact
+import io.github.nsreader.data.account.BlockedUser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The verified badge is what this screen is really about: an address that looks saved but is not
+ * verified cannot recover the account, so the rules for when the badge disappears are load-bearing.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContactBlockViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    private val verified =
+        AccountContact(
+            email = "hikari.zhg@gmail.com",
+            emailVerified = true,
+            backupEmail = "ns.backup@outlook.com",
+            backupEmailVerified = false,
+        )
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(repository: FakeAccountSettingsRepository) =
+        ContactBlockViewModel(repository)
+
+    @Test
+    fun `loads the address and the blocked list`() =
+        runTest(dispatcher) {
+            val repository =
+                FakeAccountSettingsRepository(
+                    contact = verified,
+                    blocked = listOf(BlockedUser(uid = 1, name = "机场信仰充值中")),
+                )
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertFalse(state.isLoading)
+            assertEquals("hikari.zhg@gmail.com", state.email)
+            assertTrue(state.emailVerified)
+            assertFalse(state.backupEmailVerified)
+            assertEquals(1, state.blocked.size)
+        }
+
+    /** The whole point: typing a new address must not keep claiming the old one was verified. */
+    @Test
+    fun `editing the address revokes the verified badge immediately`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(contact = verified))
+            advanceUntilIdle()
+            assertTrue(vm.uiState.value.emailVerified)
+
+            vm.updateEmail("someone.else@gmail.com")
+
+            assertFalse(vm.uiState.value.emailVerified)
+        }
+
+    @Test
+    fun `typing the original address back restores the badge`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(contact = verified))
+            advanceUntilIdle()
+
+            vm.updateEmail("someone.else@gmail.com")
+            vm.updateEmail("hikari.zhg@gmail.com")
+
+            assertTrue(vm.uiState.value.emailVerified)
+        }
+
+    /** A saved-but-changed address is unverified until the user clicks the mail the server just sent. */
+    @Test
+    fun `saving a changed address leaves it unverified`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository(contact = verified)
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+
+            vm.updateEmail("someone.else@gmail.com")
+            vm.save()
+            advanceUntilIdle()
+
+            assertEquals("someone.else@gmail.com" to "ns.backup@outlook.com", repository.savedContact)
+            assertFalse(vm.uiState.value.emailVerified)
+        }
+
+    @Test
+    fun `saving without changing the address keeps the badge`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository(contact = verified)
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+
+            vm.updateBackupEmail("other.backup@outlook.com")
+            vm.save()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.emailVerified)
+        }
+
+    @Test
+    fun `save is blocked while nothing changed and while an address is malformed`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(contact = verified))
+            advanceUntilIdle()
+            assertFalse("unchanged form must not be saveable", vm.uiState.value.canSave)
+
+            vm.updateEmail("not-an-address")
+            assertTrue(vm.uiState.value.isEmailMalformed)
+            assertFalse(vm.uiState.value.canSave)
+
+            vm.updateEmail("fine@example.com")
+            assertTrue(vm.uiState.value.canSave)
+        }
+
+    @Test
+    fun `unblocking removes the row only after the dialog is confirmed`() =
+        runTest(dispatcher) {
+            val target = BlockedUser(uid = 7, name = "vps_matthew")
+            val repository = FakeAccountSettingsRepository(blocked = listOf(target))
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+
+            vm.requestUnblock(target)
+            advanceUntilIdle()
+            assertEquals(1, vm.uiState.value.blocked.size)
+            assertTrue(repository.unblocked.isEmpty())
+
+            vm.confirmUnblock()
+            advanceUntilIdle()
+
+            assertEquals(listOf(7L), repository.unblocked)
+            assertTrue(vm.uiState.value.blocked.isEmpty())
+        }
+
+    @Test
+    fun `dismissing the dialog unblocks nobody`() =
+        runTest(dispatcher) {
+            val target = BlockedUser(uid = 7, name = "vps_matthew")
+            val repository = FakeAccountSettingsRepository(blocked = listOf(target))
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+
+            vm.requestUnblock(target)
+            vm.dismissUnblock()
+            vm.confirmUnblock()
+            advanceUntilIdle()
+
+            assertTrue(repository.unblocked.isEmpty())
+            assertEquals(1, vm.uiState.value.blocked.size)
+        }
+
+    /** A pending endpoint raises the banner and stays out of the snackbar; see the ViewModel. */
+    @Test
+    fun `a pending endpoint shows the banner without a snackbar`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository.pendingEndpoints())
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.endpointPending)
+            assertEquals(null, vm.uiState.value.message)
+        }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/FakeAccountSettingsRepository.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/FakeAccountSettingsRepository.kt
@@ -1,0 +1,103 @@
+package io.github.nsreader.ui.account
+
+import io.github.nsreader.data.account.AccountContact
+import io.github.nsreader.data.account.AccountProfileFields
+import io.github.nsreader.data.account.AccountSettingsRepository
+import io.github.nsreader.data.account.AvatarUpload
+import io.github.nsreader.data.account.BlockedUser
+import io.github.nsreader.data.account.EndpointNotVerifiedException
+import io.github.nsreader.data.account.TwoFactorState
+
+/**
+ * An [AccountSettingsRepository] whose reads are canned and whose writes are recorded.
+ *
+ * Exists so the ViewModel logic can be tested *now*, while the real implementation still throws
+ * [EndpointNotVerifiedException] for everything. That timing is the point: once the endpoints are
+ * captured, the only file that changes is the network repository, and nobody will think to come back
+ * and cover the ordering and revocation rules these tests pin down.
+ *
+ * [failWith] makes every call throw, which is how the pending-endpoint and error paths are exercised.
+ */
+internal class FakeAccountSettingsRepository(
+    var fields: AccountProfileFields = AccountProfileFields(),
+    var contact: AccountContact = AccountContact(),
+    var twoFactor: TwoFactorState = TwoFactorState(),
+    var blocked: List<BlockedUser> = emptyList(),
+    var failWith: (() -> Throwable)? = null,
+) : AccountSettingsRepository {
+
+    /** Every mutating call, in the order it happened — the ordering contracts are what matter. */
+    val calls = mutableListOf<String>()
+
+    var savedFields: AccountProfileFields? = null
+    var savedContact: Pair<String, String>? = null
+    var changedPassword: Pair<String, String>? = null
+    var uploadedAvatar: AvatarUpload? = null
+    var unblocked = mutableListOf<Long>()
+    var enrolmentUri: String = "otpauth://totp/NodeSeek:tester?secret=ABC"
+
+    private fun record(name: String) {
+        calls += name
+        failWith?.let { throw it() }
+    }
+
+    override suspend fun profileFields(): AccountProfileFields {
+        record("profileFields")
+        return fields
+    }
+
+    override suspend fun saveProfileFields(fields: AccountProfileFields) {
+        record("saveProfileFields")
+        savedFields = fields
+    }
+
+    override suspend fun uploadAvatar(upload: AvatarUpload) {
+        record("uploadAvatar")
+        uploadedAvatar = upload
+    }
+
+    override suspend fun removeAvatar() = record("removeAvatar")
+
+    override suspend fun changePassword(currentPassword: String, newPassword: String) {
+        record("changePassword")
+        changedPassword = currentPassword to newPassword
+    }
+
+    override suspend fun twoFactor(): TwoFactorState {
+        record("twoFactor")
+        return twoFactor
+    }
+
+    override suspend fun beginTwoFactorEnrolment(): String {
+        record("beginTwoFactorEnrolment")
+        return enrolmentUri
+    }
+
+    override suspend fun contact(): AccountContact {
+        record("contact")
+        return contact
+    }
+
+    override suspend fun saveContact(email: String, backupEmail: String) {
+        record("saveContact")
+        savedContact = email to backupEmail
+    }
+
+    override suspend fun resendVerification(email: String) = record("resendVerification")
+
+    override suspend fun blockedUsers(): List<BlockedUser> {
+        record("blockedUsers")
+        return blocked
+    }
+
+    override suspend fun unblock(uid: Long) {
+        record("unblock")
+        unblocked += uid
+    }
+
+    companion object {
+        /** The state the app ships in today: nothing about `/setting` has been wired up. */
+        fun pendingEndpoints() =
+            FakeAccountSettingsRepository(failWith = { EndpointNotVerifiedException("test") })
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/HomeBoardsScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/HomeBoardsScreenTest.kt
@@ -1,0 +1,114 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import io.github.nsreader.data.Board
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class HomeBoardsScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val boards =
+        listOf(
+            Board("daily", "日常", null),
+            Board("life", "生活", null),
+            Board("tech", "技术", null),
+            Board("dev", "Dev", null),
+            Board("trade", "交易", null),
+            Board("expose", "曝光", null),
+        )
+
+    private fun setContent(
+        selected: Set<String> = setOf("daily", "tech"),
+        onToggle: (String) -> Unit = {},
+        onReset: () -> Unit = {},
+        onSave: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            NodeSeekTheme {
+                HomeBoardsScreen(
+                    state =
+                    HomeBoardsUiState(isLoading = false, boards = boards, selected = selected),
+                    snackbarHostState = remember { SnackbarHostState() },
+                    onBack = {},
+                    onToggle = onToggle,
+                    onReset = onReset,
+                    onSave = onSave,
+                )
+            }
+        }
+    }
+
+    /** The four headings are the same families the board tags are coloured by on every list row. */
+    @Test
+    fun `boards are grouped under the four board families`() {
+        setContent()
+
+        listOf("日常类", "技术类", "交易类", "警示类").forEach { family ->
+            composeRule.onNodeWithText(family).performScrollTo().assertExists()
+        }
+    }
+
+    @Test
+    fun `the summary counts the selection against the total`() {
+        setContent()
+
+        composeRule.onNodeWithText("勾选的版块会出现在首页版块条 · 已选 2 / 6").assertExists()
+    }
+
+    @Test
+    fun `checked state follows the selection`() {
+        setContent(selected = setOf("daily"))
+
+        composeRule.onNodeWithText("日常").performScrollTo().assertIsOn()
+        composeRule.onNodeWithText("生活").performScrollTo().assertIsOff()
+    }
+
+    /** The whole row is the target, not the 20dp checkbox inside it. */
+    @Test
+    fun `tapping a row's label toggles it`() {
+        val toggled = mutableListOf<String>()
+        setContent(onToggle = { toggled += it })
+
+        composeRule.onNodeWithText("曝光").performScrollTo().performClick()
+
+        assertEquals(listOf("expose"), toggled)
+    }
+
+    @Test
+    fun `the save button counts what will be saved`() {
+        setContent(selected = setOf("daily", "tech", "dev"))
+
+        composeRule.onNodeWithText("保存 3 个版块").assertExists()
+    }
+
+    @Test
+    fun `reset and save are both reachable from the bottom bar`() {
+        var reset = false
+        var saved = false
+        setContent(onReset = { reset = true }, onSave = { saved = true })
+
+        composeRule.onNodeWithText("重置").performClick()
+        composeRule.onNodeWithText("保存 2 个版块").performClick()
+
+        assertEquals(true, reset)
+        assertEquals(true, saved)
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/HomeBoardsViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/HomeBoardsViewModelTest.kt
@@ -9,7 +9,6 @@ import io.github.nsreader.data.inMemoryDatabase
 import io.github.nsreader.data.local.NodeSeekDatabase
 import io.github.nsreader.data.settings.SettingsRepository
 import io.github.nsreader.data.testSettingsRepository
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -69,14 +68,13 @@ class HomeBoardsViewModelTest {
      *
      * DataStore does its file write on a real `Dispatchers.IO` that the test scheduler does not own,
      * so the scheduler goes idle while the write is still in flight and an assertion placed after
-     * `advanceUntilIdle()` reads the store before it has been touched. Awaiting the callback waits for
-     * the effect itself, which is the thing the test is actually about.
+     * `advanceUntilIdle()` reads the store before it has been touched. Waiting for the `saved` flag
+     * waits for the effect itself, which is the thing the test is actually about.
      */
     private suspend fun TestScope.saveAndAwait(viewModel: HomeBoardsViewModel) {
-        val done = CompletableDeferred<Unit>()
-        viewModel.save { done.complete(Unit) }
+        viewModel.save()
         advanceUntilIdle()
-        withTimeout(SAVE_TIMEOUT_MILLIS) { done.await() }
+        withTimeout(SAVE_TIMEOUT_MILLIS) { viewModel.uiState.first { it.saved } }
     }
 
     @Test

--- a/app/src/test/java/io/github/nsreader/ui/account/HomeBoardsViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/HomeBoardsViewModelTest.kt
@@ -1,0 +1,168 @@
+package io.github.nsreader.ui.account
+
+import io.github.nsreader.core.net.JsonSource
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.data.CategoryRepository
+import io.github.nsreader.data.MutableClock
+import io.github.nsreader.data.inMemoryDatabase
+import io.github.nsreader.data.local.NodeSeekDatabase
+import io.github.nsreader.data.settings.SettingsRepository
+import io.github.nsreader.data.testSettingsRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * 首页版块 is the one part of 账号设置 that writes something real, so its storage contract is the part
+ * worth pinning down: "everything" must never be stored as a list of today's slugs.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class HomeBoardsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val clock = MutableClock()
+    private lateinit var database: NodeSeekDatabase
+
+    /** No network in these tests: [CategoryRepository] falls back to its static board list. */
+    private val failingJson =
+        object : JsonSource {
+            override suspend fun getJson(path: String, referer: String): String =
+                throw NodeSeekException(NodeSeekError.Network)
+        }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        database = inMemoryDatabase(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+        Dispatchers.resetMain()
+    }
+
+    private fun TestScope.viewModel(settings: SettingsRepository) =
+        HomeBoardsViewModel(
+            settings = settings,
+            categories = CategoryRepository(failingJson, database.boardDao(), clock),
+        )
+
+    /**
+     * `advanceUntilIdle` cannot wait for a save.
+     *
+     * DataStore does its file write on a real `Dispatchers.IO` that the test scheduler does not own,
+     * so the scheduler goes idle while the write is still in flight and an assertion placed after
+     * `advanceUntilIdle()` reads the store before it has been touched. Awaiting the callback waits for
+     * the effect itself, which is the thing the test is actually about.
+     */
+    private suspend fun TestScope.saveAndAwait(viewModel: HomeBoardsViewModel) {
+        val done = CompletableDeferred<Unit>()
+        viewModel.save { done.complete(Unit) }
+        advanceUntilIdle()
+        withTimeout(SAVE_TIMEOUT_MILLIS) { done.await() }
+    }
+
+    @Test
+    fun `opens with every board ticked when no preference is stored`() =
+        runTest(dispatcher) {
+            val vm = viewModel(testSettingsRepository(backgroundScope))
+            advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertTrue(state.boards.isNotEmpty())
+            assertEquals(state.boards.mapNotNull { it.slug }.toSet(), state.selected)
+        }
+
+    @Test
+    fun `saving every board stores no restriction at all`() =
+        runTest(dispatcher) {
+            val settings = testSettingsRepository(backgroundScope)
+            val vm = viewModel(settings)
+            advanceUntilIdle()
+
+            saveAndAwait(vm)
+
+            // Storing the full list would pin the strip to today's boards and hide any added later.
+            assertEquals(emptySet<String>(), settings.settings.first().homeBoards)
+        }
+
+    @Test
+    fun `saving a subset stores exactly that subset`() =
+        runTest(dispatcher) {
+            val settings = testSettingsRepository(backgroundScope)
+            val vm = viewModel(settings)
+            advanceUntilIdle()
+
+            vm.uiState.value.boards.mapNotNull { it.slug }.drop(2).forEach(vm::toggle)
+            val kept = vm.uiState.value.selected
+            saveAndAwait(vm)
+
+            assertEquals(kept, settings.settings.first().homeBoards)
+        }
+
+    @Test
+    fun `the last board cannot be unticked`() =
+        runTest(dispatcher) {
+            val vm = viewModel(testSettingsRepository(backgroundScope))
+            advanceUntilIdle()
+
+            val slugs = vm.uiState.value.boards.mapNotNull { it.slug }
+            slugs.forEach(vm::toggle)
+
+            assertEquals(setOf(slugs.last()), vm.uiState.value.selected)
+            assertTrue(vm.uiState.value.message is AccountMessage.Info)
+        }
+
+    @Test
+    fun `reset returns to every board`() =
+        runTest(dispatcher) {
+            val vm = viewModel(testSettingsRepository(backgroundScope))
+            advanceUntilIdle()
+
+            vm.uiState.value.boards.mapNotNull { it.slug }.drop(1).forEach(vm::toggle)
+            vm.reset()
+
+            assertEquals(
+                vm.uiState.value.boards.mapNotNull { it.slug }.toSet(),
+                vm.uiState.value.selected,
+            )
+        }
+
+    @Test
+    fun `a stored preference survives a reopen`() =
+        runTest(dispatcher) {
+            val settings = testSettingsRepository(backgroundScope)
+            val first = viewModel(settings)
+            advanceUntilIdle()
+            first.uiState.value.boards.mapNotNull { it.slug }.drop(3).forEach(first::toggle)
+            val expected = first.uiState.value.selected
+            saveAndAwait(first)
+
+            val second = viewModel(settings)
+            advanceUntilIdle()
+
+            assertEquals(expected, second.uiState.value.selected)
+        }
+
+    private companion object {
+        /** Real milliseconds: the store's write is on a real dispatcher, not the test scheduler. */
+        const val SAVE_TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/ProfileFieldsViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/ProfileFieldsViewModelTest.kt
@@ -1,0 +1,187 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.ui.graphics.ImageBitmap
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.UserProfile
+import io.github.nsreader.data.account.AccountProfileFields
+import io.github.nsreader.data.account.AvatarUpload
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Robolectric because [PendingAvatar] holds an [ImageBitmap], which is a real Android bitmap.
+ *
+ * The contract under test is the save ordering: the avatar is its own request, and getting the order
+ * wrong means reporting success for text fields that were written after an avatar upload had already
+ * failed.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+// Legacy graphics hands back null bitmaps, so ImageBitmap(1, 1) NPEs on construction.
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class ProfileFieldsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    private val stored =
+        AccountProfileFields(bio = "常驻杭州", signature = "**出杭州腾讯云轻量**", readme = "### 关于我")
+
+    private val profiles =
+        object : ProfileRepository {
+            override suspend fun profile() =
+                UserProfile(
+                    uid = 52425,
+                    name = "林地雪原-0062",
+                    avatarUrl = "https://www.nodeseek.com/avatar/52425.png",
+                )
+        }
+
+    private fun pendingAvatar() =
+        PendingAvatar(
+            preview = ImageBitmap(1, 1),
+            upload = AvatarUpload(bytes = byteArrayOf(1, 2, 3), mimeType = "image/jpeg"),
+        )
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun viewModel(repository: FakeAccountSettingsRepository) =
+        ProfileFieldsViewModel(repository, profiles)
+
+    @Test
+    fun `loads the avatar from the forum profile and the fields from the settings page`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(fields = stored))
+            advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertEquals("林地雪原-0062", state.displayName)
+            assertEquals("https://www.nodeseek.com/avatar/52425.png", state.avatarUrl)
+            assertEquals("常驻杭州", state.bio)
+            assertEquals("### 关于我", state.readme)
+        }
+
+    /** Nothing edited means nothing to save; the top bar's 保存 is driven by this. */
+    @Test
+    fun `a freshly loaded form is not dirty`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(fields = stored))
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isDirty)
+            assertFalse(vm.uiState.value.canSave)
+        }
+
+    @Test
+    fun `editing a field or picking an avatar makes the form dirty`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(fields = stored))
+            advanceUntilIdle()
+
+            vm.updateBio("改成别的")
+            assertTrue(vm.uiState.value.canSave)
+
+            vm.updateBio("常驻杭州")
+            assertFalse(vm.uiState.value.canSave)
+
+            vm.setPendingAvatar(pendingAvatar())
+            assertTrue("a pending avatar alone is a change worth saving", vm.uiState.value.canSave)
+        }
+
+    /** Bio is one line on the site, so a pasted paragraph must not be sent as one. */
+    @Test
+    fun `newlines pasted into Bio are flattened`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(fields = stored))
+            advanceUntilIdle()
+
+            vm.updateBio("第一行\n第二行")
+
+            assertEquals("第一行 第二行", vm.uiState.value.bio)
+        }
+
+    @Test
+    fun `saving writes the avatar before the text fields`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository(fields = stored)
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+
+            vm.setPendingAvatar(pendingAvatar())
+            vm.updateBio("新的一句话")
+            vm.save()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf("uploadAvatar", "saveProfileFields"),
+                repository.calls.filter { it == "uploadAvatar" || it == "saveProfileFields" },
+            )
+            assertEquals("新的一句话", repository.savedFields?.bio)
+            assertNull("a saved avatar is no longer pending", vm.uiState.value.pendingAvatar)
+        }
+
+    /**
+     * The ordering exists for this case: an avatar that failed must stop the save, rather than let the
+     * text fields succeed and the screen report "已保存" for a half-applied change.
+     */
+    @Test
+    fun `a failed avatar upload stops the save and keeps the avatar pending`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository.pendingEndpoints()
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+
+            vm.setPendingAvatar(pendingAvatar())
+            vm.updateBio("新的一句话")
+            vm.save()
+            advanceUntilIdle()
+
+            assertFalse(
+                "text fields must not be written after the avatar failed",
+                repository.calls.contains("saveProfileFields"),
+            )
+            assertTrue(vm.uiState.value.message is AccountMessage.EndpointPending)
+            assertTrue("the picked image is still worth keeping", vm.uiState.value.pendingAvatar != null)
+        }
+
+    @Test
+    fun `saved values become the new baseline`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository(fields = stored))
+            advanceUntilIdle()
+
+            vm.updateBio("新的一句话")
+            vm.save()
+            advanceUntilIdle()
+
+            assertFalse("after a successful save there is nothing left to save", vm.uiState.value.canSave)
+            assertEquals("新的一句话", vm.uiState.value.saved?.bio)
+        }
+
+    @Test
+    fun `a pending endpoint shows the banner without a snackbar`() =
+        runTest(dispatcher) {
+            val vm = viewModel(FakeAccountSettingsRepository.pendingEndpoints())
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.endpointPending)
+            assertNull(vm.uiState.value.message)
+        }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/SecurityScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/SecurityScreenTest.kt
@@ -1,0 +1,138 @@
+package io.github.nsreader.ui.account
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The claim 安全 makes is that nothing high-risk happens on one tap. These tests hold it to that.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class SecurityScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val ready =
+        SecurityUiState(
+            isLoading = false,
+            twoFactorEnabled = false,
+            currentPassword = "old-password",
+            newPassword = "Correct-Horse-9",
+            confirmPassword = "Correct-Horse-9",
+        )
+
+    private fun setContent(
+        state: SecurityUiState,
+        onRequestPasswordChange: () -> Unit = {},
+        onConfirmPasswordChange: () -> Unit = {},
+        onDismissConfirmation: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            NodeSeekTheme {
+                SecurityScreen(
+                    state = state,
+                    snackbarHostState = remember { SnackbarHostState() },
+                    onBack = {},
+                    onCurrentPasswordChange = {},
+                    onNewPasswordChange = {},
+                    onRepeatPasswordChange = {},
+                    onToggleCurrentVisible = {},
+                    onToggleNewVisible = {},
+                    onToggleConfirmVisible = {},
+                    onRequestPasswordChange = onRequestPasswordChange,
+                    onRequestTwoFactor = {},
+                    onDismissConfirmation = onDismissConfirmation,
+                    onConfirmPasswordChange = onConfirmPasswordChange,
+                    onConfirmTwoFactor = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `pressing update only opens the dialog, it does not submit`() {
+        var requested = false
+        var submitted = false
+        setContent(
+            state = ready,
+            onRequestPasswordChange = { requested = true },
+            onConfirmPasswordChange = { submitted = true },
+        )
+
+        composeRule.onNodeWithText("更新密码").performScrollTo().performClick()
+
+        assertEquals(true, requested)
+        assertFalse(submitted)
+    }
+
+    @Test
+    fun `only the dialog's confirm submits`() {
+        var submitted = false
+        setContent(
+            state = ready.copy(confirming = SecurityConfirmation.Password),
+            onConfirmPasswordChange = { submitted = true },
+        )
+
+        composeRule.onNodeWithText("确认修改").performClick()
+
+        assertEquals(true, submitted)
+    }
+
+    /** The dialog names the consequence, which is the point of having one. */
+    @Test
+    fun `the confirmation says what changing the password does to other devices`() {
+        setContent(ready.copy(confirming = SecurityConfirmation.Password))
+
+        composeRule.onNodeWithText("确认修改密码？").assertExists()
+        composeRule
+            .onNodeWithText("修改后除当前设备外，其他已登录设备将全部退出，需要用新密码重新登录。")
+            .assertExists()
+    }
+
+    @Test
+    fun `mismatched confirmations block the update`() {
+        setContent(ready.copy(confirmPassword = "Correct-Horse-8"))
+
+        composeRule.onNodeWithText("两次输入的新密码不一致").performScrollTo().assertExists()
+        composeRule.onNodeWithText("更新密码").performScrollTo().assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a too-short password blocks the update and says the minimum`() {
+        setContent(ready.copy(newPassword = "short", confirmPassword = "short"))
+
+        composeRule.onNodeWithText("新密码至少 8 位").performScrollTo().assertExists()
+        composeRule.onNodeWithText("更新密码").performScrollTo().assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a complete, matching form enables the update`() {
+        setContent(ready)
+
+        composeRule.onNodeWithText("更新密码").performScrollTo().assertIsEnabled()
+    }
+
+    /** The banner has to be visible before the user types a password, not after they submit one. */
+    @Test
+    fun `a pending endpoint is stated at the top of the screen`() {
+        setContent(ready.copy(endpointPending = true))
+
+        composeRule.onNodeWithText("这一组还没接入站点接口").assertExists()
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/account/SecurityViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/account/SecurityViewModelTest.kt
@@ -1,0 +1,188 @@
+package io.github.nsreader.ui.account
+
+import io.github.nsreader.data.account.TwoFactorState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * The two riskiest writes in the app. What is tested here is that neither can happen on one tap, and
+ * that a failed attempt does not cost the user everything they typed.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecurityViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() = Dispatchers.setMain(dispatcher)
+
+    @After
+    fun tearDown() = Dispatchers.resetMain()
+
+    private fun readyViewModel(repository: FakeAccountSettingsRepository): SecurityViewModel {
+        val vm = SecurityViewModel(repository)
+        vm.updateCurrentPassword("old-password")
+        vm.updateNewPassword("Correct-Horse-9")
+        vm.updateConfirmPassword("Correct-Horse-9")
+        return vm
+    }
+
+    @Test
+    fun `reads the two-factor state on open`() =
+        runTest(dispatcher) {
+            val vm = SecurityViewModel(FakeAccountSettingsRepository(twoFactor = TwoFactorState(true)))
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isLoading)
+            assertEquals(true, vm.uiState.value.twoFactorEnabled)
+        }
+
+    @Test
+    fun `requesting a password change only opens the dialog`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository()
+            val vm = readyViewModel(repository)
+            advanceUntilIdle()
+
+            vm.requestPasswordChange()
+            advanceUntilIdle()
+
+            assertEquals(SecurityConfirmation.Password, vm.uiState.value.confirming)
+            assertNull("the request alone must not reach the network", repository.changedPassword)
+        }
+
+    @Test
+    fun `only the confirmation submits`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository()
+            val vm = readyViewModel(repository)
+            advanceUntilIdle()
+
+            vm.requestPasswordChange()
+            vm.confirmPasswordChange()
+            advanceUntilIdle()
+
+            assertEquals("old-password" to "Correct-Horse-9", repository.changedPassword)
+            assertNull(vm.uiState.value.confirming)
+        }
+
+    @Test
+    fun `a successful change clears all three fields`() =
+        runTest(dispatcher) {
+            val vm = readyViewModel(FakeAccountSettingsRepository())
+            advanceUntilIdle()
+
+            vm.confirmPasswordChange()
+            advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertEquals("", state.currentPassword)
+            assertEquals("", state.newPassword)
+            assertEquals("", state.confirmPassword)
+        }
+
+    /** Wiping the form on failure would make the user retype three passwords to retry. */
+    @Test
+    fun `a failed change keeps what was typed`() =
+        runTest(dispatcher) {
+            val vm = readyViewModel(FakeAccountSettingsRepository.pendingEndpoints())
+            advanceUntilIdle()
+
+            vm.confirmPasswordChange()
+            advanceUntilIdle()
+
+            val state = vm.uiState.value
+            assertEquals("old-password", state.currentPassword)
+            assertEquals("Correct-Horse-9", state.newPassword)
+            assertTrue(state.message is AccountMessage.EndpointPending)
+        }
+
+    @Test
+    fun `an incomplete or mismatched form cannot be submitted`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository()
+            val vm = SecurityViewModel(repository)
+            advanceUntilIdle()
+
+            vm.updateCurrentPassword("old-password")
+            vm.updateNewPassword("Correct-Horse-9")
+            vm.updateConfirmPassword("Correct-Horse-8")
+            assertTrue(vm.uiState.value.isMismatched)
+            assertFalse(vm.uiState.value.canSubmitPassword)
+
+            vm.confirmPasswordChange()
+            advanceUntilIdle()
+            assertNull(repository.changedPassword)
+        }
+
+    @Test
+    fun `a too-short password cannot be submitted`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository()
+            val vm = SecurityViewModel(repository)
+            advanceUntilIdle()
+
+            vm.updateCurrentPassword("old-password")
+            vm.updateNewPassword("short")
+            vm.updateConfirmPassword("short")
+
+            assertTrue(vm.uiState.value.isTooShort)
+            vm.confirmPasswordChange()
+            advanceUntilIdle()
+            assertNull(repository.changedPassword)
+        }
+
+    @Test
+    fun `two-factor enrolment also waits for its confirmation, then hands out the uri`() =
+        runTest(dispatcher) {
+            val repository = FakeAccountSettingsRepository()
+            val vm = SecurityViewModel(repository)
+            advanceUntilIdle()
+
+            vm.requestTwoFactorEnrolment()
+            advanceUntilIdle()
+            assertEquals(SecurityConfirmation.TwoFactor, vm.uiState.value.confirming)
+            assertFalse(repository.calls.contains("beginTwoFactorEnrolment"))
+
+            vm.confirmTwoFactorEnrolment()
+            advanceUntilIdle()
+
+            assertEquals(repository.enrolmentUri, vm.uiState.value.enrolmentUri)
+        }
+
+    /** The URI is handed over once; keeping it would re-launch the authenticator on every recomposition. */
+    @Test
+    fun `the enrolment uri is consumed after being handed over`() =
+        runTest(dispatcher) {
+            val vm = SecurityViewModel(FakeAccountSettingsRepository())
+            advanceUntilIdle()
+            vm.confirmTwoFactorEnrolment()
+            advanceUntilIdle()
+
+            vm.consumeEnrolmentUri()
+
+            assertNull(vm.uiState.value.enrolmentUri)
+        }
+
+    @Test
+    fun `a missing authenticator app is reported rather than swallowed`() =
+        runTest(dispatcher) {
+            val vm = SecurityViewModel(FakeAccountSettingsRepository())
+            advanceUntilIdle()
+
+            vm.reportMissingAuthenticatorApp()
+
+            assertTrue(vm.uiState.value.message is AccountMessage.Info)
+        }
+}

--- a/app/src/test/java/io/github/nsreader/ui/common/MarkdownFormattingTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/common/MarkdownFormattingTest.kt
@@ -1,0 +1,87 @@
+package io.github.nsreader.ui.common
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The caret arithmetic that used to exist twice — once in the post composer, once in the signature
+ * editor — and was the thing most likely to drift when only one copy got fixed.
+ */
+class MarkdownFormattingTest {
+    private val bold = MarkdownInsertion(prefix = "**", suffix = "**", placeholder = "加粗文字")
+    private val heading = MarkdownInsertion(prefix = "## ", placeholder = "标题")
+    private val link =
+        MarkdownInsertion(
+            prefix = "[",
+            suffix = MARKDOWN_LINK_SUFFIX,
+            placeholder = "链接文字",
+            caretInSuffix = MARKDOWN_LINK_CARET,
+        )
+
+    private fun field(text: String, selection: IntRange? = null) =
+        TextFieldValue(
+            text = text,
+            selection =
+            selection?.let { TextRange(it.first, it.last) } ?: TextRange(text.length),
+        )
+
+    @Test
+    fun `with nothing selected the placeholder is inserted and the caret sits on it`() {
+        val result = field("").applyMarkdown(bold)
+
+        assertEquals("**加粗文字**", result.text)
+        // Just past the opening delimiter, so typing replaces the placeholder in place.
+        assertEquals(TextRange(2), result.selection)
+    }
+
+    @Test
+    fun `a selection is wrapped and the caret goes to the end`() {
+        val result = field("出杭州轻量", selection = 0..5).applyMarkdown(bold)
+
+        assertEquals("**出杭州轻量**", result.text)
+        assertEquals(TextRange("**出杭州轻量**".length), result.selection)
+    }
+
+    @Test
+    fun `a prefix-only action needs no suffix`() {
+        val result = field("关于我", selection = 0..3).applyMarkdown(heading)
+
+        assertEquals("## 关于我", result.text)
+        assertEquals(TextRange("## 关于我".length), result.selection)
+    }
+
+    /** Link is the exception: with the text written, the URL is the only thing left to type. */
+    @Test
+    fun `link puts the caret in the url slot rather than at the end`() {
+        val result = field("星辰担保", selection = 0..4).applyMarkdown(link)
+
+        assertEquals("[星辰担保](https://)", result.text)
+        assertEquals(TextRange("[星辰担保](".length), result.selection)
+    }
+
+    @Test
+    fun `an empty link selection puts the caret on the link text`() {
+        val result = field("").applyMarkdown(link)
+
+        assertEquals("[链接文字](https://)", result.text)
+        assertEquals(TextRange(1), result.selection)
+    }
+
+    @Test
+    fun `formatting applies in the middle of existing text`() {
+        val result = field("交易走星辰担保，勿私", selection = 3..7).applyMarkdown(bold)
+
+        assertEquals("交易走**星辰担保**，勿私", result.text)
+        assertEquals(TextRange("交易走**星辰担保**".length), result.selection)
+    }
+
+    @Test
+    fun `an out-of-range selection is clamped rather than crashing`() {
+        val result =
+            TextFieldValue("短", selection = TextRange(0, 99)).applyMarkdown(bold)
+
+        assertEquals("**短**", result.text)
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/postlist/PostListViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/postlist/PostListViewModelTest.kt
@@ -11,11 +11,14 @@ import io.github.nsreader.data.OfflineFirstPostRepository
 import io.github.nsreader.data.inMemoryDatabase
 import io.github.nsreader.data.local.NodeSeekDatabase
 import io.github.nsreader.data.session.SessionState
+import io.github.nsreader.data.settings.SettingsRepository
+import io.github.nsreader.data.testSettingsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -71,12 +74,14 @@ class PostListViewModelTest {
 
     private val session = MutableStateFlow(SessionState())
 
-    private fun viewModel() =
-        PostListViewModel(
-            repository = OfflineFirstPostRepository(database, remote, clock),
-            categoryRepository = CategoryRepository(failingJson, database.boardDao(), clock),
-            session = session,
-        )
+    private fun TestScope.viewModel(
+        settings: SettingsRepository = testSettingsRepository(backgroundScope),
+    ) = PostListViewModel(
+        repository = OfflineFirstPostRepository(database, remote, clock),
+        categoryRepository = CategoryRepository(failingJson, database.boardDao(), clock),
+        settingsRepository = settings,
+        session = session,
+    )
 
     @Test
     fun `starts on the front page with the front page tab selected`() =
@@ -98,6 +103,40 @@ class PostListViewModelTest {
             assertEquals(CategoryRepository.FRONT_PAGE, boards.first())
             // The API call failed, so this is the offline fallback list — still more than nothing.
             assertTrue("expected fallback boards, got $boards", boards.size > 1)
+        }
+
+    @Test
+    fun `the strip honours the 首页版块 preference and always keeps the front page`() =
+        runTest(dispatcher) {
+            val settings = testSettingsRepository(backgroundScope)
+            settings.setHomeBoards(setOf("tech", "trade"))
+            val vm = viewModel(settings)
+            advanceUntilIdle()
+
+            val boards = vm.uiState.value.boards
+            assertEquals(CategoryRepository.FRONT_PAGE, boards.first())
+            assertEquals(listOf("tech", "trade"), boards.drop(1).map { it.slug })
+        }
+
+    /**
+     * Hiding the board being read would leave a selected pill that is no longer on the strip, and the
+     * feed underneath would keep paging a board the user can no longer see or leave.
+     */
+    @Test
+    fun `hiding the board being read falls back to the front page`() =
+        runTest(dispatcher) {
+            val settings = testSettingsRepository(backgroundScope)
+            val vm = viewModel(settings)
+            advanceUntilIdle()
+            vm.selectCategory("tech")
+            advanceUntilIdle()
+            assertEquals("tech", vm.uiState.value.categorySlug)
+
+            settings.setHomeBoards(setOf("trade"))
+            advanceUntilIdle()
+
+            assertEquals(null, vm.uiState.value.categorySlug)
+            assertEquals(0, vm.uiState.value.selectedBoardIndex)
         }
 
     @Test
@@ -204,6 +243,7 @@ class PostListViewModelTest {
                 PostListViewModel(
                     repository = repository,
                     categoryRepository = CategoryRepository(failingJson, database.boardDao(), clock),
+                    settingsRepository = testSettingsRepository(backgroundScope),
                     session = session,
                 )
             advanceUntilIdle()

--- a/app/src/test/java/io/github/nsreader/ui/profile/ProfileScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/profile/ProfileScreenTest.kt
@@ -35,6 +35,7 @@ class ProfileScreenTest {
                     onSignOut = {},
                     onRetry = {},
                     onSettings = {},
+                    onAccountSettings = {},
                     onOpenWebsite = {},
                     onEditProfile = {},
                 )
@@ -59,6 +60,7 @@ class ProfileScreenTest {
                     onSignOut = {},
                     onRetry = {},
                     onSettings = {},
+                    onAccountSettings = {},
                     onOpenWebsite = {},
                     onEditProfile = {},
                 )
@@ -79,6 +81,7 @@ class ProfileScreenTest {
                     onSignOut = {},
                     onRetry = {},
                     onSettings = {},
+                    onAccountSettings = {},
                     onOpenWebsite = {},
                     onEditProfile = { clicked = true },
                 )


### PR DESCRIPTION
落地 `design/` 里的 **8g 账号设置** 和 **d6 账号设置二级页（1/4–4/4）** 两张画板。

## 改了什么

**8g 账号设置** — 按 `/setting` 实测的七分组落地：个人信息 / 安全 / 双因素验证 / 联系方式 / 屏蔽用户 / 常用偏好 / 首页版块。高风险项一律进二级页并二次确认，**不给开关**。每行带当前值副文案 —— 站点自己的页面只是一串锚点链接，副文案是这个界面唯一比「在浏览器里打开 /setting」多出来的东西。入口加在「我的」菜单。

**d6 四个二级页**

| 页 | 内容 |
|---|---|
| 1/4 个人信息 | 头像（系统相册选择器 + 拍照，512px 下采样）、Bio、签名、Readme |
| 2/4 安全 | 改密三字段 + 实时强度条、TOTP 绑定 |
| 3/4 联系方式与屏蔽 | 邮箱已验证/未验证徽章、屏蔽列表 + 空态 |
| 4/4 首页版块 | 13 个版块按四色族分组，本地偏好过滤首页版块条 |

签名工具栏刻意减配为 加粗/斜体/删除线/链接/代码 —— 站点 helper 明说签名不支持图片和引用，给了按钮再让服务端悄悄丢掉标记，正是这个界面要避免的失败模式。

**顺带的重构**
- `BoardTag` 的四色族提升为共享 API（`boardFamilyOf` / `boardFamilyColors`），版块选择页和列表行的标签用同一套分组
- `SettingsScreen` 的分组列表原语抽到 `SettingsListItems`，两个设置页共用同一套 18/5/2 圆角节奏

## 为什么这么做

**首页版块是唯一真正打通写操作的一页**，因为它本来就不是站点设置，而是 App 自己的呈现选择，存在 DataStore 里。站点的 `#homepage` 分组管的是网站自己的布局，绕服务端会让版块条依赖网络才能画出来。

「全部」存成**空集合**而不是当天 13 个 slug 的快照 —— 否则站点以后加版块会被永久隐藏。当前所选版块被取消勾选时，选中态回落到综合，不然会留下一个不在条上的选中 pill。

**其余三页的读写集中在 `AccountSettingsRepository` 一个文件**，每个方法的 KDoc 记着该抓哪个请求。NodeSeek 没有公开 API，`/setting` 是客户端渲染页、写操作走 XHR，请求形状没法像列表和详情解析器那样从 HTML 读出来，必须在真机登录态下抓（沙箱里任何带认证的请求都吃 Cloudflare 403）。

这里统一抛 `EndpointNotVerifiedException`、界面顶部显示待接入横幅，**而不是猜端点**：`/api/account/…` 猜错很可能返回一个 `{"success":false}`，在只看异常的调用方眼里就等于「已保存」—— 而这些操作里有改密码和换邮箱，静默什么都不做或静默做错事的代价是账号。之后抓到真实请求只改那一个文件，横幅会自己消失，界面不用动。

## 真机上发现并修掉的两个 bug

1. **版块描述压住标题。** fixture 里 `description = null`，但线上 API 每个版块都带一整句描述（交易那条 30 个字），侧排会把标题挤成零宽再折行盖上去。改成两行 ListItem，并把真实描述写进 `@Preview`，这类问题以后在预览里就能看见。
2. **密码强度算法被自己的测试推翻。** 长度和字符种类等权时，25 位口令和 `aB1!` 同分 —— 正好倒转了这个条要给的建议。长度改成比种类多一档权重。

## 验证

- `testDebugUnitTest` / `lintDebug` / `spotlessCheck` 全绿，新增 30 个测试（纯逻辑、ViewModel 存储契约、三个界面的交互）
- 真机（索尼 J9110 / Android 10）带真实账号走通全部五个界面
- **端到端验证过首页版块**：13 → 取消 4 个 → 保存 → 首页版块条确实只剩那 9 个 + 综合；「重置」后 8g 副文案回到「全部 13 个版块」而不是「已选 13 个」，确认存的是「不限制」

## Reviewer 需要知道的

- 强度条**永远不拦保存**，只在提示。服务端才拥有真正的口令策略，客户端规则和它不一致会拒掉站点其实接受的密码。
- 邮箱校验刻意只够抓错别字，不试图实现 RFC 5322 —— 那种正则会拒掉能用的地址。
- `HomeBoardsViewModelTest` 里有个 `saveAndAwait` 辅助方法，因为 `advanceUntilIdle()` **等不到** DataStore 的写：它在测试调度器管不到的真实 `Dispatchers.IO` 上落盘，调度器会在写还在飞的时候就空闲，紧跟其后的断言读到的是还没被碰过的 store。原因写在那个方法的 KDoc 里。
- 拍照用的是 `TakePicturePreview`（不用权限、不用 FileProvider，代价是缩略图分辨率）。接真实上传时要确认站点接受的尺寸，必要时换 `TakePicture` + 缓存文件 Uri，`AvatarPicker` 的 KDoc 里记了这一条。
- `重新发送` 验证邮件那行文案目前是静态的，等联系方式接口接上后应改成由服务器响应驱动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
