### PR TITLE
实现用户空间、资产成长、社区工具与图片查看器（含 22 项审查修复）

### DIFF
--- a/app/src/main/java/io/github/nsreader/Navigation.kt
+++ b/app/src/main/java/io/github/nsreader/Navigation.kt
@@ -1,18 +1,33 @@
 package io.github.nsreader
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
@@ -24,6 +39,10 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import io.github.nsreader.core.NodeSeekSite
 import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.assets.AssetsRoute
+import io.github.nsreader.ui.assets.AssetsViewModel
+import io.github.nsreader.ui.assets.StardustRoute
+import io.github.nsreader.ui.assets.StardustViewModel
 import io.github.nsreader.ui.composer.PostComposerRoute
 import io.github.nsreader.ui.composer.PostComposerViewModel
 import io.github.nsreader.ui.login.WebViewGoal
@@ -40,8 +59,25 @@ import io.github.nsreader.ui.profile.ProfileRoute
 import io.github.nsreader.ui.profile.ProfileViewModel
 import io.github.nsreader.ui.search.SearchRoute
 import io.github.nsreader.ui.search.SearchViewModel
+import io.github.nsreader.ui.settings.AccountSettingsRoute
+import io.github.nsreader.ui.settings.AccountSettingsViewModel
 import io.github.nsreader.ui.settings.SettingsRoute
 import io.github.nsreader.ui.settings.SettingsViewModel
+import io.github.nsreader.ui.space.FollowRoute
+import io.github.nsreader.ui.space.FollowViewModel
+import io.github.nsreader.ui.space.UserSpaceRoute
+import io.github.nsreader.ui.space.UserSpaceViewModel
+import io.github.nsreader.ui.tools.AwardRoute
+import io.github.nsreader.ui.tools.AwardViewModel
+import io.github.nsreader.ui.tools.CommunityToolsScreen
+import io.github.nsreader.ui.tools.InviteRoute
+import io.github.nsreader.ui.tools.InviteViewModel
+import io.github.nsreader.ui.tools.LuckyRoute
+import io.github.nsreader.ui.tools.LuckyViewModel
+import io.github.nsreader.ui.tools.RulingRoute
+import io.github.nsreader.ui.tools.RulingViewModel
+import io.github.nsreader.ui.viewer.ImageViewerScreen
+import io.github.nsreader.ui.viewer.ImageViewerViewModel
 
 @Composable
 fun MainNavigation(container: AppContainer) {
@@ -146,12 +182,15 @@ fun MainNavigation(container: AppContainer) {
                 entry<PostListKey> {
                     val viewModel: PostListViewModel =
                         viewModel(factory = PostListViewModel.factory(container))
-                    PostListRoute(
-                        viewModel = viewModel,
-                        onPostClick = { backStack.add(PostDetailKey(it)) },
+                    HomePane(
+                        container = container,
+                        listViewModel = viewModel,
+                        onOpenPostFullScreen = { backStack.add(PostDetailKey(it)) },
                         onCreatePost = { backStack.add(PostComposerKey) },
                         onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
                         onVerify = { backStack.add(WebKey(it, siteTitle, WebViewGoal.CHALLENGE)) },
+                        onOpenBrowser = openExternalUrl,
+                        onImageClick = { urls, url -> backStack.add(imageViewerKeyFor(urls, url)) },
                     )
                 }
 
@@ -161,7 +200,13 @@ fun MainNavigation(container: AppContainer) {
                     SearchRoute(
                         viewModel = viewModel,
                         onPostClick = { backStack.add(PostDetailKey(it)) },
-                        onUserClick = { uid -> openExternalUrl(NodeSeekSite.BASE_URL + NodeSeekSite.spacePath(uid)) },
+                        // A user result now has a screen of its own, so it stays in the app. Finding
+                        // yourself in search must open the same self-shaped space 我的 opens.
+                        onUserClick = { uid ->
+                            backStack.add(
+                                UserSpaceKey(uid, isSelf = uid == container.profileRepository.selfUid),
+                            )
+                        },
                         onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
                         onVerify = { backStack.add(WebKey(it, siteTitle, WebViewGoal.CHALLENGE)) },
                     )
@@ -192,9 +237,11 @@ fun MainNavigation(container: AppContainer) {
                         onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
                         onSettings = { backStack.add(SettingsKey) },
                         onOpenWebsite = { openExternalUrl(NodeSeekSite.BASE_URL) },
-                        onEditProfile = { uid ->
-                            openExternalUrl(NodeSeekSite.BASE_URL + NodeSeekSite.spacePath(uid))
-                        },
+                        onOpenSpace = { uid -> backStack.add(UserSpaceKey(uid, isSelf = true)) },
+                        onAssets = { backStack.add(AssetsKey) },
+                        onFollow = { backStack.add(FollowKey) },
+                        onTools = { backStack.add(CommunityToolsKey) },
+                        onAccountSettings = { backStack.add(AccountSettingsKey) },
                     )
                 }
 
@@ -204,6 +251,196 @@ fun MainNavigation(container: AppContainer) {
                     SettingsRoute(
                         viewModel = viewModel,
                         onBack = { backStack.removeLastOrNull() },
+                    )
+                }
+
+                entry<UserSpaceKey> { key ->
+                    val viewModel: UserSpaceViewModel =
+                        viewModel(
+                            key = "space-${key.uid}",
+                            factory = UserSpaceViewModel.factory(container, key.uid, key.isSelf),
+                        )
+                    UserSpaceRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onPostClick = { postId, floor -> backStack.add(PostDetailKey(postId, floor)) },
+                        // 私信 is the site's own conversation page: authenticated, and with a Markdown
+                        // composer we have not reimplemented, so it opens in the session's web view.
+                        onMessage = { uid ->
+                            backStack.add(
+                                WebKey(
+                                    NodeSeekSite.BASE_URL + NodeSeekSite.messagePath(uid),
+                                    siteTitle,
+                                    WebViewGoal.MANAGE,
+                                ),
+                            )
+                        },
+                        onEditProfile = { backStack.add(AccountSettingsKey) },
+                        onOpenBrowser = openExternalUrl,
+                        onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
+                    )
+                }
+
+                entry<FollowKey> {
+                    val viewModel: FollowViewModel =
+                        viewModel(factory = FollowViewModel.factory(container))
+                    FollowRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onUserClick = { uid ->
+                            backStack.add(
+                                UserSpaceKey(uid, isSelf = uid == container.profileRepository.selfUid),
+                            )
+                        },
+                        // `/fans` only exists for the signed-in user, so it follows the app's rule for
+                        // authenticated pages: the session's own web view, never the system browser.
+                        onOpenBrowser = { url ->
+                            backStack.add(WebKey(url, siteTitle, WebViewGoal.MANAGE))
+                        },
+                        onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
+                    )
+                }
+
+                entry<AssetsKey> {
+                    val viewModel: AssetsViewModel =
+                        viewModel(factory = AssetsViewModel.factory(container))
+                    AssetsRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        // The chicken ledger has no board of its own in this batch and no endpoint
+                        // behind it; the site's table is the honest destination.
+                        onChickenLedger = {
+                            backStack.add(
+                                WebKey(
+                                    NodeSeekSite.BASE_URL + NodeSeekSite.CREDIT_PATH,
+                                    siteTitle,
+                                    WebViewGoal.MANAGE,
+                                ),
+                            )
+                        },
+                        onStardust = { backStack.add(StardustKey) },
+                        // In-app, not the system browser: a Cloudflare pass earned out there lands in
+                        // Chrome's cookie store, and the app's own retry keeps failing forever.
+                        onOpenBrowser = {
+                            backStack.add(
+                                WebKey(NodeSeekSite.BASE_URL, siteTitle, WebViewGoal.CHALLENGE),
+                            )
+                        },
+                        onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
+                    )
+                }
+
+                entry<StardustKey> {
+                    val viewModel: StardustViewModel =
+                        viewModel(factory = StardustViewModel.factory(container))
+                    val state by viewModel.uiState.collectAsStateWithLifecycle()
+                    // The ledger URL is per-member, so it exists only once the profile call has said
+                    // who we are. The screen keeps the transfer entry off until then — landing a
+                    // just-confirmed transfer on the home page would silently drop the typed form.
+                    val ledgerUrl = state.uid?.let { NodeSeekSite.BASE_URL + NodeSeekSite.stardustPath(it) }
+                    val openLedger = {
+                        backStack.add(
+                            WebKey(ledgerUrl ?: NodeSeekSite.BASE_URL, siteTitle, WebViewGoal.MANAGE),
+                        )
+                        Unit
+                    }
+                    StardustRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        // The ledger needs the session's cookies, so it opens in-app like every other
+                        // authenticated page rather than in the cookie-less system browser.
+                        onOpenBrowser = openLedger,
+                        // Confirmed in the app, submitted on the site: sending stardust is irreversible
+                        // and the endpoint is undocumented, so the last step stays where it works.
+                        onTransferOnSite = openLedger,
+                        onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
+                    )
+                }
+
+                entry<AccountSettingsKey> {
+                    val viewModel: AccountSettingsViewModel =
+                        viewModel(factory = AccountSettingsViewModel.factory(container))
+                    AccountSettingsRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onOpenSetting = { group ->
+                            backStack.add(
+                                WebKey(
+                                    NodeSeekSite.BASE_URL + NodeSeekSite.settingPath(group),
+                                    siteTitle,
+                                    WebViewGoal.MANAGE,
+                                ),
+                            )
+                        },
+                    )
+                }
+
+                entry<CommunityToolsKey> {
+                    CommunityToolsScreen(
+                        onBack = { backStack.removeLastOrNull() },
+                        onAward = { backStack.add(AwardKey) },
+                        onProviders = { openExternalUrl(NodeSeekSite.BASE_URL + NodeSeekSite.PROVIDERS_PATH) },
+                        onFriends = { openExternalUrl(NodeSeekSite.BASE_URL + NodeSeekSite.FRIENDS_PATH) },
+                        onLucky = { backStack.add(LuckyKey) },
+                        onInvite = { backStack.add(InviteKey) },
+                        onRuling = { backStack.add(RulingKey) },
+                    )
+                }
+
+                entry<AwardKey> {
+                    val viewModel: AwardViewModel =
+                        viewModel(factory = AwardViewModel.factory(container))
+                    AwardRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onPostClick = { backStack.add(PostDetailKey(it)) },
+                        onOpenBrowser = openExternalUrl,
+                        onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
+                    )
+                }
+
+                entry<LuckyKey> {
+                    val viewModel: LuckyViewModel =
+                        viewModel(factory = LuckyViewModel.factory(container))
+                    LuckyRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onOpenBrowser = openExternalUrl,
+                    )
+                }
+
+                entry<InviteKey> {
+                    val viewModel: InviteViewModel =
+                        viewModel(factory = InviteViewModel.factory(container))
+                    InviteRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onBuyOnSite = { backStack.add(inviteWebKey(siteTitle)) },
+                    )
+                }
+
+                entry<RulingKey> {
+                    val viewModel: RulingViewModel =
+                        viewModel(factory = RulingViewModel.factory(container))
+                    RulingRoute(
+                        viewModel = viewModel,
+                        onBack = { backStack.removeLastOrNull() },
+                        onOpenBrowser = openExternalUrl,
+                        onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
+                    )
+                }
+
+                entry<ImageViewerKey> { key ->
+                    val viewModel: ImageViewerViewModel =
+                        viewModel(factory = ImageViewerViewModel.factory(container))
+                    val saveOutcome by viewModel.saveOutcome.collectAsStateWithLifecycle()
+                    ImageViewerScreen(
+                        urls = key.urls,
+                        initialIndex = key.index,
+                        onClose = { backStack.removeLastOrNull() },
+                        onOpenBrowser = openExternalUrl,
+                        saveOutcome = saveOutcome,
+                        onSave = viewModel::save,
                     )
                 }
 
@@ -221,7 +458,7 @@ fun MainNavigation(container: AppContainer) {
                         onOpenBrowser = openExternalUrl,
                         onSignIn = { backStack.add(WebKey(signInUrl, siteTitle, WebViewGoal.SIGN_IN)) },
                         onVerify = { backStack.add(WebKey(it, siteTitle, WebViewGoal.CHALLENGE)) },
-                        onImageClick = openExternalUrl,
+                        onImageClick = { urls, url -> backStack.add(imageViewerKeyFor(urls, url)) },
                     )
                 }
 
@@ -265,3 +502,131 @@ fun MainNavigation(container: AppContainer) {
         )
     }
 }
+
+/**
+ * The home tab: one column on a phone, list and thread side by side once the window can hold both.
+ *
+ * Above 600dp the thread stops being a separate destination and becomes the right pane, which is what
+ * makes a tablet or an unfolded foldable worth the extra width — you keep your place in the list while
+ * reading, and the rail stays reachable. Below it, nothing changes: tapping a row pushes the full-screen
+ * thread exactly as before.
+ *
+ * The width is read from the actual space this pane was given rather than from the window, so it is
+ * still correct in multi-window and in a preview.
+ */
+@Composable
+private fun HomePane(
+    container: AppContainer,
+    listViewModel: PostListViewModel,
+    onOpenPostFullScreen: (Long) -> Unit,
+    onCreatePost: () -> Unit,
+    onSignIn: () -> Unit,
+    onVerify: (String) -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onImageClick: (List<String>, String) -> Unit,
+) {
+    BoxWithConstraints {
+        val twoPane = maxWidth >= TWO_PANE_MIN_WIDTH
+        val listPaneWidth = if (maxWidth >= WIDE_WINDOW_WIDTH) WIDE_LIST_PANE_WIDTH else LIST_PANE_WIDTH
+
+        // Survives rotation, and survives switching tabs and coming back, because the whole entry does.
+        var selectedPostId by rememberSaveable { mutableStateOf<Long?>(null) }
+
+        if (!twoPane) {
+            /*
+             * A selection made in the two-pane layout follows the user through a rotation as a pushed
+             * full-screen thread — the alternative was losing their place mid-read. Migrating rather
+             * than rendering it here also consumes the selection, so widening the window hours later
+             * cannot resurrect a thread the user finished with.
+             */
+            val orphanedSelection = selectedPostId
+            LaunchedEffect(orphanedSelection) {
+                if (orphanedSelection != null) {
+                    selectedPostId = null
+                    onOpenPostFullScreen(orphanedSelection)
+                }
+            }
+            PostListRoute(
+                viewModel = listViewModel,
+                onPostClick = onOpenPostFullScreen,
+                onCreatePost = onCreatePost,
+                onSignIn = onSignIn,
+                onVerify = onVerify,
+            )
+            return@BoxWithConstraints
+        }
+
+        // Back closes the thread rather than leaving the tab: the pane is where the user's attention is.
+        BackHandler(enabled = selectedPostId != null) { selectedPostId = null }
+
+        Row(Modifier.fillMaxSize()) {
+            PostListRoute(
+                viewModel = listViewModel,
+                onPostClick = { postId -> selectedPostId = postId },
+                onCreatePost = onCreatePost,
+                onSignIn = onSignIn,
+                onVerify = onVerify,
+                modifier = Modifier.width(listPaneWidth),
+            )
+            VerticalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Box(Modifier.weight(1f)) {
+                val postId = selectedPostId
+                if (postId == null) {
+                    EmptyDetailPane()
+                } else {
+                    /*
+                     * One disposable store per selection: switching threads clears the previous
+                     * ViewModel instead of parking it in the entry's store forever. Entry-keyed
+                     * ViewModels looked cheaper, but a long tablet session left every thread ever
+                     * opened — full comment tree and all — alive until the entry itself died.
+                     */
+                    val storeOwner = remember(postId) { PaneViewModelStoreOwner() }
+                    DisposableEffect(storeOwner) {
+                        onDispose { storeOwner.viewModelStore.clear() }
+                    }
+                    val detailViewModel: PostDetailViewModel =
+                        viewModel(
+                            viewModelStoreOwner = storeOwner,
+                            factory = PostDetailViewModel.factory(container, postId),
+                        )
+                    PostDetailRoute(
+                        viewModel = detailViewModel,
+                        onBack = { selectedPostId = null },
+                        onOpenBrowser = onOpenBrowser,
+                        onSignIn = onSignIn,
+                        onVerify = onVerify,
+                        onImageClick = onImageClick,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyDetailPane() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = stringResource(R.string.home_pane_empty),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/** A ViewModel store the detail pane can discard wholesale when the selection moves on. */
+private class PaneViewModelStoreOwner : ViewModelStoreOwner {
+    override val viewModelStore = ViewModelStore()
+}
+
+/** Buying an invite code is a site-side spend; the app only confirms it. */
+private fun inviteWebKey(title: String): WebKey =
+    WebKey(NodeSeekSite.BASE_URL + NodeSeekSite.INVITE_PATH, title, WebViewGoal.MANAGE)
+
+private fun imageViewerKeyFor(urls: List<String>, url: String): ImageViewerKey =
+    ImageViewerKey(urls = urls, index = urls.indexOf(url).coerceAtLeast(0))
+
+private val TWO_PANE_MIN_WIDTH = 600.dp
+private val WIDE_WINDOW_WIDTH = 840.dp
+private val LIST_PANE_WIDTH = 260.dp
+private val WIDE_LIST_PANE_WIDTH = 320.dp

--- a/app/src/main/java/io/github/nsreader/NavigationKeys.kt
+++ b/app/src/main/java/io/github/nsreader/NavigationKeys.kt
@@ -30,6 +30,60 @@ data class PostDetailKey(
 ) : NavKey
 
 /**
+ * A user's space.
+ *
+ * [isSelf] is carried rather than compared at render time because it changes the screen's shape, not
+ * just its contents: the signed-in user gets a 收藏 tab and no 私信 button, and the site has no way to
+ * read anyone else's collections. Deciding that from the session inside the screen would make the tab
+ * row flicker on the first frame, before the profile call resolves.
+ */
+@Serializable
+data class UserSpaceKey(
+    val uid: Long,
+    val isSelf: Boolean = false,
+) : NavKey
+
+/** 我的关注 / 我的粉丝. Only ever the signed-in user's — the site publishes nobody else's. */
+@Serializable
+data object FollowKey : NavKey
+
+@Serializable
+data object AssetsKey : NavKey
+
+@Serializable
+data object StardustKey : NavKey
+
+@Serializable
+data object AccountSettingsKey : NavKey
+
+@Serializable
+data object CommunityToolsKey : NavKey
+
+@Serializable
+data object AwardKey : NavKey
+
+@Serializable
+data object LuckyKey : NavKey
+
+@Serializable
+data object InviteKey : NavKey
+
+@Serializable
+data object RulingKey : NavKey
+
+/**
+ * Full-screen image viewer.
+ *
+ * Carries the whole set of images in the thread plus which one was tapped, so swiping between them
+ * needs no further trip to the data layer — the URLs were already parsed into the rendered content.
+ */
+@Serializable
+data class ImageViewerKey(
+    val urls: List<String>,
+    val index: Int = 0,
+) : NavKey
+
+/**
  * Opens the restricted in-app browser for login and Cloudflare challenges.
  *
  * [goal] is what turns it from a browser into a step in a flow: it names the cookie the screen is

--- a/app/src/main/java/io/github/nsreader/core/LuckyDraw.kt
+++ b/app/src/main/java/io/github/nsreader/core/LuckyDraw.kt
@@ -1,0 +1,62 @@
+package io.github.nsreader.core
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * The parameters of a T-floor draw, as `/lucky` asks for them.
+ *
+ * NodeSeek's "幸运抽奖" is not a game — it is a notary: you declare in advance which thread, when it
+ * closes, how many prizes, which floor counting starts from, and whether one user can win twice. The
+ * link that comes out is what gets pasted into the thread, and anyone can open it afterwards to check
+ * the result was not chosen after the fact. Nothing is spent.
+ */
+data class LuckyDrawParams(
+    val postId: Long,
+    val drawAtMillis: Long,
+    val prizeCount: Int,
+    val startFloor: Int,
+    val dedupeFloors: Boolean,
+)
+
+object LuckyDraw {
+
+    const val MAX_PRIZE_COUNT = 999
+
+    /**
+     * Builds the public draw link.
+     *
+     * The query keys follow the site's own form (`post` / `time` / `n` / `start` / `unique`). They are
+     * read off the page rather than from a documented API, so this stays one small function with a
+     * test: if the site renames a key, one assertion fails instead of a screen going quietly wrong.
+     */
+    fun link(params: LuckyDrawParams, zone: ZoneId = ZoneId.systemDefault()): String {
+        val drawAt =
+            LocalDateTime
+                .ofInstant(Instant.ofEpochMilli(params.drawAtMillis), zone)
+                .format(DRAW_TIME_FORMAT)
+        val query =
+            listOf(
+                "post" to params.postId.toString(),
+                "time" to drawAt,
+                "n" to params.prizeCount.coerceAtLeast(1).toString(),
+                "start" to params.startFloor.coerceAtLeast(0).toString(),
+                "unique" to if (params.dedupeFloors) "1" else "0",
+            ).joinToString("&") { (key, value) -> "$key=${value.urlEncode()}" }
+        return "${NodeSeekSite.BASE_URL}${NodeSeekSite.LUCKY_PATH}?$query"
+    }
+
+    /** The same instant, formatted the way the form displays it. */
+    fun formatDrawTime(millis: Long, zone: ZoneId = ZoneId.systemDefault()): String =
+        LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), zone).format(DISPLAY_TIME_FORMAT)
+
+    private val DRAW_TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+    private val DISPLAY_TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy/M/d HH:mm")
+
+    private fun String.urlEncode(): String =
+        URLEncoder.encode(this, StandardCharsets.UTF_8.toString()).replace("+", "%20")
+}

--- a/app/src/main/java/io/github/nsreader/core/NodeSeekSite.kt
+++ b/app/src/main/java/io/github/nsreader/core/NodeSeekSite.kt
@@ -72,6 +72,65 @@ object NodeSeekSite {
 
     fun spacePath(uid: Long): String = "/space/$uid"
 
+    /**
+     * The site's own hash routes inside a space page.
+     *
+     * Worth naming because the tab a user was on is not recoverable from the path alone: `/space/12`
+     * and `/space/12#/comments` are the same document, and the WebView fallbacks below only land on
+     * the right tab when the fragment goes with them.
+     */
+    fun spaceTabPath(uid: Long, tab: String): String = "${spacePath(uid)}#/$tab"
+
+    const val SPACE_TAB_GENERAL = "general"
+    const val SPACE_TAB_DISCUSSIONS = "discussions"
+    const val SPACE_TAB_COMMENTS = "comments"
+    const val SPACE_TAB_COLLECTIONS = "collections"
+
+    /** The conversation with one user, which is the only action a public space page offers. */
+    fun messagePath(uid: Long): String = "/notification#/message?mode=talk&to=$uid"
+
+    /** Follows and followers are one page with a query parameter, and only for the signed-in user. */
+    fun fansPath(followers: Boolean): String = if (followers) "/fans?type=fans" else "/fans?type=follow"
+
+    const val PROGRESS_PATH = "/progress"
+    const val CREDIT_PATH = "/credit"
+
+    fun stardustPath(uid: Long): String = "/stardust/list?member_id=$uid"
+
+    const val RULING_PATH = "/ruling"
+    const val INVITE_PATH = "/invite"
+    const val LUCKY_PATH = "/lucky"
+    const val PROVIDERS_PATH = "/providers"
+    const val FRIENDS_PATH = "/friends"
+
+    /**
+     * Curated ("加精") threads. Server-rendered like the feed, so [listPath]'s parser applies.
+     *
+     * Paged as `/award/page-2`, the same scheme as the boards. `?page=` looks plausible and the server
+     * even answers it — with page 1, silently, which is worse than an error (verified live 2026-07).
+     */
+    fun awardPath(page: Int): String {
+        val safePage = page.coerceAtLeast(1)
+        return if (safePage == 1) "/award" else "/award/page-$safePage"
+    }
+
+    /**
+     * Account settings, one hash per group.
+     *
+     * Every one of these opens in the WebView rather than in a native form: they change credentials,
+     * two-factor enrolment and block lists, and the site exposes no API for any of it. Guessing the
+     * form fields would mean submitting credential changes we cannot verify.
+     */
+    fun settingPath(group: String): String = "/setting#$group"
+
+    const val SETTING_INTRODUCTION = "introduction"
+    const val SETTING_SECURITY = "security"
+    const val SETTING_TWO_FACTOR = "2fa"
+    const val SETTING_CONTACT = "contact"
+    const val SETTING_BLOCK = "block"
+    const val SETTING_PREFERENCE = "preference"
+    const val SETTING_HOMEPAGE = "homepage"
+
     const val NEW_DISCUSSION_PATH = "/new-discussion"
     const val NEW_DISCUSSION_API_PATH = "/api/content/new-discussion"
 

--- a/app/src/main/java/io/github/nsreader/core/html/PostListParser.kt
+++ b/app/src/main/java/io/github/nsreader/core/html/PostListParser.kt
@@ -18,6 +18,15 @@ object PostListParser {
             // The pager renders `pager-next` as a disabled <span> on the last page, so
             // requiring an <a href> is what tells us whether more pages exist.
             hasNextPage = document.selectFirst(Selectors.LIST_PAGER_NEXT) != null,
+            totalPages =
+            document
+                .select(Selectors.LIST_PAGER_POSITIONS)
+                // The last position renders as "..100" — an ellipsis span glued to the number — so
+                // only the digits are read; a position with none (a bare "…") is skipped.
+                .mapNotNull { position -> position.text().filter(Char::isDigit).toIntOrNull() }
+                .maxOrNull()
+                ?.coerceAtLeast(page)
+                ?: page,
         )
     }
 

--- a/app/src/main/java/io/github/nsreader/core/net/NodeSeekError.kt
+++ b/app/src/main/java/io/github/nsreader/core/net/NodeSeekError.kt
@@ -23,6 +23,17 @@ sealed interface NodeSeekError {
     /** Transport failure — no connection, timeout, TLS. */
     data object Network : NodeSeekError
 
+    /**
+     * The page exists on the site but the app has no endpoint for it.
+     *
+     * Not a failure of this request — nothing was sent. Several NodeSeek pages (`/credit`,
+     * `/stardust/list`, `/fans`, `/ruling`) render entirely client-side and expose no XHR we could
+     * read without guessing at a contract, so the screen says so and offers the web page instead of
+     * inventing rows. Distinct from [Unparsable], which means we *did* ask and could not read the
+     * answer.
+     */
+    data object NotWired : NodeSeekError
+
     /** Anything we could not classify. */
     data object Unknown : NodeSeekError
 }

--- a/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
+++ b/app/src/main/java/io/github/nsreader/core/net/NodeSeekJsonClient.kt
@@ -2,20 +2,42 @@ package io.github.nsreader.core.net
 
 import io.github.nsreader.core.AppDispatchers
 import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.html.Selectors
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+
+/** A POST answer that survived transport and challenge classification; the status is the caller's to read. */
+data class JsonPostResponse(
+    val code: Int,
+    val body: String,
+) {
+    val isSuccessful: Boolean get() = code in 200..299
+}
 
 /**
  * The handful of real JSON endpoints NodeSeek exposes. They do not cover browsing — lists and post
  * pages are still HTML — but they are authoritative where one exists, so prefer them over scraping.
  *
  * Endpoints under `/api/notification` and `/api/statistics` answer **500 when unauthenticated**
- * rather than 401, so callers must treat any failure as possibly meaning "sign in first".
+ * rather than 401. [NodeSeekJsonClient] maps that quirk to [NodeSeekError.LoginRequired] itself,
+ * so callers see the same error a 401 would have produced.
  */
 interface JsonSource {
     suspend fun getJson(path: String, referer: String = NodeSeekSite.BASE_URL + "/"): String
+
+    /**
+     * POST to a JSON endpoint with the same headers and challenge classification as [getJson].
+     *
+     * Unlike [getJson] the answer comes back with its status code instead of a thrown [NodeSeekError.Http]:
+     * NodeSeek's write endpoints put meaningful JSON bodies on non-2xx statuses (a repeat sign-in is
+     * an HTTP 500 whose body carries the sentence to show), so status-versus-body is the caller's
+     * contract. Transport failures and Cloudflare interception still throw.
+     */
+    suspend fun postJson(path: String, referer: String = NodeSeekSite.BASE_URL + "/"): JsonPostResponse =
+        throw UnsupportedOperationException("This JsonSource does not support POST")
 }
 
 class NodeSeekJsonClient(
@@ -25,35 +47,74 @@ class NodeSeekJsonClient(
 
     override suspend fun getJson(path: String, referer: String): String =
         withContext(dispatchers.io) {
-            val url = NodeSeekSite.absoluteUrl(path) ?: error("Invalid path: $path")
-            val request = Request.Builder()
-                .url(url)
-                .header("Accept", "application/json, text/plain, */*")
-                .header("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
-                .header("Referer", referer)
-                // The site's own XHRs carry this; without it some endpoints answer with HTML.
-                .header("X-Requested-With", "XMLHttpRequest")
-                .header("Sec-Fetch-Dest", "empty")
-                .header("Sec-Fetch-Mode", "cors")
-                .header("Sec-Fetch-Site", "same-origin")
-                .build()
-
-            val response = try {
-                okHttpClient.newCall(request).execute()
-            } catch (e: IOException) {
-                throw NodeSeekException(NodeSeekError.Network, e)
-            }
+            val response = execute(xhrRequest(path, referer).build())
 
             response.use {
                 val body = it.body?.string().orEmpty()
-                if (!it.isSuccessful) throw NodeSeekException(NodeSeekError.Http(it.code))
-                // An HTML body on a JSON endpoint means Cloudflare intercepted the call.
-                if (body.trimStart().startsWith("<")) {
-                    throw NodeSeekException(NodeSeekError.Cloudflare)
+                throwIfChallenge(it.header("cf-mitigated"), body)
+                // Session-scoped endpoints answer 500, not 401, when the cookie is missing or stale.
+                // "服务器错误" with a retry button would hide the one action that fixes it: signing in.
+                if (it.code == 500 && isSessionScoped(path)) {
+                    throw NodeSeekException(NodeSeekError.LoginRequired)
                 }
+                if (!it.isSuccessful) throw NodeSeekException(NodeSeekError.Http(it.code))
                 body
             }
         }
+
+    override suspend fun postJson(path: String, referer: String): JsonPostResponse =
+        withContext(dispatchers.io) {
+            val request = xhrRequest(path, referer)
+                .header("Origin", NodeSeekSite.BASE_URL)
+                .post(ByteArray(0).toRequestBody())
+                .build()
+            val response = execute(request)
+
+            response.use {
+                val body = it.body?.string().orEmpty()
+                throwIfChallenge(it.header("cf-mitigated"), body)
+                JsonPostResponse(code = it.code, body = body)
+            }
+        }
+
+    private fun xhrRequest(path: String, referer: String): Request.Builder {
+        val url = NodeSeekSite.absoluteUrl(path) ?: error("Invalid path: $path")
+        return Request.Builder()
+            .url(url)
+            .header("Accept", "application/json, text/plain, */*")
+            .header("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
+            .header("Referer", referer)
+            // The site's own XHRs carry this; without it some endpoints answer with HTML.
+            .header("X-Requested-With", "XMLHttpRequest")
+            .header("Sec-Fetch-Dest", "empty")
+            .header("Sec-Fetch-Mode", "cors")
+            .header("Sec-Fetch-Site", "same-origin")
+    }
+
+    private fun execute(request: Request) =
+        try {
+            okHttpClient.newCall(request).execute()
+        } catch (e: IOException) {
+            throw NodeSeekException(NodeSeekError.Network, e)
+        }
+
+    /**
+     * Cloudflare intercepts a JSON call as challenge HTML, as a tagged `cf-mitigated: challenge`
+     * header on non-HTML shapes, or as a 403 wrapping either — so this runs before any status
+     * handling: "please verify" and "please sign in" send the user down different recovery paths.
+     */
+    private fun throwIfChallenge(cfMitigated: String?, body: String) {
+        val isChallenge =
+            cfMitigated?.equals("challenge", ignoreCase = true) == true ||
+                Selectors.CLOUDFLARE_MARKERS.any(body::contains) ||
+                // An HTML body on a JSON endpoint means Cloudflare intercepted the call.
+                body.trimStart().startsWith("<")
+        if (isChallenge) throw NodeSeekException(NodeSeekError.Cloudflare)
+    }
+
+    /** The endpoint families that only answer for a signed-in session — see the interface KDoc. */
+    private fun isSessionScoped(path: String): Boolean =
+        path.startsWith("/api/notification") || path.startsWith("/api/statistics")
 
     companion object {
         const val PATH_CATEGORIES = "/api/content/list-categories"
@@ -63,5 +124,21 @@ class NodeSeekJsonClient(
             "/api/notification/$type/list?page=$page"
 
         fun accountInfoPath(uid: Long) = "/api/account/getInfo/$uid"
+
+        fun discussionListPath(uid: Long, page: Int = 1) =
+            "/api/content/list-discussions?uid=$uid&page=${page.coerceAtLeast(1)}"
+
+        fun commentListPath(uid: Long, page: Int = 1) =
+            "/api/content/list-comments?uid=$uid&page=${page.coerceAtLeast(1)}"
+
+        /** Collections belong to the session, not to a uid: the site offers no one else's. */
+        fun collectionListPath(page: Int = 1) =
+            "/api/statistics/list-collection?page=${page.coerceAtLeast(1)}"
+
+        /** `random` is the sign-in mode's wire value: "true" gambles, "false" takes a flat five. */
+        fun attendancePath(random: String) = "/api/attendance?random=$random"
+
+        fun attendanceBoardPath(page: Int = 1) =
+            "/api/attendance/board?page=${page.coerceAtLeast(1)}"
     }
 }

--- a/app/src/main/java/io/github/nsreader/data/AssetsRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/AssetsRepository.kt
@@ -1,0 +1,165 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.AppDispatchers
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.net.JsonSource
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.net.NodeSeekJsonClient
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A daily allowance, as `/progress` shows it: how much of today's cap has been earned.
+ *
+ * Both halves are nullable because the page that carries them renders client-side. A quota we cannot
+ * read has to be distinguishable from a quota that is genuinely zero — Lv1's free feeding allowance
+ * really is `0 / 0`, and showing that as "unknown" would be as wrong as the reverse.
+ */
+data class DailyQuota(
+    val used: Int?,
+    val total: Int?,
+) {
+    val isKnown: Boolean get() = used != null && total != null
+}
+
+/**
+ * Everything the 账户与成长 screen needs.
+ *
+ * Levelling is chicken-based: the progress bar *is* the chicken count, and Lv1 becomes Lv2 at 400.
+ * Only that one threshold is published, so [nextLevelChicken] is null on every other level rather
+ * than extrapolated from a curve nobody has stated.
+ */
+data class GrowthSnapshot(
+    val level: Int?,
+    val chickenCount: Int?,
+    val starCount: Int?,
+    val nextLevelChicken: Int?,
+    val postQuota: DailyQuota,
+    val commentQuota: DailyQuota,
+    val attendanceQuota: DailyQuota,
+    val feedingQuota: DailyQuota,
+)
+
+/** The outcome of signing in for the day: the site answers with a sentence and a chicken count. */
+data class AttendanceResult(
+    val gain: Int?,
+    val message: String?,
+)
+
+/**
+ * The site's two sign-in modes, spelled as the wire parameter.
+ *
+ * `random=true` gambles for a random count (the board shows up to +15); `random=false` takes a flat
+ * five. The choice is the user's every day — hardcoding one mode was a bug, not a simplification.
+ */
+enum class AttendanceMode(val wireValue: String) {
+    RANDOM("true"),
+    FIXED_FIVE("false"),
+}
+
+/** One row of today's sign-in board: who signed, what they rolled. */
+data class AttendanceBoardEntry(
+    val uid: Long?,
+    val name: String,
+    val gain: Int?,
+    val timeText: String?,
+)
+
+interface AssetsRepository {
+    suspend fun growth(): GrowthSnapshot
+
+    suspend fun signInForToday(mode: AttendanceMode): AttendanceResult
+
+    /** Today's sign-in board, ranked by gain. */
+    suspend fun attendanceBoard(page: Int = 1): List<AttendanceBoardEntry>
+}
+
+class NetworkAssetsRepository(
+    private val profileRepository: ProfileRepository,
+    private val jsonSource: JsonSource,
+    private val dispatchers: AppDispatchers,
+) : AssetsRepository {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun growth(): GrowthSnapshot {
+        val profile = profileRepository.profile()
+        return GrowthSnapshot(
+            level = profile.rank,
+            chickenCount = profile.chickenCount,
+            starCount = profile.starCount,
+            nextLevelChicken = LEVEL_TWO_CHICKEN.takeIf { profile.rank == 1 },
+            // `/progress` is a client-rendered page with no endpoint behind it, so today's four
+            // allowances are unknown rather than zero. The card renders them as such.
+            postQuota = DailyQuota(null, POST_QUOTA_TOTAL),
+            commentQuota = DailyQuota(null, COMMENT_QUOTA_TOTAL),
+            attendanceQuota = DailyQuota(null, null),
+            feedingQuota = DailyQuota(null, null),
+        )
+    }
+
+    override suspend fun signInForToday(mode: AttendanceMode): AttendanceResult {
+        val response =
+            jsonSource.postJson(
+                path = NodeSeekJsonClient.attendancePath(mode.wireValue),
+                referer = NodeSeekSite.BASE_URL + "/",
+            )
+        return withContext(dispatchers.default) {
+            /*
+             * The body is read before the status, and deliberately so: a repeat sign-in is answered
+             * with **HTTP 500** plus `{"success":false,"message":"今天已完成签到…"}` (verified on the
+             * live site). That sentence is the answer the user needs, so any parseable payload with a
+             * message wins over the status code; the status only matters once the body says nothing.
+             */
+            val root = runCatching { json.parseToJsonElement(response.body) as? JsonObject }.getOrNull()
+            val message = root?.text("message", "msg", "info")
+            // A bare `{"success":false}` is a refusal, not an answer: without the site's sentence
+            // there is nothing to show, so it falls through to the status-code handling below.
+            if (root != null && (message != null || root.bool("success") == true)) {
+                return@withContext AttendanceResult(
+                    // `current`/`coin` deliberately excluded: those carry the account balance, and
+                    // showing 4071 as today's gain would be worse than showing nothing.
+                    gain = root.int("gain", "amount"),
+                    message = message,
+                )
+            }
+            if (response.code == 401 || response.code == 403) {
+                throw NodeSeekException(NodeSeekError.LoginRequired)
+            }
+            if (!response.isSuccessful) throw NodeSeekException(NodeSeekError.Http(response.code))
+            throw NodeSeekException(NodeSeekError.Unparsable)
+        }
+    }
+
+    override suspend fun attendanceBoard(page: Int): List<AttendanceBoardEntry> {
+        val body =
+            jsonSource.getJson(
+                path = NodeSeekJsonClient.attendanceBoardPath(page),
+                referer = NodeSeekSite.BASE_URL + "/board",
+            )
+        return withContext(dispatchers.default) {
+            val root =
+                runCatching { json.parseToJsonElement(body) }
+                    .getOrElse { throw NodeSeekException(NodeSeekError.Unparsable, it) }
+            val rows =
+                root.findObjectArray("list", "board", "data")
+                    ?: throw NodeSeekException(NodeSeekError.Unparsable)
+            rows.mapNotNull { row ->
+                val name = row.text("member_name", "username", "name") ?: return@mapNotNull null
+                AttendanceBoardEntry(
+                    uid = row.long("member_id", "uid"),
+                    name = name,
+                    gain = row.int("gain", "amount"),
+                    timeText = row.text("created_at_str", "created_at", "createdAt"),
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val LEVEL_TWO_CHICKEN = 400
+        const val POST_QUOTA_TOTAL = 20
+        const val COMMENT_QUOTA_TOTAL = 20
+    }
+}

--- a/app/src/main/java/io/github/nsreader/data/AwardRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/AwardRepository.kt
@@ -1,0 +1,29 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.AppDispatchers
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.html.PostListParser
+import io.github.nsreader.core.net.HtmlSource
+import io.github.nsreader.model.PostListPage
+import kotlinx.coroutines.withContext
+
+/**
+ * 推荐阅读 — the curated ("加精") threads at `/award`.
+ *
+ * The one community-tools page that needs no new anything: it is server-rendered with the same markup
+ * as the feed, so the feed's parser reads it and the feed's row renders it. Paged by number rather
+ * than scrolled, because that is how the site indexes it and it runs to eighteen pages.
+ */
+interface AwardRepository {
+    suspend fun page(page: Int): PostListPage
+}
+
+class NetworkAwardRepository(
+    private val htmlSource: HtmlSource,
+    private val dispatchers: AppDispatchers,
+) : AwardRepository {
+    override suspend fun page(page: Int): PostListPage {
+        val html = htmlSource.getHtml(NodeSeekSite.awardPath(page))
+        return withContext(dispatchers.default) { PostListParser.parse(html, page) }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/data/JsonFields.kt
+++ b/app/src/main/java/io/github/nsreader/data/JsonFields.kt
@@ -1,0 +1,104 @@
+package io.github.nsreader.data
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * Field readers for NodeSeek's JSON, which is not a documented API.
+ *
+ * The endpoints are the site's own XHRs and their payloads are inconsistent between themselves —
+ * `member_id` here, `uid` there, `nPost` next to `post_count`. Reading by a list of candidate names
+ * rather than by a generated model is what keeps one renamed key from emptying a whole screen, and it
+ * costs nothing at these payload sizes.
+ *
+ * Every reader tolerates a value arriving as the wrong primitive type: ids and counts come back as
+ * JSON strings often enough that requiring a number would be a bug rather than strictness.
+ */
+internal fun JsonObject.text(vararg names: String): String? {
+    names.forEach { name ->
+        (this[name] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() && it != "null" }
+            ?.let { return it }
+    }
+    return null
+}
+
+internal fun JsonObject.long(vararg names: String): Long? {
+    names.forEach { name ->
+        (this[name] as? JsonPrimitive)?.let { primitive ->
+            (primitive.longOrNull ?: primitive.contentOrNull?.trim()?.toLongOrNull())?.let { return it }
+        }
+    }
+    return null
+}
+
+internal fun JsonObject.int(vararg names: String): Int? {
+    names.forEach { name ->
+        (this[name] as? JsonPrimitive)?.let { primitive ->
+            (primitive.intOrNull ?: primitive.contentOrNull?.trim()?.toIntOrNull())?.let { return it }
+        }
+    }
+    return null
+}
+
+internal fun JsonObject.bool(vararg names: String): Boolean? {
+    names.forEach { name ->
+        (this[name] as? JsonPrimitive)?.let { primitive ->
+            primitive.booleanOrNull?.let { return it }
+            primitive.intOrNull?.let { return it != 0 }
+        }
+    }
+    return null
+}
+
+internal fun JsonObject.obj(vararg names: String): JsonObject? {
+    names.forEach { name -> (this[name] as? JsonObject)?.let { return it } }
+    return null
+}
+
+/**
+ * The array of objects behind one of the [preferredNames], wherever the payload nests it.
+ *
+ * A walk rather than a fixed path: these responses wrap their list in `data`, in `result`, or in
+ * nothing at all depending on the endpoint. When no preferred name matches, an unnamed array is
+ * trusted only if it is the single candidate in the payload — with several, picking one by traversal
+ * order could hand back a sibling block (badges, a pager) and turn a shape mismatch into a confident
+ * empty list, when the caller's Unparsable path is the honest answer.
+ */
+internal fun JsonElement.findObjectArray(vararg preferredNames: String): List<JsonObject>? {
+    if (this is JsonArray) return objectsOrNull()
+    if (this !is JsonObject) return null
+
+    findByPreferredName(preferredNames)?.let { return it }
+    val candidates = collectObjectArrays()
+    return when {
+        candidates.size == 1 -> candidates.first()
+        candidates.isNotEmpty() && candidates.all { it.isEmpty() } -> candidates.first()
+        else -> null
+    }
+}
+
+private fun JsonObject.findByPreferredName(preferredNames: Array<out String>): List<JsonObject>? {
+    preferredNames.forEach { name ->
+        (this[name] as? JsonArray)?.objectsOrNull()?.let { return it }
+    }
+    values.forEach { child ->
+        (child as? JsonObject)?.findByPreferredName(preferredNames)?.let { return it }
+    }
+    return null
+}
+
+private fun JsonElement.collectObjectArrays(): List<List<JsonObject>> =
+    when (this) {
+        is JsonArray -> objectsOrNull()?.let { listOf(it) }.orEmpty()
+        is JsonObject -> values.flatMap { it.collectObjectArrays() }
+        else -> emptyList()
+    }
+
+private fun JsonArray.objectsOrNull(): List<JsonObject>? =
+    if (all { it is JsonObject }) map { it as JsonObject } else null

--- a/app/src/main/java/io/github/nsreader/data/NotificationRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/NotificationRepository.kt
@@ -3,14 +3,8 @@ package io.github.nsreader.data
 import io.github.nsreader.core.net.JsonSource
 import io.github.nsreader.core.net.NodeSeekJsonClient
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.longOrNull
 
 enum class NotificationCategory(val endpoint: String?) {
     REPLIES("reply-to-me"),
@@ -53,10 +47,10 @@ class NotificationRepository(
 
     suspend fun unreadCounts(): NotificationCounts {
         val root = json.parseToJsonElement(jsonSource.getJson(NodeSeekJsonClient.PATH_UNREAD_COUNT))
-        val replies = root.int("reply", "replyCount")
-        val mentions = root.int("atMe", "at_me", "mention")
-        val messages = root.int("message", "messages", "msg")
-        val declaredAll = root.int("all", "total")
+        val replies = root.count("reply", "replyCount")
+        val mentions = root.count("atMe", "at_me", "mention")
+        val messages = root.count("message", "messages", "msg")
+        val declaredAll = root.count("all", "total")
         return NotificationCounts(
             replies = replies,
             mentions = mentions,
@@ -71,61 +65,30 @@ class NotificationRepository(
             json.parseToJsonElement(
                 jsonSource.getJson(NodeSeekJsonClient.notificationListPath(endpoint)),
             )
-        val rows = root.findNotificationArray()
-        return rows.mapIndexedNotNull { index, element ->
-            val item = element as? JsonObject ?: return@mapIndexedNotNull null
-            item.toNotification(category, index)
-        }
+        val rows =
+            root.findObjectArray("replyList", "atList", "msgArray", "notifications", "list", "data")
+        return rows.orEmpty().mapIndexed { index, item -> item.toNotification(category, index) }
     }
 }
 
-private fun JsonElement.int(vararg names: String): Int {
+/** The counts endpoint sometimes nests its numbers one level down; zero is the honest default. */
+private fun JsonElement.count(vararg names: String): Int {
     val objectValue = this as? JsonObject ?: return 0
-    names.forEach { name ->
-        objectValue[name]?.jsonPrimitive?.intOrNull?.let { return it }
-    }
+    objectValue.int(*names)?.let { return it }
     objectValue.values.forEach { child ->
-        val nested = child as? JsonObject ?: return@forEach
-        names.forEach { name -> nested[name]?.jsonPrimitive?.intOrNull?.let { return it } }
+        (child as? JsonObject)?.int(*names)?.let { return it }
     }
     return 0
-}
-
-private fun JsonElement.findNotificationArray(): JsonArray {
-    if (this is JsonArray && any { it is JsonObject }) return this
-    if (this !is JsonObject) return JsonArray(emptyList())
-    val preferred = listOf("replyList", "atList", "msgArray", "notifications", "list", "data")
-    preferred.forEach { key ->
-        val child = this[key] ?: return@forEach
-        val found = child.findNotificationArray()
-        if (found.isNotEmpty()) return found
-    }
-    values.forEach { child ->
-        val found = child.findNotificationArray()
-        if (found.isNotEmpty()) return found
-    }
-    return JsonArray(emptyList())
 }
 
 private fun JsonObject.toNotification(
     category: NotificationCategory,
     index: Int,
 ): ForumNotification {
-    fun text(vararg names: String): String? {
-        names.forEach { name -> this[name]?.jsonPrimitive?.contentOrNull?.let { return it } }
-        return null
-    }
-
-    fun long(vararg names: String): Long? {
-        names.forEach { name -> this[name]?.jsonPrimitive?.longOrNull?.let { return it } }
-        return null
-    }
-
     val postId = long("post_id", "postId", "discussion_id")
     val floorValue = text("floor_id", "floor", "floorId")
     val actor = text("commenter_name", "username", "sender_name", "name") ?: "NodeSeek 用户"
-    val viewed =
-        this["viewed"]?.jsonPrimitive?.let { it.booleanOrNull ?: (it.intOrNull ?: 0) != 0 } ?: false
+    val viewed = bool("viewed") ?: false
     return ForumNotification(
         id = text("comment_id", "id", "message_id") ?: "${category.name}-$postId-$index",
         postId = postId,

--- a/app/src/main/java/io/github/nsreader/data/ProfileRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/ProfileRepository.kt
@@ -1,5 +1,6 @@
 package io.github.nsreader.data
 
+import io.github.nsreader.core.AppClock
 import io.github.nsreader.core.NodeSeekSite
 import io.github.nsreader.core.net.HtmlSource
 import io.github.nsreader.core.net.JsonSource
@@ -7,13 +8,11 @@ import io.github.nsreader.core.net.NodeSeekError
 import io.github.nsreader.core.net.NodeSeekException
 import io.github.nsreader.core.net.NodeSeekJsonClient
 import io.github.nsreader.core.runCatchingExceptCancellation
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.longOrNull
 import org.jsoup.Jsoup
 import java.nio.charset.StandardCharsets
 import java.util.Base64
@@ -27,10 +26,38 @@ data class UserProfile(
     val chickenCount: Int? = null,
     val starCount: Int? = null,
     val streakDays: Int? = null,
+    val bio: String? = null,
+    /** Markdown, shown on the space page. The site's own empty state is "没有找到readme 🙄". */
+    val readme: String? = null,
+    val topicCount: Int? = null,
+    val commentCount: Int? = null,
 )
 
 interface ProfileRepository {
-    suspend fun profile(): UserProfile
+    /**
+     * The signed-in account.
+     *
+     * May answer from a short-lived cache: every profile-area screen asks for this on entry, and the
+     * call behind it costs two round-trips (home-page HTML, then the account endpoint). [refresh]
+     * bypasses the cache for the flows that must see the network — pull-to-refresh, sign-in changes.
+     */
+    suspend fun profile(refresh: Boolean = false): UserProfile
+
+    /**
+     * Any account, by uid — the public space page.
+     *
+     * Separate from [profile] because the two resolve their subject differently: this one is told who
+     * to load, while [profile] has to work out who the session belongs to before it can ask.
+     */
+    suspend fun profile(uid: Long): UserProfile
+
+    /**
+     * The signed-in account's uid, remembered from the last successful [profile] call.
+     *
+     * Null until a profile has loaded once this process. Callers that navigate to a user's space use
+     * it to decide `isSelf` — a null simply means "not known to be self", never "known not to be".
+     */
+    val selfUid: Long? get() = null
 }
 
 /**
@@ -44,12 +71,39 @@ interface ProfileRepository {
 class NetworkProfileRepository(
     private val htmlSource: HtmlSource,
     private val jsonSource: JsonSource,
+    private val clock: AppClock,
 ) : ProfileRepository {
     private val json = Json { ignoreUnknownKeys = true }
 
-    override suspend fun profile(): UserProfile {
+    @Volatile
+    override var selfUid: Long? = null
+        private set
+
+    private val cacheLock = Mutex()
+    private var cachedProfile: UserProfile? = null
+    private var cachedAtMillis = 0L
+
+    override suspend fun profile(refresh: Boolean): UserProfile =
+        // The lock also serializes concurrent callers, so two screens opening at once cost one
+        // fetch, not two racing ones.
+        cacheLock.withLock {
+            if (!refresh) {
+                cachedProfile
+                    ?.takeIf { clock.nowMillis() - cachedAtMillis < PROFILE_CACHE_TTL_MILLIS }
+                    ?.let { return@withLock it }
+            }
+            fetchProfile().also {
+                cachedProfile = it
+                cachedAtMillis = clock.nowMillis()
+            }
+        }
+
+    private suspend fun fetchProfile(): UserProfile {
         val bootstrap = parseProfilePage(htmlSource.getHtml("/"))
-        val uid = bootstrap.uid ?: throw NodeSeekException(NodeSeekError.Unparsable)
+        // The page parsed but named no account: the session cookie is missing or stale. Reporting
+        // that as Unparsable sent users to a "站点改版" card whose retry can never succeed.
+        val uid = bootstrap.uid ?: throw NodeSeekException(NodeSeekError.LoginRequired)
+        selfUid = uid
         val account =
             runCatchingExceptCancellation {
                 parseProfileJson(
@@ -63,6 +117,17 @@ class NetworkProfileRepository(
         return bootstrap.merge(account).toProfile()
     }
 
+    override suspend fun profile(uid: Long): UserProfile {
+        val body =
+            jsonSource.getJson(
+                path = NodeSeekJsonClient.accountInfoPath(uid),
+                referer = NodeSeekSite.BASE_URL + NodeSeekSite.spacePath(uid),
+            )
+        val raw = parseProfileJson(body) ?: throw NodeSeekException(NodeSeekError.Unparsable)
+        // The endpoint omits the uid on some accounts, and the caller already knows it.
+        return raw.copy(uid = raw.uid ?: uid).toProfile()
+    }
+
     internal fun parseProfilePage(html: String): RawProfile {
         val encoded =
             Jsoup.parse(html)
@@ -70,7 +135,9 @@ class NetworkProfileRepository(
                 ?.data()
                 ?.trim()
                 .orEmpty()
-        if (encoded.isEmpty()) throw NodeSeekException(NodeSeekError.Unparsable)
+        // No bootstrap element at all is how the home page looks to a signed-out visitor, not how a
+        // redesign would look — a redesign would still carry *something* where the profile was.
+        if (encoded.isEmpty()) throw NodeSeekException(NodeSeekError.LoginRequired)
 
         val decoded =
             try {
@@ -103,6 +170,10 @@ class NetworkProfileRepository(
             chickenCount = newer.chickenCount ?: chickenCount,
             starCount = newer.starCount ?: starCount,
             streakDays = newer.streakDays ?: streakDays,
+            bio = newer.bio ?: bio,
+            readme = newer.readme ?: readme,
+            topicCount = newer.topicCount ?: topicCount,
+            commentCount = newer.commentCount ?: commentCount,
         )
     }
 
@@ -120,6 +191,10 @@ class NetworkProfileRepository(
             chickenCount = chickenCount,
             starCount = starCount,
             streakDays = streakDays,
+            bio = bio,
+            readme = readme,
+            topicCount = topicCount,
+            commentCount = commentCount,
         )
     }
 
@@ -137,6 +212,10 @@ internal data class RawProfile(
     val chickenCount: Int? = null,
     val starCount: Int? = null,
     val streakDays: Int? = null,
+    val bio: String? = null,
+    val readme: String? = null,
+    val topicCount: Int? = null,
+    val commentCount: Int? = null,
 )
 
 private fun JsonElement.findProfileObject(): JsonObject? {
@@ -158,26 +237,18 @@ private fun JsonObject.toRawProfile(): RawProfile =
         name = text(*PROFILE_NAME_KEYS.toTypedArray()),
         avatarUrl = text("avatar", "avatarUrl", "avatar_url"),
         rank = int("rank", "level"),
-        createdAt = text("created_at", "createdAt", "registered_at"),
+        createdAt = text("created_at", "createdAt", "registered_at", "created_at_str"),
         chickenCount = int("coin", "chicken", "chickenCount", "chicken_count"),
         starCount = int("stardust", "star", "stars", "starCount", "star_count"),
         streakDays = int("streak", "streakDays", "streak_days"),
+        bio = text("bio", "introduction", "signature_text"),
+        readme = text("readme", "readMe", "read_me"),
+        topicCount = int("nPost", "post_count", "postCount", "topicCount", "discussion_count"),
+        commentCount = int("nComment", "comment_count", "commentCount"),
     )
 
-private fun JsonObject.text(vararg names: String): String? {
-    names.forEach { name -> this[name]?.jsonPrimitive?.contentOrNull?.let { return it } }
-    return null
-}
-
-private fun JsonObject.long(vararg names: String): Long? {
-    names.forEach { name -> this[name]?.jsonPrimitive?.longOrNull?.let { return it } }
-    return null
-}
-
-private fun JsonObject.int(vararg names: String): Int? {
-    names.forEach { name -> this[name]?.jsonPrimitive?.intOrNull?.let { return it } }
-    return null
-}
+/** Long enough to cover one walk through the profile area, short enough that balances stay honest. */
+private const val PROFILE_CACHE_TTL_MILLIS = 60_000L
 
 private val PROFILE_ID_KEYS = setOf("member_id", "uid", "user_id")
 private val PROFILE_NAME_KEYS = setOf("member_name", "username", "name")

--- a/app/src/main/java/io/github/nsreader/data/SiteOnlyRepositories.kt
+++ b/app/src/main/java/io/github/nsreader/data/SiteOnlyRepositories.kt
@@ -1,0 +1,102 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+
+/*
+ * The pages NodeSeek renders entirely in the browser.
+ *
+ * `/fans`, `/stardust/list` and `/ruling` return an empty shell to a plain GET and build their tables
+ * from XHRs that are not part of any documented contract; we could not observe them without a signed-in
+ * browser session. Rather than ship a parser written against a guessed payload — which would fail
+ * silently and look like "you have no followers" — each repository here declares its shape, and the
+ * default implementation answers [NodeSeekError.NotWired].
+ *
+ * That keeps three things true at once: the screens are finished and render real rows the moment an
+ * implementation exists, the UiState contracts are already the ones the site's fields imply, and the
+ * user is told the truth instead of being shown a plausible empty list.
+ */
+
+/** A row of 我的关注 / 我的粉丝. No relationship button: the site has no follow action to offer. */
+data class FollowUser(
+    val uid: Long,
+    val name: String,
+    val avatarUrl: String?,
+)
+
+interface FollowRepository {
+    suspend fun following(page: Int = 1): List<FollowUser>
+
+    suspend fun followers(page: Int = 1): List<FollowUser>
+}
+
+/**
+ * One stardust movement.
+ *
+ * Stardust has exactly one source — a comment of yours being liked, +1 a time — and exactly one use,
+ * transfer. So a row is the amount, the balance it left behind, and which comment earned it.
+ */
+data class StardustEntry(
+    val amount: Int,
+    val balanceAfter: Int?,
+    val commentId: Long?,
+    val timestampText: String?,
+)
+
+interface StardustRepository {
+    suspend fun entries(page: Int = 1): List<StardustEntry>
+}
+
+/** What a moderation entry did. Drives the leading icon, which is the only scannable part of the row. */
+enum class RulingKind {
+    PENALTY,
+    BAN,
+    MOVE,
+    PERMISSION,
+    REWARD,
+}
+
+/**
+ * One line of the public moderation log.
+ *
+ * The site's table splits a single decision across columns; a phone row cannot, so [actions] keeps the
+ * compound action ("扣 20 鸡腿" + "移动版块至 促销" + "锁定修改") as the separate verbs it is and lets
+ * the row join them. Losing that split would make the longest and most informative entries unreadable.
+ */
+data class RulingRecord(
+    val id: Long,
+    val targetName: String,
+    val targetKind: String,
+    val reason: String?,
+    val actions: List<String>,
+    val moderatorName: String?,
+    val timeText: String?,
+    val kind: RulingKind,
+)
+
+data class RulingPage(
+    val records: List<RulingRecord>,
+    val page: Int,
+    val totalPages: Int,
+)
+
+interface RulingRepository {
+    suspend fun records(page: Int = 1): RulingPage
+}
+
+/** The single place that says "not wired yet", so switching one page to real data is one class. */
+private fun notWired(): Nothing = throw NodeSeekException(NodeSeekError.NotWired)
+
+class SiteOnlyFollowRepository : FollowRepository {
+    override suspend fun following(page: Int): List<FollowUser> = notWired()
+
+    override suspend fun followers(page: Int): List<FollowUser> = notWired()
+}
+
+class SiteOnlyStardustRepository : StardustRepository {
+    override suspend fun entries(page: Int): List<StardustEntry> = notWired()
+}
+
+class SiteOnlyRulingRepository : RulingRepository {
+    override suspend fun records(page: Int): RulingPage = notWired()
+}

--- a/app/src/main/java/io/github/nsreader/data/UserSpaceRepository.kt
+++ b/app/src/main/java/io/github/nsreader/data/UserSpaceRepository.kt
@@ -1,0 +1,178 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.AppDispatchers
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.net.JsonSource
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.net.NodeSeekJsonClient
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import org.jsoup.Jsoup
+
+/** A thread as it appears in a space tab: the user's own topics, or a row of their collections. */
+data class SpacePost(
+    val postId: Long,
+    val title: String,
+    val categoryTitle: String?,
+    val categorySlug: String?,
+    val authorName: String?,
+    val commentCount: Int?,
+    val viewCount: Int?,
+    val createdAtText: String?,
+)
+
+/** One of the user's comments, with enough of the thread around it to be worth tapping. */
+data class SpaceComment(
+    val postId: Long,
+    val commentId: Long?,
+    val postTitle: String?,
+    val excerpt: String,
+    val createdAtText: String?,
+    /** Site floor format ("#3"), so tapping the row can land on the comment, not just the thread. */
+    val floor: String? = null,
+)
+
+data class SpacePage<T>(
+    val items: List<T>,
+    val page: Int,
+    val hasNextPage: Boolean,
+)
+
+/**
+ * The three lists behind a space page's tabs.
+ *
+ * These are the site's own XHR endpoints rather than scraped HTML, because the space page renders
+ * client-side: fetching `/space/12` returns an empty shell. The payload shapes are undocumented, so
+ * every field is read by candidate name (see [text]) and a response that yields no rows at all is
+ * reported as [NodeSeekError.Unparsable] — the screen then offers the web page, which is the truth we
+ * can still show.
+ */
+interface UserSpaceRepository {
+    suspend fun topics(uid: Long, page: Int): SpacePage<SpacePost>
+
+    suspend fun comments(uid: Long, page: Int): SpacePage<SpaceComment>
+
+    /** Only the signed-in user's: the site exposes no one else's collections. */
+    suspend fun collections(page: Int): SpacePage<SpacePost>
+}
+
+class NetworkUserSpaceRepository(
+    private val jsonSource: JsonSource,
+    private val dispatchers: AppDispatchers,
+) : UserSpaceRepository {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun topics(uid: Long, page: Int): SpacePage<SpacePost> =
+        load(
+            path = NodeSeekJsonClient.discussionListPath(uid, page),
+            referer = NodeSeekSite.BASE_URL + NodeSeekSite.spaceTabPath(uid, NodeSeekSite.SPACE_TAB_DISCUSSIONS),
+            page = page,
+            arrayNames = arrayOf("discussions", "postList", "list", "data"),
+            map = JsonObject::toSpacePost,
+        )
+
+    override suspend fun comments(uid: Long, page: Int): SpacePage<SpaceComment> =
+        load(
+            path = NodeSeekJsonClient.commentListPath(uid, page),
+            referer = NodeSeekSite.BASE_URL + NodeSeekSite.spaceTabPath(uid, NodeSeekSite.SPACE_TAB_COMMENTS),
+            page = page,
+            arrayNames = arrayOf("comments", "commentList", "list", "data"),
+            map = JsonObject::toSpaceComment,
+        )
+
+    override suspend fun collections(page: Int): SpacePage<SpacePost> =
+        load(
+            path = NodeSeekJsonClient.collectionListPath(page),
+            referer = NodeSeekSite.BASE_URL + "/",
+            page = page,
+            arrayNames = arrayOf("collections", "collectionList", "list", "data"),
+            map = JsonObject::toSpacePost,
+        )
+
+    private suspend fun <T> load(
+        path: String,
+        referer: String,
+        page: Int,
+        arrayNames: Array<String>,
+        map: (JsonObject) -> T?,
+    ): SpacePage<T> {
+        val body = jsonSource.getJson(path = path, referer = referer)
+        return withContext(dispatchers.default) {
+            val root =
+                runCatching { json.parseToJsonElement(body) }
+                    .getOrElse { throw NodeSeekException(NodeSeekError.Unparsable, it) }
+            val rows = root.findObjectArray(*arrayNames)
+            // An empty array is a real answer ("no topics yet"); no array at all means we guessed the
+            // payload shape wrong, and pretending that is an empty list would hide the mismatch.
+            if (rows == null) throw NodeSeekException(NodeSeekError.Unparsable)
+            val items = rows.mapNotNull(map)
+            SpacePage(
+                items = items,
+                page = page,
+                hasNextPage = (root as? JsonObject)?.hasNextPage(page, rows.size) ?: false,
+            )
+        }
+    }
+}
+
+/**
+ * Whether asking for the next page is worth a request.
+ *
+ * Explicit paging metadata when the payload carries it; otherwise any non-empty page is treated as
+ * "probably more". Guessing from row count would hide every later page the moment the endpoint's real
+ * page size dips below the guess, so the fallback instead costs one wasted request at the end of a
+ * list and never hides a page.
+ */
+private fun JsonObject.hasNextPage(page: Int, rowCount: Int): Boolean {
+    pagingBool("hasNext", "has_next", "hasMore", "has_more")?.let { return it }
+    pagingInt("totalPage", "total_page", "totalPages", "pages")?.let { return page < it }
+    return rowCount > 0
+}
+
+/** The paging fields ride either on the payload root or inside its envelope (`data`, `result`). */
+private fun JsonObject.pagingBool(vararg names: String): Boolean? {
+    bool(*names)?.let { return it }
+    values.forEach { child -> (child as? JsonObject)?.bool(*names)?.let { return it } }
+    return null
+}
+
+private fun JsonObject.pagingInt(vararg names: String): Int? {
+    int(*names)?.let { return it }
+    values.forEach { child -> (child as? JsonObject)?.int(*names)?.let { return it } }
+    return null
+}
+
+private const val COMMENT_EXCERPT_LENGTH = 140
+
+private fun JsonObject.toSpacePost(): SpacePost? {
+    val postId = long("post_id", "postId", "pid", "id") ?: return null
+    val title = text("title", "post_title", "subject") ?: return null
+    return SpacePost(
+        postId = postId,
+        title = title,
+        categoryTitle = text("category_title", "categoryTitle", "category_name"),
+        categorySlug = text("category", "category_slug", "categorySlug"),
+        authorName = text("member_name", "author", "username", "user_name"),
+        commentCount = int("comments", "comment_count", "nComment", "reply_count"),
+        viewCount = int("views", "view_count", "click", "nView"),
+        createdAtText = text("created_at_str", "created_at", "createdAt", "time", "date"),
+    )
+}
+
+private fun JsonObject.toSpaceComment(): SpaceComment? {
+    val postId = long("post_id", "postId", "pid") ?: return null
+    // The live payload calls the body `text` (verified 2026-07); the rest are defensive.
+    val raw = text("text", "content", "comment", "body", "excerpt").orEmpty()
+    return SpaceComment(
+        postId = postId,
+        commentId = long("comment_id", "commentId", "id"),
+        postTitle = text("post_title", "title", "subject"),
+        // Comments come back as the site's rendered markup. Rendering it properly is the detail
+        // screen's job; here it has to fit one line, so it is flattened to text.
+        excerpt = Jsoup.parse(raw).text().trim().take(COMMENT_EXCERPT_LENGTH),
+        createdAtText = text("created_at_str", "created_at", "createdAt", "time", "date"),
+        floor = long("floor_id", "floorId", "floor")?.let { "#$it" },
+    )
+}

--- a/app/src/main/java/io/github/nsreader/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nsreader/di/AppContainer.kt
@@ -12,15 +12,27 @@ import io.github.nsreader.core.net.NodeSeekJsonClient
 import io.github.nsreader.core.net.UserAgent
 import io.github.nsreader.core.net.WebViewCookieJar
 import io.github.nsreader.core.net.resolveUserAgent
+import io.github.nsreader.data.AssetsRepository
+import io.github.nsreader.data.AwardRepository
 import io.github.nsreader.data.CategoryRepository
+import io.github.nsreader.data.FollowRepository
+import io.github.nsreader.data.NetworkAssetsRepository
+import io.github.nsreader.data.NetworkAwardRepository
 import io.github.nsreader.data.NetworkPostDataSource
 import io.github.nsreader.data.NetworkProfileRepository
 import io.github.nsreader.data.NetworkSearchRepository
+import io.github.nsreader.data.NetworkUserSpaceRepository
 import io.github.nsreader.data.NotificationRepository
 import io.github.nsreader.data.OfflineFirstPostRepository
 import io.github.nsreader.data.PostRepository
 import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.RulingRepository
 import io.github.nsreader.data.SearchRepository
+import io.github.nsreader.data.SiteOnlyFollowRepository
+import io.github.nsreader.data.SiteOnlyRulingRepository
+import io.github.nsreader.data.SiteOnlyStardustRepository
+import io.github.nsreader.data.StardustRepository
+import io.github.nsreader.data.UserSpaceRepository
 import io.github.nsreader.data.composer.DefaultPostComposerRepository
 import io.github.nsreader.data.composer.PostComposerRepository
 import io.github.nsreader.data.local.NodeSeekDatabase
@@ -51,6 +63,17 @@ interface AppContainer {
     val searchRepository: SearchRepository
     val postComposerRepository: PostComposerRepository
     val sessionRepository: SessionRepository
+    val userSpaceRepository: UserSpaceRepository
+    val assetsRepository: AssetsRepository
+    val awardRepository: AwardRepository
+
+    /*
+     * The three site-only pages. Typed here rather than left out so that wiring one up later is a
+     * single constructor swap — see `SiteOnlyRepositories.kt` for why they answer NotWired today.
+     */
+    val followRepository: FollowRepository
+    val stardustRepository: StardustRepository
+    val rulingRepository: RulingRepository
 
     /**
      * The UA the WebView and OkHttp both use. Shared rather than duplicated: `cf_clearance` is issued
@@ -121,7 +144,7 @@ class DefaultAppContainer(
     }
 
     override val profileRepository: ProfileRepository by lazy {
-        NetworkProfileRepository(htmlClient, jsonClient)
+        NetworkProfileRepository(htmlClient, jsonClient, clock)
     }
 
     override val searchRepository: SearchRepository by lazy {
@@ -131,6 +154,24 @@ class DefaultAppContainer(
     override val postComposerRepository: PostComposerRepository by lazy {
         DefaultPostComposerRepository(appContext, okHttpClient, dispatchers, clock)
     }
+
+    override val userSpaceRepository: UserSpaceRepository by lazy {
+        NetworkUserSpaceRepository(jsonClient, dispatchers)
+    }
+
+    override val assetsRepository: AssetsRepository by lazy {
+        NetworkAssetsRepository(profileRepository, jsonClient, dispatchers)
+    }
+
+    override val awardRepository: AwardRepository by lazy {
+        NetworkAwardRepository(htmlClient, dispatchers)
+    }
+
+    override val followRepository: FollowRepository by lazy { SiteOnlyFollowRepository() }
+
+    override val stardustRepository: StardustRepository by lazy { SiteOnlyStardustRepository() }
+
+    override val rulingRepository: RulingRepository by lazy { SiteOnlyRulingRepository() }
 
     /**
      * Shares the cookie jar rather than owning a store of its own: the cookies OkHttp sends and the

--- a/app/src/main/java/io/github/nsreader/model/Models.kt
+++ b/app/src/main/java/io/github/nsreader/model/Models.kt
@@ -24,6 +24,14 @@ data class PostListPage(
     val posts: List<PostSummary>,
     val page: Int,
     val hasNextPage: Boolean,
+    /**
+     * Highest page the pager offers, or [page] when it offers none.
+     *
+     * The feed ignores this — it scrolls — but the lists the site pages by number (curated threads,
+     * the moderation log) need the total to draw "1 … 18", and it is only knowable from the markup we
+     * are already holding.
+     */
+    val totalPages: Int = page,
 )
 
 /**

--- a/app/src/main/java/io/github/nsreader/ui/assets/AssetsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/assets/AssetsScreen.kt
@@ -1,0 +1,693 @@
+package io.github.nsreader.ui.assets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.AttendanceMode
+import io.github.nsreader.data.DailyQuota
+import io.github.nsreader.ui.common.GroupedRow
+import io.github.nsreader.ui.common.LoadingState
+import io.github.nsreader.ui.common.NodeSeekErrorState
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.SpendConfirmDialog
+import io.github.nsreader.ui.common.SpendDetail
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+import io.github.nsreader.ui.theme.readableWidth
+
+/** What buying an invite code costs, and the reason the confirm dialog exists at all. */
+const val INVITE_CODE_CHICKEN_COST = 1_000
+
+@Composable
+fun AssetsRoute(
+    viewModel: AssetsViewModel,
+    onBack: () -> Unit,
+    onChickenLedger: () -> Unit,
+    onStardust: () -> Unit,
+    onOpenBrowser: () -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    AssetsScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::refresh,
+        onRequestAttendance = viewModel::requestAttendance,
+        onDismissAttendanceChooser = viewModel::dismissAttendanceChooser,
+        onSignInForToday = viewModel::signInForToday,
+        onOpenBoard = viewModel::openBoard,
+        onDismissBoard = viewModel::dismissBoard,
+        onRetryBoard = viewModel::loadBoard,
+        onChickenLedger = onChickenLedger,
+        onStardust = onStardust,
+        onOpenBrowser = onOpenBrowser,
+        onSignIn = onSignIn,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AssetsScreen(
+    state: AssetsUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onRequestAttendance: () -> Unit,
+    onDismissAttendanceChooser: () -> Unit,
+    onSignInForToday: (AttendanceMode) -> Unit,
+    onOpenBoard: () -> Unit,
+    onDismissBoard: () -> Unit,
+    onRetryBoard: () -> Unit,
+    onChickenLedger: () -> Unit,
+    onStardust: () -> Unit,
+    onOpenBrowser: () -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.assets_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (state.isLoading && !state.hasData) {
+            LoadingState(Modifier.padding(padding))
+            return@Scaffold
+        }
+        if (state.error != null && !state.hasData) {
+            NodeSeekErrorState(
+                error = state.error,
+                onRetry = onRetry,
+                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                modifier = Modifier.padding(padding),
+            )
+            return@Scaffold
+        }
+
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            LevelCard(state)
+            DailyQuotaCard(state)
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                BalanceCard(
+                    label = stringResource(R.string.assets_chicken),
+                    value = state.chickenCount,
+                    action = stringResource(R.string.assets_ledger),
+                    container = MaterialTheme.colorScheme.primaryContainer,
+                    content = MaterialTheme.colorScheme.onPrimaryContainer,
+                    onClick = onChickenLedger,
+                )
+                BalanceCard(
+                    label = stringResource(R.string.assets_stars),
+                    value = state.starCount,
+                    action = stringResource(R.string.assets_ledger_transfer),
+                    container = MaterialTheme.colorScheme.secondaryContainer,
+                    content = MaterialTheme.colorScheme.onSecondaryContainer,
+                    onClick = onStardust,
+                )
+            }
+            AttendanceButton(state = state, onRequestAttendance = onRequestAttendance)
+            // 邀请购码住在社区工具里，和站点的入口位置一致；这里不再重复一份。
+            GroupedRow(
+                title = stringResource(R.string.assets_board),
+                subtitle = stringResource(R.string.assets_board_subtitle),
+                icon = NodeSeekIcons.Group,
+                first = true,
+                last = true,
+                onClick = onOpenBoard,
+            )
+        }
+    }
+
+    if (state.choosingAttendanceMode) {
+        AttendanceModeDialog(
+            onPick = onSignInForToday,
+            onDismiss = onDismissAttendanceChooser,
+        )
+    }
+
+    if (state.boardOpen) {
+        AttendanceBoardDialog(
+            state = state,
+            onRetry = onRetryBoard,
+            onDismiss = onDismissBoard,
+        )
+    }
+}
+
+/**
+ * The site's sign-in is a choice, not a button: gamble on a random count or take a flat five.
+ *
+ * Presented at tap time rather than as a setting, because it is a daily decision and the site's own
+ * page asks it the same way.
+ */
+@Composable
+private fun AttendanceModeDialog(
+    onPick: (AttendanceMode) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(NodeSeekIcons.ChickenLeg, contentDescription = null, tint = MaterialTheme.colorScheme.primary) },
+        title = { Text(stringResource(R.string.assets_sign_in_choice_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                Button(
+                    onClick = { onPick(AttendanceMode.RANDOM) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(24.dp),
+                ) {
+                    Text(stringResource(R.string.assets_sign_in_random))
+                }
+                FilledTonalButton(
+                    onClick = { onPick(AttendanceMode.FIXED_FIVE) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(24.dp),
+                ) {
+                    Text(stringResource(R.string.assets_sign_in_fixed))
+                }
+                Text(
+                    text = stringResource(R.string.assets_sign_in_choice_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
+    )
+}
+
+/** 今日签到榜 — who signed in and what they rolled, straight off `/api/attendance/board`. */
+@Composable
+private fun AttendanceBoardDialog(
+    state: AssetsUiState,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.assets_board)) },
+        text = {
+            when {
+                state.isLoadingBoard ->
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(160.dp),
+                        contentAlignment = Alignment.Center,
+                    ) { CircularProgressIndicator(Modifier.size(24.dp)) }
+
+                state.boardError != null ->
+                    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                        Text(
+                            stringResource(R.string.assets_board_failed),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        TextButton(onClick = onRetry) { Text(stringResource(R.string.action_retry)) }
+                    }
+
+                else ->
+                    LazyColumn(Modifier.height(BOARD_LIST_HEIGHT)) {
+                        items(count = state.board.size, key = { it }) { index ->
+                            val entry = state.board[index]
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 7.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                            ) {
+                                Text(
+                                    text = (index + 1).toString(),
+                                    style =
+                                    MaterialTheme.typography.labelMedium.copy(
+                                        fontFeatureSettings = TABULAR_FIGURES,
+                                    ),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.width(22.dp),
+                                )
+                                Text(
+                                    text = entry.name,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                entry.gain?.let {
+                                    Text(
+                                        text = stringResource(R.string.assets_board_gain, it),
+                                        style =
+                                        MaterialTheme.typography.labelLarge.copy(
+                                            fontWeight = FontWeight.Bold,
+                                            fontFeatureSettings = TABULAR_FIGURES,
+                                        ),
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            }
+                        }
+                    }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_close)) }
+        },
+    )
+}
+
+private val BOARD_LIST_HEIGHT = 360.dp
+
+/**
+ * Buying an invite code, confirmed the same way as every other spend.
+ *
+ * Shared with the invite screen deliberately: the same 1000 chicken leave the account whichever entry
+ * point was tapped, so they get the same sentence and the same disabled state when the balance is short.
+ */
+@Composable
+fun InviteConfirmDialog(
+    chickenCount: Int?,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val shortfall = chickenCount?.let { (INVITE_CODE_CHICKEN_COST - it).takeIf { gap -> gap > 0 } }
+    SpendConfirmDialog(
+        title = stringResource(R.string.invite_confirm_title),
+        details =
+        buildList {
+            add(SpendDetail(stringResource(R.string.invite_cost), stringResource(R.string.invite_cost_value)))
+            chickenCount?.let { balance ->
+                add(SpendDetail(stringResource(R.string.spend_current_balance), balance.toString()))
+                if (shortfall == null) {
+                    add(
+                        SpendDetail(
+                            stringResource(R.string.invite_balance_after),
+                            (balance - INVITE_CODE_CHICKEN_COST).toString(),
+                        ),
+                    )
+                }
+            }
+        },
+        caution =
+        stringResource(R.string.invite_caution) + "\n" + stringResource(R.string.invite_opened_web),
+        confirmLabel = stringResource(R.string.invite_confirm),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+        icon = NodeSeekIcons.ConfirmationNumber,
+        shortfall = shortfall?.let { stringResource(R.string.invite_shortfall, it) },
+    )
+}
+
+/**
+ * The level card, whose bar is the chicken count itself.
+ *
+ * Only Lv 1 → Lv 2 has a published threshold (400). Above that the card shows the count and says the
+ * threshold is not public, rather than drawing a bar against a number we made up.
+ */
+@Composable
+private fun LevelCard(state: AssetsUiState) {
+    AssetsCard(radius = 22.dp) {
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                text = state.level?.let { stringResource(R.string.assets_level, it) } ?: UNKNOWN,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f),
+            )
+            val target = state.nextLevelChicken
+            val chicken = state.chickenCount
+            Text(
+                text =
+                if (target != null && chicken != null) {
+                    stringResource(R.string.assets_level_progress, chicken, target)
+                } else {
+                    chicken?.let { stringResource(R.string.assets_chicken_count, it) } ?: UNKNOWN
+                },
+                style = MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        ProgressTrack(progress = state.levelProgress, height = 8.dp)
+        Text(
+            text =
+            state.chickenToNextLevel?.let { remaining ->
+                stringResource(R.string.assets_level_remaining, remaining, (state.level ?: 1) + 1)
+            } ?: stringResource(R.string.assets_level_no_threshold),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DailyQuotaCard(state: AssetsUiState) {
+    AssetsCard(radius = 22.dp) {
+        Text(
+            text = stringResource(R.string.assets_daily_title),
+            style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
+        )
+        QuotaRow(stringResource(R.string.assets_quota_post), state.postQuota)
+        QuotaRow(stringResource(R.string.assets_quota_comment), state.commentQuota)
+        QuotaRow(
+            label = stringResource(R.string.assets_quota_attendance),
+            quota = state.attendanceQuota,
+            badge = state.attendanceGain?.let { stringResource(R.string.assets_signed_in, it) },
+        )
+        QuotaRow(stringResource(R.string.assets_quota_feeding), state.feedingQuota)
+        if (!state.postQuota.isKnown) {
+            Text(
+                text = stringResource(R.string.assets_quota_hint),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuotaRow(
+    label: String,
+    quota: DailyQuota,
+    badge: String? = null,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(label, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+            badge?.let {
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.padding(end = Spacing.sm),
+                ) {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                        modifier = Modifier.padding(horizontal = 7.dp, vertical = 2.dp),
+                    )
+                }
+            }
+            Text(
+                text = quota.label(),
+                style = MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        ProgressTrack(progress = quota.progress(), height = 4.dp)
+    }
+}
+
+@Composable
+private fun DailyQuota.label(): String =
+    when {
+        used != null && total != null -> stringResource(R.string.assets_quota_value, used, total)
+        total != null -> stringResource(R.string.assets_quota_value_unknown, total)
+        else -> UNKNOWN
+    }
+
+private fun DailyQuota.progress(): Float? {
+    val cap = total?.takeIf { it > 0 } ?: return null
+    val current = used ?: return null
+    return (current.toFloat() / cap).coerceIn(0f, 1f)
+}
+
+/** A determinate bar when the number is known, an empty track when it is not. Never a guessed fill. */
+@Composable
+private fun ProgressTrack(
+    progress: Float?,
+    height: Dp,
+) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(height)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+    ) {
+        if (progress != null && progress > 0f) {
+            Box(
+                Modifier
+                    .fillMaxWidth(progress)
+                    .height(height)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RowScope.BalanceCard(
+    label: String,
+    value: Int?,
+    action: String,
+    container: Color,
+    content: Color,
+    onClick: () -> Unit,
+) {
+    Surface(
+        color = container,
+        contentColor = content,
+        shape = RoundedCornerShape(20.dp),
+        modifier = Modifier
+            .weight(1f)
+            .clickable(onClick = onClick),
+    ) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+            )
+            Text(
+                text = value?.toString() ?: UNKNOWN,
+                style =
+                MaterialTheme.typography.headlineMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontFeatureSettings = TABULAR_FIGURES,
+                ),
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(action, style = MaterialTheme.typography.labelMedium)
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(15.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Sign-in, which is the only write this screen performs.
+ *
+ * The site does not say whether today is already signed until the request is made, so the button starts
+ * enabled and becomes a tonal, disabled receipt afterwards — including when the answer was "已经签到过
+ * 了", which is the site's own sentence and more use than a generic error.
+ */
+@Composable
+private fun AttendanceButton(
+    state: AssetsUiState,
+    onRequestAttendance: () -> Unit,
+) {
+    val done = state.hasSignedInThisSession
+    Button(
+        onClick = onRequestAttendance,
+        enabled = !done && !state.isSigningIn,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors =
+        if (done) {
+            ButtonDefaults.filledTonalButtonColors()
+        } else {
+            ButtonDefaults.buttonColors()
+        },
+    ) {
+        when {
+            state.isSigningIn -> {
+                CircularProgressIndicator(Modifier.size(18.dp))
+                Text(
+                    stringResource(R.string.assets_signing_in),
+                    modifier = Modifier.padding(start = Spacing.sm),
+                )
+            }
+
+            done -> {
+                Icon(Icons.Default.CheckCircle, contentDescription = null, modifier = Modifier.size(20.dp))
+                Text(
+                    text =
+                    state.attendanceGain?.let { stringResource(R.string.assets_signed_in, it) }
+                        ?: state.attendanceMessage
+                        ?: stringResource(R.string.assets_sign_in),
+                    modifier = Modifier.padding(start = Spacing.sm),
+                )
+            }
+
+            else -> {
+                Icon(NodeSeekIcons.ChickenLeg, contentDescription = null, modifier = Modifier.size(20.dp))
+                Text(
+                    stringResource(R.string.assets_sign_in),
+                    modifier = Modifier.padding(start = Spacing.sm),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AssetsCard(
+    radius: Dp,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(radius),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            content = content,
+        )
+    }
+}
+
+private const val UNKNOWN = "—"
+
+// -------------------------------------------------------------------------------------------------
+
+private val previewState =
+    AssetsUiState(
+        isLoading = false,
+        level = 1,
+        chickenCount = 344,
+        starCount = 4,
+        nextLevelChicken = 400,
+        postQuota = DailyQuota(0, 20),
+        commentQuota = DailyQuota(3, 20),
+        attendanceQuota = DailyQuota(7, 7),
+        feedingQuota = DailyQuota(0, 0),
+        hasSignedInThisSession = true,
+        attendanceGain = 7,
+    )
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8d 账户与成长")
+@Composable
+private fun AssetsPreview() {
+    NodeSeekTheme { PreviewScreen(previewState) }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8d 额度未接入 · dark")
+@Composable
+private fun AssetsUnknownQuotaPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        PreviewScreen(
+            previewState.copy(
+                postQuota = DailyQuota(null, 20),
+                commentQuota = DailyQuota(null, 20),
+                attendanceQuota = DailyQuota(null, null),
+                feedingQuota = DailyQuota(null, null),
+                hasSignedInThisSession = false,
+                attendanceGain = null,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun PreviewScreen(state: AssetsUiState) {
+    AssetsScreen(
+        state = state,
+        onBack = {},
+        onRetry = {},
+        onRequestAttendance = {},
+        onDismissAttendanceChooser = {},
+        onSignInForToday = {},
+        onOpenBoard = {},
+        onDismissBoard = {},
+        onRetryBoard = {},
+        onChickenLedger = {},
+        onStardust = {},
+        onOpenBrowser = {},
+        onSignIn = {},
+    )
+}

--- a/app/src/main/java/io/github/nsreader/ui/assets/AssetsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/assets/AssetsViewModel.kt
@@ -1,0 +1,180 @@
+package io.github.nsreader.ui.assets
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.AssetsRepository
+import io.github.nsreader.data.AttendanceBoardEntry
+import io.github.nsreader.data.AttendanceMode
+import io.github.nsreader.data.DailyQuota
+import io.github.nsreader.data.GrowthSnapshot
+import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AssetsUiState(
+    val isLoading: Boolean = true,
+    val error: NodeSeekError? = null,
+    val level: Int? = null,
+    val chickenCount: Int? = null,
+    val starCount: Int? = null,
+    /** Null on every level but Lv 1, whose 400-chicken threshold is the only published one. */
+    val nextLevelChicken: Int? = null,
+    val postQuota: DailyQuota = DailyQuota(null, null),
+    val commentQuota: DailyQuota = DailyQuota(null, null),
+    val attendanceQuota: DailyQuota = DailyQuota(null, null),
+    val feedingQuota: DailyQuota = DailyQuota(null, null),
+    val isSigningIn: Boolean = false,
+    /** Set once today's sign-in has been attempted; the site tells us nothing before that. */
+    val attendanceGain: Int? = null,
+    val attendanceMessage: String? = null,
+    val hasSignedInThisSession: Boolean = false,
+    /** True while the mode chooser (随机 / 固定 5 个) is on screen. */
+    val choosingAttendanceMode: Boolean = false,
+    val boardOpen: Boolean = false,
+    val isLoadingBoard: Boolean = false,
+    val board: List<AttendanceBoardEntry> = emptyList(),
+    val boardError: NodeSeekError? = null,
+) {
+    val hasData: Boolean get() = chickenCount != null || starCount != null || level != null
+
+    /** How much more the level bar needs, when the threshold is known and not yet reached. */
+    val chickenToNextLevel: Int?
+        get() {
+            val target = nextLevelChicken ?: return null
+            val current = chickenCount ?: return null
+            return (target - current).takeIf { it > 0 }
+        }
+
+    val levelProgress: Float?
+        get() {
+            val target = nextLevelChicken?.takeIf { it > 0 } ?: return null
+            val current = chickenCount ?: return null
+            return (current.toFloat() / target).coerceIn(0f, 1f)
+        }
+}
+
+/**
+ * State holder for 账户与成长.
+ *
+ * Levelling on NodeSeek is chicken-based — the progress bar *is* the chicken count — so this screen has
+ * no separate growth number to fetch. What it cannot get is today's four allowances: they live on a
+ * client-rendered page, and the UiState carries them as unknown rather than as zero.
+ */
+class AssetsViewModel(
+    private val repository: AssetsRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(AssetsUiState())
+    val uiState: StateFlow<AssetsUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+    private var signInJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                runCatchingExceptCancellation { repository.growth() }
+                    .onSuccess { snapshot -> _uiState.update { it.withGrowth(snapshot) } }
+                    .onFailure { throwable ->
+                        _uiState.update { it.copy(isLoading = false, error = throwable.toNodeSeekError()) }
+                    }
+            }
+    }
+
+    fun requestAttendance() = _uiState.update { it.copy(choosingAttendanceMode = true) }
+
+    fun dismissAttendanceChooser() = _uiState.update { it.copy(choosingAttendanceMode = false) }
+
+    /**
+     * Signs in for the day, in whichever of the site's two modes the user picked.
+     *
+     * The result is kept as the site's own sentence rather than translated into a boolean: a repeat
+     * sign-in is answered with "今天已完成签到", which is more useful to show than to classify.
+     */
+    fun signInForToday(mode: AttendanceMode) {
+        if (signInJob?.isActive == true) return
+        signInJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isSigningIn = true, choosingAttendanceMode = false) }
+                runCatchingExceptCancellation { repository.signInForToday(mode) }
+                    .onSuccess { result ->
+                        _uiState.update {
+                            it.copy(
+                                isSigningIn = false,
+                                hasSignedInThisSession = true,
+                                attendanceGain = result.gain,
+                                attendanceMessage = result.message,
+                            )
+                        }
+                        // Chicken earned moves the level bar, so the account is re-read rather than
+                        // patched locally: the server's number is the one that matters here.
+                        refresh()
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(isSigningIn = false, error = throwable.toNodeSeekError())
+                        }
+                    }
+            }
+    }
+
+    fun dismissError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    fun openBoard() {
+        _uiState.update { it.copy(boardOpen = true) }
+        if (_uiState.value.board.isEmpty()) loadBoard()
+    }
+
+    fun dismissBoard() = _uiState.update { it.copy(boardOpen = false) }
+
+    fun loadBoard() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingBoard = true, boardError = null) }
+            runCatchingExceptCancellation { repository.attendanceBoard() }
+                .onSuccess { entries ->
+                    _uiState.update { it.copy(isLoadingBoard = false, board = entries) }
+                }.onFailure { throwable ->
+                    _uiState.update {
+                        it.copy(isLoadingBoard = false, boardError = throwable.toNodeSeekError())
+                    }
+                }
+        }
+    }
+
+    private fun AssetsUiState.withGrowth(snapshot: GrowthSnapshot): AssetsUiState =
+        copy(
+            isLoading = false,
+            error = null,
+            level = snapshot.level,
+            chickenCount = snapshot.chickenCount,
+            starCount = snapshot.starCount,
+            nextLevelChicken = snapshot.nextLevelChicken,
+            postQuota = snapshot.postQuota,
+            commentQuota = snapshot.commentQuota,
+            attendanceQuota = snapshot.attendanceQuota,
+            feedingQuota = snapshot.feedingQuota,
+        )
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { AssetsViewModel(container.assetsRepository) }
+            }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/assets/StardustScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/assets/StardustScreen.kt
@@ -1,0 +1,464 @@
+package io.github.nsreader.ui.assets
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.ThumbUp
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.StardustEntry
+import io.github.nsreader.ui.common.LoadingState
+import io.github.nsreader.ui.common.NodeSeekErrorState
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.SpendConfirmDialog
+import io.github.nsreader.ui.common.SpendDetail
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun StardustRoute(
+    viewModel: StardustViewModel,
+    onBack: () -> Unit,
+    onOpenBrowser: () -> Unit,
+    onTransferOnSite: () -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    StardustScreen(
+        state = state,
+        onBack = onBack,
+        onRetry = viewModel::refresh,
+        onOpenBrowser = onOpenBrowser,
+        onSignIn = onSignIn,
+        onOpenTransfer = viewModel::openTransfer,
+        onDismissTransfer = viewModel::dismissTransfer,
+        onFormChange = viewModel::updateForm,
+        onRequestConfirm = viewModel::requestConfirm,
+        onDismissConfirm = viewModel::dismissConfirm,
+        onConfirmTransfer = {
+            viewModel.transferHandedOff()
+            onTransferOnSite()
+        },
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StardustScreen(
+    state: StardustUiState,
+    onBack: () -> Unit,
+    onRetry: () -> Unit,
+    onOpenBrowser: () -> Unit,
+    onSignIn: () -> Unit,
+    onOpenTransfer: () -> Unit,
+    onDismissTransfer: () -> Unit,
+    onFormChange: (TransferForm) -> Unit,
+    onRequestConfirm: () -> Unit,
+    onDismissConfirm: () -> Unit,
+    onConfirmTransfer: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.stardust_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            // No uid yet means no per-member ledger URL to hand the transfer to — the button that
+            // would end on the site's home page with the typed form lost is better absent.
+            if (state.uid != null) {
+                ExtendedFloatingActionButton(
+                    onClick = onOpenTransfer,
+                    icon = { Icon(Icons.Default.Send, contentDescription = null) },
+                    text = { Text(stringResource(R.string.transfer_action)) },
+                )
+            }
+        },
+    ) { padding ->
+        Column(
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth(),
+        ) {
+            BalanceHeader(state.balance)
+            StardustLedger(
+                state = state,
+                onRetry = onRetry,
+                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+
+    if (state.transferOpen) {
+        TransferDialog(
+            state = state,
+            onDismiss = onDismissTransfer,
+            onFormChange = onFormChange,
+            onRequestConfirm = onRequestConfirm,
+        )
+    }
+
+    if (state.confirmOpen) {
+        TransferConfirmDialog(
+            state = state,
+            onConfirm = onConfirmTransfer,
+            onDismiss = onDismissConfirm,
+        )
+    }
+}
+
+@Composable
+private fun BalanceHeader(balance: Int?) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        shape = RoundedCornerShape(22.dp),
+        modifier = Modifier
+            .padding(start = Spacing.lg, end = Spacing.lg, bottom = Spacing.md)
+            .fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.stardust_balance),
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+            )
+            Text(
+                text = balance?.toString() ?: "—",
+                style =
+                MaterialTheme.typography.headlineLarge.copy(
+                    fontWeight = FontWeight.Bold,
+                    fontFeatureSettings = TABULAR_FIGURES,
+                ),
+            )
+            Text(
+                text = stringResource(R.string.stardust_balance_hint),
+                style = MaterialTheme.typography.labelMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StardustLedger(
+    state: StardustUiState,
+    onRetry: () -> Unit,
+    onOpenBrowser: () -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when {
+        state.isLoading && state.entries.isEmpty() -> LoadingState(modifier)
+
+        state.error != null && state.entries.isEmpty() ->
+            NodeSeekErrorState(
+                error = state.error,
+                onRetry = onRetry,
+                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                modifier = modifier,
+            )
+
+        else ->
+            LazyColumn(modifier) {
+                items(count = state.entries.size, key = { state.entries[it].commentId ?: it.toLong() }) { index ->
+                    StardustRow(state.entries[index])
+                }
+                item(key = "footer") {
+                    Text(
+                        text = stringResource(R.string.stardust_end),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 14.dp, bottom = 96.dp),
+                    )
+                }
+            }
+    }
+}
+
+/**
+ * One +1.
+ *
+ * Every stardust row is a comment of yours being liked, so the icon is a thumb and the amount is always
+ * a gain. The meta line carries what the site's table carried: the balance it left, which comment, when.
+ */
+@Composable
+private fun StardustRow(entry: StardustEntry) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(38.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerLow),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Default.ThumbUp,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(19.dp),
+            )
+        }
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = stringResource(R.string.stardust_entry_title),
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text =
+                listOfNotNull(
+                    entry.balanceAfter?.let { stringResource(R.string.stardust_entry_balance, it) },
+                    entry.commentId?.let { stringResource(R.string.stardust_entry_comment, it) },
+                    entry.timestampText,
+                ).joinToString(" · "),
+                style = MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(
+            text = stringResource(R.string.stardust_entry_amount, entry.amount),
+            style =
+            MaterialTheme.typography.titleSmall.copy(
+                fontWeight = FontWeight.Bold,
+                fontFeatureSettings = TABULAR_FIGURES,
+            ),
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+/**
+ * The transfer form, matching the site's three fields exactly.
+ *
+ * A dialog rather than a bottom sheet, for two reasons that point the same way: the site presents
+ * transfer as a modal layer (8f's own framing), and a dialog window resizes for the keyboard — the
+ * sheet provably did not on a real device, hiding the fields behind the IME as they were typed into.
+ *
+ * No memo field and no recipient name lookup: the site's own layer has neither, and a nickname echo
+ * would need an endpoint that does not exist. The caution line under the fields says so, because the
+ * only protection against a mistyped uid here is the user reading it back.
+ */
+@Composable
+private fun TransferDialog(
+    state: StardustUiState,
+    onDismiss: () -> Unit,
+    onFormChange: (TransferForm) -> Unit,
+    onRequestConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.transfer_title)) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(Spacing.md),
+            ) {
+                NumberField(
+                    value = state.form.amount,
+                    label = stringResource(R.string.transfer_amount),
+                    onValueChange = { onFormChange(state.form.copy(amount = it)) },
+                )
+                NumberField(
+                    value = state.form.recipientUid,
+                    label = stringResource(R.string.transfer_recipient),
+                    onValueChange = { onFormChange(state.form.copy(recipientUid = it)) },
+                )
+                NumberField(
+                    value = state.form.refId,
+                    label = stringResource(R.string.transfer_ref),
+                    onValueChange = { onFormChange(state.form.copy(refId = it)) },
+                )
+                Text(
+                    text = stringResource(R.string.transfer_hint),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onRequestConfirm, enabled = state.form.isComplete) {
+                Text(stringResource(R.string.transfer_next))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
+    )
+}
+
+@Composable
+private fun NumberField(
+    value: String,
+    label: String,
+    onValueChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { input -> onValueChange(input.filter(Char::isDigit).take(MAX_NUMBER_LENGTH)) },
+        label = { Text(label) },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+private const val MAX_NUMBER_LENGTH = 12
+
+@Composable
+private fun TransferConfirmDialog(
+    state: StardustUiState,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val amount = state.form.amountValue ?: return
+    SpendConfirmDialog(
+        title = stringResource(R.string.transfer_confirm_title, amount),
+        details =
+        buildList {
+            add(
+                SpendDetail(
+                    stringResource(R.string.transfer_amount),
+                    stringResource(R.string.transfer_amount_value, amount),
+                ),
+            )
+            state.form.recipientValue?.let {
+                add(SpendDetail(stringResource(R.string.transfer_recipient), it.toString()))
+            }
+            state.form.refValue?.let {
+                add(SpendDetail(stringResource(R.string.transfer_ref), it.toString()))
+            }
+            state.balance?.let { balance ->
+                // With enough balance the row answers "what will be left"; short of it there is no
+                // after to describe, so the row honestly labels what it shows — the balance itself.
+                add(
+                    if (state.shortfall == null) {
+                        SpendDetail(
+                            stringResource(R.string.transfer_balance_after),
+                            stringResource(R.string.transfer_balance_change, balance, balance - amount),
+                        )
+                    } else {
+                        SpendDetail(stringResource(R.string.spend_current_balance), balance.toString())
+                    },
+                )
+            }
+        },
+        // Two sentences: what cannot be undone, and where the last step actually happens. Saying the
+        // hand-off *before* the tap is what stops the web view from looking like a failure.
+        caution =
+        stringResource(R.string.transfer_caution) + "\n" + stringResource(R.string.transfer_opened_web),
+        confirmLabel = stringResource(R.string.transfer_confirm),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+        icon = NodeSeekIcons.Wallet,
+        shortfall = state.shortfall?.let { stringResource(R.string.transfer_shortfall, it) },
+    )
+}
+
+// -------------------------------------------------------------------------------------------------
+
+private val previewEntries =
+    listOf(
+        StardustEntry(1, 4, 866042, "2026/7/21 18:09:50"),
+        StardustEntry(1, 3, 861377, "2026/6/30 09:41:12"),
+        StardustEntry(1, 2, 852206, "2026/5/18 22:03:45"),
+        StardustEntry(1, 1, 838914, "2026/3/2 12:57:08"),
+    )
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8e 星辰流水")
+@Composable
+private fun StardustPreview() {
+    NodeSeekTheme {
+        PreviewScreen(StardustUiState(isLoading = false, balance = 4, entries = previewEntries))
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8e 流水未接入 · dark")
+@Composable
+private fun StardustNotWiredPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        PreviewScreen(StardustUiState(isLoading = false, balance = 4, error = NodeSeekError.NotWired))
+    }
+}
+
+@Composable
+private fun PreviewScreen(state: StardustUiState) {
+    StardustScreen(
+        state = state,
+        onBack = {},
+        onRetry = {},
+        onOpenBrowser = {},
+        onSignIn = {},
+        onOpenTransfer = {},
+        onDismissTransfer = {},
+        onFormChange = {},
+        onRequestConfirm = {},
+        onDismissConfirm = {},
+        onConfirmTransfer = {},
+    )
+}

--- a/app/src/main/java/io/github/nsreader/ui/assets/StardustViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/assets/StardustViewModel.kt
@@ -1,0 +1,139 @@
+package io.github.nsreader.ui.assets
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.StardustEntry
+import io.github.nsreader.data.StardustRepository
+import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * The transfer form: amount, recipient uid, reference id.
+ *
+ * Three text fields rather than three numbers because a half-typed uid is a real state the user passes
+ * through, and [isComplete] is what decides whether the confirmation step may be reached at all.
+ */
+data class TransferForm(
+    val amount: String = "",
+    val recipientUid: String = "",
+    val refId: String = "",
+) {
+    val amountValue: Int? get() = amount.trim().toIntOrNull()?.takeIf { it > 0 }
+    val recipientValue: Long? get() = recipientUid.trim().toLongOrNull()?.takeIf { it > 0 }
+    val refValue: Long? get() = refId.trim().toLongOrNull()?.takeIf { it > 0 }
+
+    val isComplete: Boolean get() = amountValue != null && recipientValue != null && refValue != null
+}
+
+data class StardustUiState(
+    val isLoading: Boolean = true,
+    val error: NodeSeekError? = null,
+    /** Needed to reach the site's own ledger, whose URL is per-member. */
+    val uid: Long? = null,
+    val balance: Int? = null,
+    val entries: List<StardustEntry> = emptyList(),
+    val transferOpen: Boolean = false,
+    val confirmOpen: Boolean = false,
+    val form: TransferForm = TransferForm(),
+) {
+    /** How far the balance falls short of the amount typed, or null when it covers it. */
+    val shortfall: Int?
+        get() {
+            val amount = form.amountValue ?: return null
+            val balance = balance ?: return null
+            return (amount - balance).takeIf { it > 0 }
+        }
+}
+
+/**
+ * State holder for 星辰.
+ *
+ * The balance comes from the account endpoint, which does publish it; the ledger comes from a page the
+ * site renders client-side, which does not. So the balance card is real and the list says it is not
+ * wired — a distinction worth keeping visible, since the balance is what a transfer depends on.
+ */
+class StardustViewModel(
+    private val profileRepository: ProfileRepository,
+    private val stardustRepository: StardustRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(StardustUiState())
+    val uiState: StateFlow<StardustUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                val profile =
+                    runCatchingExceptCancellation { profileRepository.profile() }.getOrNull()
+                runCatchingExceptCancellation { stardustRepository.entries() }
+                    .onSuccess { entries ->
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                error = null,
+                                uid = profile?.uid,
+                                balance = profile?.starCount,
+                                entries = entries,
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                uid = profile?.uid,
+                                balance = profile?.starCount,
+                                error = throwable.toNodeSeekError(),
+                            )
+                        }
+                    }
+            }
+    }
+
+    fun openTransfer() = _uiState.update { it.copy(transferOpen = true) }
+
+    fun dismissTransfer() = _uiState.update { it.copy(transferOpen = false, confirmOpen = false) }
+
+    fun updateForm(form: TransferForm) = _uiState.update { it.copy(form = form) }
+
+    fun requestConfirm() {
+        if (!_uiState.value.form.isComplete) return
+        _uiState.update { it.copy(confirmOpen = true) }
+    }
+
+    fun dismissConfirm() = _uiState.update { it.copy(confirmOpen = false) }
+
+    /** Clears the form after the transfer has been handed to the site's own page. */
+    fun transferHandedOff() =
+        _uiState.update { it.copy(transferOpen = false, confirmOpen = false, form = TransferForm()) }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    StardustViewModel(
+                        profileRepository = container.profileRepository,
+                        stardustRepository = container.stardustRepository,
+                    )
+                }
+            }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/common/GroupedRows.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/GroupedRows.kt
@@ -1,0 +1,147 @@
+package io.github.nsreader.ui.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.ui.theme.Spacing
+
+/**
+ * The grouped rounded list the settings and tools screens are built from.
+ *
+ * The shape is the grouping: the first and last row round to 18dp on their outer corners and every
+ * seam stays at 5dp, so a group reads as one object without a card border or a divider. A single-row
+ * group is both first and last and therefore fully rounded.
+ */
+fun groupShape(first: Boolean, last: Boolean): Shape =
+    RoundedCornerShape(
+        topStart = if (first) GROUP_OUTER_RADIUS else GROUP_SEAM_RADIUS,
+        topEnd = if (first) GROUP_OUTER_RADIUS else GROUP_SEAM_RADIUS,
+        bottomEnd = if (last) GROUP_OUTER_RADIUS else GROUP_SEAM_RADIUS,
+        bottomStart = if (last) GROUP_OUTER_RADIUS else GROUP_SEAM_RADIUS,
+    )
+
+private val GROUP_OUTER_RADIUS = 18.dp
+private val GROUP_SEAM_RADIUS = 5.dp
+
+/** Group heading. Primary-coloured and small: it labels the block without competing with the rows. */
+@Composable
+fun SectionLabel(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier.padding(start = Spacing.xs, bottom = 5.dp),
+    )
+}
+
+/** Wraps rows so the 2dp seams are declared once rather than at every call site. */
+@Composable
+fun GroupedColumn(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(2.dp), content = content)
+}
+
+/**
+ * One row of a grouped list: icon, title, optional second line, optional current value, chevron.
+ *
+ * [value] is the row's current state rendered at the trailing edge — "未开启", "3 人", an avatar. It is
+ * deliberately separate from [subtitle]: a value that wrapped onto its own line stopped reading as
+ * *this row's* state and started reading as another sentence.
+ */
+@Composable
+fun GroupedRow(
+    title: String,
+    modifier: Modifier = Modifier,
+    first: Boolean = false,
+    last: Boolean = false,
+    icon: ImageVector? = null,
+    iconTint: Color? = null,
+    titleColor: Color? = null,
+    subtitle: String? = null,
+    value: String? = null,
+    onClick: (() -> Unit)? = null,
+    showChevron: Boolean = onClick != null,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = groupShape(first, last),
+        modifier = modifier.then(if (onClick == null) Modifier else Modifier.clickable(onClick = onClick)),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.lg, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            icon?.let {
+                Icon(
+                    imageVector = it,
+                    contentDescription = null,
+                    tint = iconTint ?: MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = titleColor ?: MaterialTheme.colorScheme.onSurface,
+                )
+                subtitle?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            value?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+            }
+            trailing?.invoke()
+            if (showChevron) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/NodeSeekIcons.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.graphics.vector.addPathNodes
 import androidx.compose.ui.unit.dp
 
 /**
- * The four Material Symbols the design uses that `material-icons-core` does not ship.
+ * The Material Symbols the design uses that `material-icons-core` does not ship.
  *
  * Declared here rather than pulling in `material-icons-extended`, which would add roughly two
  * thousand unused vectors — and, more to the point, a dependency-graph change that this project's
@@ -101,6 +101,130 @@ object NodeSeekIcons {
                 "c2.3,1.8 5.7,1.2 7.6,-1.5c1.9,-2.7 2.7,-7.8 0,-9.1z" +
                 "M14.1,13.2l2.8,2.8c0.8,-0.4 1.8,-0.3 2.4,0.4c0.9,0.9 0.9,2.3 0,3.2" +
                 "c-0.9,0.9 -2.3,0.9 -3.2,0c-0.7,-0.7 -0.8,-1.6 -0.4,-2.4l-2.8,-2.8z",
+        )
+    }
+
+    /** Curated reading list. */
+    val MenuBook: ImageVector by lazy {
+        materialIcon(
+            name = "MenuBook",
+            pathData =
+            "M21,5c-1.1,-0.35 -2.3,-0.5 -3.5,-0.5 -1.95,0 -4.05,0.4 -5.5,1.5" +
+                "c-1.45,-1.1 -3.55,-1.5 -5.5,-1.5S2.45,4.9 1,6v14.65c0,0.25 0.25,0.5 0.5,0.5" +
+                "c0.1,0 0.15,-0.05 0.25,-0.05C3.1,20.45 5.05,20 6.5,20c1.95,0 4.05,0.4 5.5,1.5" +
+                "c1.35,-0.85 3.8,-1.5 5.5,-1.5 1.65,0 3.35,0.3 4.75,1.05 0.1,0.05 0.15,0.05 0.25,0.05" +
+                "c0.25,0 0.5,-0.25 0.5,-0.5V6c-0.6,-0.45 -1.25,-0.75 -2,-1z" +
+                "M21,18.5c-1.1,-0.35 -2.3,-0.5 -3.5,-0.5 -1.7,0 -4.15,0.65 -5.5,1.5V8" +
+                "c1.35,-0.85 3.8,-1.5 5.5,-1.5 1.2,0 2.4,0.15 3.5,0.5v11.5z",
+        )
+    }
+
+    /** Lucky draw — the site's T-floor notary tool. */
+    val Casino: ImageVector by lazy {
+        materialIcon(
+            name = "Casino",
+            pathData =
+            "M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z" +
+                "M7.5,18C6.67,18 6,17.33 6,16.5S6.67,15 7.5,15 9,15.67 9,16.5 8.33,18 7.5,18z" +
+                "M7.5,9C6.67,9 6,8.33 6,7.5S6.67,6 7.5,6 9,6.67 9,7.5 8.33,9 7.5,9z" +
+                "M12,13.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5z" +
+                "M16.5,18c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5z" +
+                "M16.5,9c-0.83,0 -1.5,-0.67 -1.5,-1.5S15.67,6 16.5,6 18,6.67 18,7.5 17.33,9 16.5,9z",
+        )
+    }
+
+    /** Invite code. */
+    val ConfirmationNumber: ImageVector by lazy {
+        materialIcon(
+            name = "ConfirmationNumber",
+            pathData =
+            "M22,10V6c0,-1.1 -0.9,-2 -2,-2H4C2.9,4 2.01,4.9 2.01,6v4C3.11,10 4,10.9 4,12s-0.89,2 -2,2v4" +
+                "c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2v-4c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2z" +
+                "M13,17.5h-2v-2h2v2zM13,13h-2v-2h2v2zM13,8.5h-2v-2h2v2z",
+        )
+    }
+
+    /** Moderation log. */
+    val Gavel: ImageVector by lazy {
+        materialIcon(
+            name = "Gavel",
+            pathData =
+            "M2,20h12v2H2zM14.5,2.5l-3,3 6,6 3,-3zM10.4,6.6l-6.5,6.5 3,3 6.5,-6.5z",
+        )
+    }
+
+    /** Balances and the transfer sheet. */
+    val Wallet: ImageVector by lazy {
+        materialIcon(
+            name = "Wallet",
+            pathData =
+            "M21,18v1c0,1.1 -0.9,2 -2,2H5c-1.11,0 -2,-0.9 -2,-2V5c0,-1.1 0.89,-2 2,-2h14" +
+                "c1.1,0 2,0.9 2,2v1h-9c-1.11,0 -2,0.9 -2,2v8c0,1.1 0.89,2 2,2h9z" +
+                "M12,16h10V8H12v8zM16,13.5c-0.83,0 -1.5,-0.67 -1.5,-1.5s0.67,-1.5 1.5,-1.5 1.5,0.67 1.5,1.5" +
+                " -0.67,1.5 -1.5,1.5z",
+        )
+    }
+
+    /** Two-factor authentication. */
+    val Shield: ImageVector by lazy {
+        materialIcon(
+            name = "Shield",
+            pathData =
+            "M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12V5l-9,-4z" +
+                "M12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94V12H5V6.3l7,-3.11v8.8z",
+        )
+    }
+
+    /** Blocked users. */
+    val Block: ImageVector by lazy {
+        materialIcon(
+            name = "Block",
+            pathData =
+            "M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z" +
+                "M4,12c0,-4.42 3.58,-8 8,-8 1.85,0 3.55,0.63 4.9,1.69L5.69,16.9C4.63,15.55 4,13.85 4,12z" +
+                "M12,20c-1.85,0 -3.55,-0.63 -4.9,-1.69L18.31,7.1C19.37,8.45 20,10.15 20,12c0,4.42 -3.58,8 -8,8z",
+        )
+    }
+
+    /** Saves a viewed image to the gallery. */
+    val Download: ImageVector by lazy {
+        materialIcon(
+            name = "Download",
+            pathData = "M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z",
+        )
+    }
+
+    /** Generated links, friend sites. */
+    val Link: ImageVector by lazy {
+        materialIcon(
+            name = "Link",
+            pathData =
+            "M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4V7H7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9H7" +
+                "c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2H8v2z" +
+                "M17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1s-1.39,3.1 -3.1,3.1h-4V17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z",
+        )
+    }
+
+    /** Leaves the app for the site. */
+    val OpenInNew: ImageVector by lazy {
+        materialIcon(
+            name = "OpenInNew",
+            pathData =
+            "M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7z" +
+                "M14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z",
+        )
+    }
+
+    /** Follows and followers. */
+    val Group: ImageVector by lazy {
+        materialIcon(
+            name = "Group",
+            pathData =
+            "M16,11c1.66,0 2.99,-1.34 2.99,-3S17.66,5 16,5c-1.66,0 -3,1.34 -3,3s1.34,3 3,3z" +
+                "M8,11c1.66,0 2.99,-1.34 2.99,-3S9.66,5 8,5C6.34,5 5,6.34 5,8s1.34,3 3,3z" +
+                "M8,13c-2.33,0 -7,1.17 -7,3.5V19h14v-2.5c0,-2.33 -4.67,-3.5 -7,-3.5z" +
+                "M16,13c-0.29,0 -0.62,0.02 -0.97,0.05 1.16,0.84 1.97,1.97 1.97,3.45V19h6v-2.5" +
+                "c0,-2.33 -4.67,-3.5 -7,-3.5z",
         )
     }
 

--- a/app/src/main/java/io/github/nsreader/ui/common/NumericPager.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/NumericPager.kt
@@ -1,0 +1,135 @@
+package io.github.nsreader.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.R
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+
+/**
+ * The site's numeric pager, for the lists that have one instead of infinite scroll.
+ *
+ * Curated threads and the moderation log are read by page number on the site — "第 104 页" is how
+ * people refer to them — and both run to three digits, so an endless scroll would replace a two-tap
+ * jump with a hundred flings. The window is deliberately narrow: current page, its neighbours, and
+ * the last page, with an ellipsis standing in for everything skipped.
+ */
+@Composable
+fun NumericPager(
+    page: Int,
+    totalPages: Int,
+    onPageSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    approximateTotal: Boolean = false,
+) {
+    if (totalPages <= 1) return
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(52.dp)
+            .padding(horizontal = Spacing.md),
+        horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        pageWindow(page, totalPages).forEach { entry ->
+            when (entry) {
+                null ->
+                    Text(
+                        text = "…",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 2.dp),
+                    )
+
+                else -> PageChip(number = entry, selected = entry == page, onClick = { onPageSelected(entry) })
+            }
+        }
+        if (approximateTotal) {
+            Text(
+                text = stringResource(R.string.pager_total_approx, totalPages),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** `null` marks a gap the ellipsis stands in for. */
+internal fun pageWindow(page: Int, totalPages: Int): List<Int?> {
+    if (totalPages <= MAX_VISIBLE_PAGES) return (1..totalPages).toList()
+    val current = page.coerceIn(1, totalPages)
+    val head = (1..3).toList()
+    val around = ((current - 1)..(current + 1)).filter { it in 1..totalPages }
+    val numbers = (head + around + totalPages).distinct().sorted()
+
+    return buildList {
+        var previous: Int? = null
+        numbers.forEach { number ->
+            if (previous != null && number - previous!! > 1) add(null)
+            add(number)
+            previous = number
+        }
+    }
+}
+
+private const val MAX_VISIBLE_PAGES = 6
+
+@Composable
+private fun PageChip(
+    number: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(16.dp),
+        color =
+        if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor =
+        if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.semantics { this.selected = selected },
+    ) {
+        Box(
+            modifier = Modifier
+                .defaultMinSize(minWidth = 32.dp, minHeight = 32.dp)
+                .padding(horizontal = 10.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = number.toString(),
+                style =
+                MaterialTheme.typography.labelLarge.copy(
+                    fontFeatureSettings = TABULAR_FIGURES,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+                ),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+private fun NumericPagerPreview() {
+    NodeSeekTheme {
+        NumericPager(page = 1, totalPages = 104, onPageSelected = {}, approximateTotal = true)
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/common/SpendConfirmDialog.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/SpendConfirmDialog.kt
@@ -1,0 +1,164 @@
+package io.github.nsreader.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.R
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+
+/** One line of the "what exactly is being spent" block. */
+data class SpendDetail(
+    val label: String,
+    val value: String,
+    val note: String? = null,
+)
+
+/**
+ * The single confirmation layer in front of every irreversible spend: transfer, invite code, feeding.
+ *
+ * One component rather than three dialogs because the thing being confirmed is always the same shape —
+ * how much leaves the account, where it goes, what is left afterwards, and that none of it can be
+ * undone. Reading those four facts in the same place each time is what makes a habitual tap safe.
+ *
+ * [shortfall] is what turns it into a dead end on purpose: when the balance cannot cover the amount,
+ * the confirm button is disabled and the gap is named, because "确认" that fails server-side teaches
+ * the user nothing.
+ */
+@Composable
+fun SpendConfirmDialog(
+    title: String,
+    details: List<SpendDetail>,
+    caution: String,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: ImageVector = Icons.Default.Warning,
+    shortfall: String? = null,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        shape = RoundedCornerShape(28.dp),
+        icon = { Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary) },
+        title = { Text(title, style = MaterialTheme.typography.headlineSmall) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.md)) {
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainer,
+                    shape = RoundedCornerShape(14.dp),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 14.dp, vertical = Spacing.md),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+                    ) {
+                        details.forEach { detail ->
+                            Row(Modifier.fillMaxWidth()) {
+                                Text(
+                                    text = detail.label,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                Text(
+                                    text = detail.value,
+                                    style =
+                                    MaterialTheme.typography.bodyMedium.copy(
+                                        fontWeight = FontWeight.SemiBold,
+                                        fontFeatureSettings = TABULAR_FIGURES,
+                                    ),
+                                )
+                                detail.note?.let {
+                                    Text(
+                                        text = " · $it",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+                Text(
+                    text = caution,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                shortfall?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = shortfall == null) {
+                Text(confirmLabel)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
+    )
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 640)
+@Composable
+private fun SpendConfirmDialogPreview() {
+    NodeSeekTheme {
+        SpendConfirmDialog(
+            title = "确认转账 2 星辰？",
+            details =
+            listOf(
+                SpendDetail("数额", "2 星辰"),
+                SpendDetail("收款人 UID", "28742", note = "demain"),
+                SpendDetail("Ref ID", "866042"),
+                SpendDetail("转账后余额", "4 → 2"),
+            ),
+            caution = "星辰转账一旦提交无法撤销，请确认收款人 UID 与 Ref ID 无误。",
+            confirmLabel = "确认转账",
+            onConfirm = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 640, name = "余额不足")
+@Composable
+private fun SpendConfirmDialogShortfallPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        SpendConfirmDialog(
+            title = "确认转账 7 星辰？",
+            details = listOf(SpendDetail("数额", "7 星辰"), SpendDetail("当前余额", "4")),
+            caution = "星辰转账一旦提交无法撤销。",
+            confirmLabel = "确认转账",
+            onConfirm = {},
+            onDismiss = {},
+            shortfall = "还差 3 星辰",
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/common/StatusViews.kt
+++ b/app/src/main/java/io/github/nsreader/ui/common/StatusViews.kt
@@ -177,6 +177,10 @@ fun LoadingState(modifier: Modifier = Modifier) {
  * Most NodeSeek failures are not really errors — they are a human step the app cannot take: solve
  * the Cloudflare challenge, or sign in. Those get the action as the *primary* button and the retry
  * as the quiet one, because retrying without doing the thing will fail again.
+ *
+ * Picking the recovery action per error lives here, not at call sites: [onSignIn] and [onVerify]
+ * exist so a screen never has to branch on the error itself — a hand-written
+ * `if (LoginRequired) …` at every call site is exactly the copy that goes stale.
  */
 @Composable
 fun NodeSeekErrorState(
@@ -186,6 +190,8 @@ fun NodeSeekErrorState(
     modifier: Modifier = Modifier,
     boardTitle: String? = null,
     onBrowseElsewhere: (() -> Unit)? = null,
+    onSignIn: (() -> Unit)? = null,
+    onVerify: (() -> Unit)? = null,
 ) {
     val scheme = MaterialTheme.colorScheme
     val extra = LocalNodeSeekExtraColors.current
@@ -201,7 +207,7 @@ fun NodeSeekErrorState(
                 title = stringResource(R.string.status_challenge_title),
                 description = stringResource(R.string.status_challenge_body),
                 footnote = stringResource(R.string.status_challenge_footnote),
-                primaryAction = StatusAction(stringResource(R.string.action_verify), onOpenBrowser),
+                primaryAction = StatusAction(stringResource(R.string.action_verify), onVerify ?: onOpenBrowser),
                 secondaryAction = retry,
                 modifier = modifier,
             )
@@ -219,7 +225,7 @@ fun NodeSeekErrorState(
                     stringResource(R.string.status_sign_in_title_board, boardTitle)
                 },
                 description = stringResource(R.string.status_sign_in_body),
-                primaryAction = StatusAction(stringResource(R.string.action_sign_in), onOpenBrowser),
+                primaryAction = StatusAction(stringResource(R.string.action_sign_in), onSignIn ?: onOpenBrowser),
                 secondaryAction =
                 onBrowseElsewhere?.let {
                     StatusAction(stringResource(R.string.status_sign_in_secondary), it)
@@ -268,6 +274,9 @@ fun NodeSeekErrorState(
                 StatusAction(stringResource(R.string.action_open_in_browser), onOpenBrowser),
                 modifier = modifier,
             )
+
+        // Nothing was requested, so "重试" would be a lie: the only move is the site's own page.
+        NodeSeekError.NotWired -> NotWiredState(onOpenBrowser = onOpenBrowser, modifier = modifier)
 
         NodeSeekError.Unknown ->
             StatusView(
@@ -374,6 +383,32 @@ fun SignedInState(
         title = stringResource(R.string.status_signed_in_title),
         description = stringResource(R.string.status_signed_in_body),
         secondaryAction = StatusAction(stringResource(R.string.action_sign_out), onSignOut),
+        modifier = modifier,
+    )
+}
+
+/**
+ * The site renders this page in the browser and exposes no endpoint we can read.
+ *
+ * Distinct from [ComingSoonState] on purpose: the screen exists and is designed, what is missing is
+ * the data. Saying "还在做" would blame the wrong half and hide the one action that works today —
+ * opening the same page in the web view, where the site's own JavaScript renders it.
+ */
+@Composable
+fun NotWiredState(
+    onOpenBrowser: () -> Unit,
+    modifier: Modifier = Modifier,
+    description: String? = null,
+) {
+    StatusView(
+        icon = Icons.Default.Info,
+        shape = StatusShapes.Empty,
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        iconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        title = stringResource(R.string.status_not_wired_title),
+        description = description ?: stringResource(R.string.status_not_wired_body),
+        primaryAction =
+        StatusAction(stringResource(R.string.action_open_in_browser), onOpenBrowser),
         modifier = modifier,
     )
 }

--- a/app/src/main/java/io/github/nsreader/ui/login/WebViewScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/login/WebViewScreen.kt
@@ -49,6 +49,15 @@ enum class WebViewGoal {
 
     /** Close once Cloudflare has issued a clearance cookie. */
     CHALLENGE,
+
+    /**
+     * Stays open until the user leaves it.
+     *
+     * For the authenticated pages the app deliberately does not reimplement — account settings, the
+     * stardust transfer layer, buying an invite code. There is no cookie to wait for: the user is done
+     * when they say so, and auto-closing mid-form would lose what they typed.
+     */
+    MANAGE,
 }
 
 /**
@@ -110,6 +119,8 @@ fun WebViewRoute(
                     state.hasClearance && state.fingerprint != baseline.fingerprint
                 }
             }
+
+            WebViewGoal.MANAGE -> null
         },
         modifier = modifier,
     )

--- a/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/notifications/NotificationsScreen.kt
@@ -132,12 +132,8 @@ fun NotificationsScreen(
                         NodeSeekErrorState(
                             error = state.error,
                             onRetry = onRetry,
-                            onOpenBrowser =
-                            if (state.error == io.github.nsreader.core.net.NodeSeekError.LoginRequired) {
-                                onSignIn
-                            } else {
-                                onVerify
-                            },
+                            onOpenBrowser = onVerify,
+                            onSignIn = onSignIn,
                         )
 
                     state.items.isEmpty() ->

--- a/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/postdetail/PostDetailScreen.kt
@@ -103,12 +103,15 @@ fun PostDetailRoute(
     onOpenBrowser: (String) -> Unit,
     onSignIn: () -> Unit,
     onVerify: (String) -> Unit,
-    onImageClick: (String) -> Unit,
+    onImageClick: (List<String>, String) -> Unit,
     modifier: Modifier = Modifier,
     initialFloor: String? = null,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val postUrl = viewModel.postUrl()
+    // Every image in the thread as currently loaded, so the viewer can page between them without
+    // going back to the data layer — the URLs were already parsed into the rendered content.
+    val images = remember(state.body, state.comments) { state.imageUrls() }
     PostDetailScreen(
         state = state,
         initialFloor = initialFloor,
@@ -117,7 +120,7 @@ fun PostDetailRoute(
         onOpenBrowser = onOpenBrowser,
         onSignIn = onSignIn,
         onVerify = { onVerify(postUrl) },
-        onImageClick = onImageClick,
+        onImageClick = { url -> onImageClick(images.ifEmpty { listOf(url) }, url) },
         onRetry = viewModel::refresh,
         onLoadMore = viewModel::loadNextPage,
         onLoadPage = viewModel::loadPage,
@@ -1194,6 +1197,28 @@ private fun PostDetailDarkPreview() {
         )
     }
 }
+
+/**
+ * Every block image in the thread, in reading order and without duplicates.
+ *
+ * Reading order is what makes the viewer's "2 / 4" mean anything: it has to match the order the images
+ * appear while scrolling, so a tap on the third screenshot opens page three. Inline stickers are left
+ * out — nobody opens a full-screen viewer for an emoji.
+ */
+internal fun PostDetailUiState.imageUrls(): List<String> =
+    (listOfNotNull(body) + comments)
+        .flatMap { content -> content.nodes.imageUrls() }
+        .distinct()
+
+private fun List<RichNode>.imageUrls(): List<String> =
+    flatMap { node ->
+        when (node) {
+            is RichNode.BlockImage -> listOf(node.url)
+            is RichNode.Quote -> node.children.imageUrls()
+            is RichNode.ListBlock -> node.items.flatMap { it.imageUrls() }
+            else -> emptyList()
+        }
+    }
 
 @Suppress("UnusedPrivateMember")
 @Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "Post detail · skeleton")

--- a/app/src/main/java/io/github/nsreader/ui/postlist/PostListScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/postlist/PostListScreen.kt
@@ -186,8 +186,8 @@ fun PostListScreen(
                             onRetry = posts::refresh,
                             // Both recoveries open a browser, but not the same page: a challenge is
                             // cleared on the list URL, a locked board on the sign-in page.
-                            onOpenBrowser =
-                            if (error == NodeSeekError.LoginRequired) onSignInClick else onRecoverInBrowser,
+                            onOpenBrowser = onRecoverInBrowser,
+                            onSignIn = onSignInClick,
                             boardTitle = state.selectedBoardTitle,
                             onBrowseElsewhere = { onBoardClick(null) }.takeIf { state.categorySlug != null },
                         )

--- a/app/src/main/java/io/github/nsreader/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/profile/ProfileScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nsreader.R
 import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.ui.common.GroupedColumn
+import io.github.nsreader.ui.common.GroupedRow
 import io.github.nsreader.ui.common.LoadingState
 import io.github.nsreader.ui.common.NodeSeekErrorState
 import io.github.nsreader.ui.common.NodeSeekIcons
@@ -57,7 +59,11 @@ fun ProfileRoute(
     onSignIn: () -> Unit,
     onSettings: () -> Unit,
     onOpenWebsite: () -> Unit,
-    onEditProfile: (Long) -> Unit,
+    onOpenSpace: (Long) -> Unit,
+    onAssets: () -> Unit,
+    onFollow: () -> Unit,
+    onTools: () -> Unit,
+    onAccountSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -68,7 +74,11 @@ fun ProfileRoute(
         onRetry = viewModel::refresh,
         onSettings = onSettings,
         onOpenWebsite = onOpenWebsite,
-        onEditProfile = { state.uid?.let(onEditProfile) },
+        onOpenSpace = { state.uid?.let(onOpenSpace) },
+        onAssets = onAssets,
+        onFollow = onFollow,
+        onTools = onTools,
+        onAccountSettings = onAccountSettings,
         modifier = modifier,
     )
 }
@@ -81,7 +91,11 @@ fun ProfileScreen(
     onRetry: () -> Unit,
     onSettings: () -> Unit,
     onOpenWebsite: () -> Unit,
-    onEditProfile: () -> Unit,
+    onOpenSpace: () -> Unit,
+    onAssets: () -> Unit,
+    onFollow: () -> Unit,
+    onTools: () -> Unit,
+    onAccountSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(modifier = modifier) { padding ->
@@ -99,8 +113,8 @@ fun ProfileScreen(
             NodeSeekErrorState(
                 error = state.error,
                 onRetry = onRetry,
-                onOpenBrowser =
-                if (state.error == NodeSeekError.LoginRequired) onSignIn else onOpenWebsite,
+                onOpenBrowser = onOpenWebsite,
+                onSignIn = onSignIn,
                 modifier = Modifier.padding(padding),
             )
             return@Scaffold
@@ -120,14 +134,14 @@ fun ProfileScreen(
             verticalArrangement = Arrangement.spacedBy(Spacing.lg),
         ) {
             item(key = "profile-header") {
-                ProfileHeader(state, onEditProfile)
+                ProfileHeader(state, onOpenSpace)
             }
             item(key = "resources") {
-                ResourceCards(state)
+                ResourceCards(state, onAssets)
             }
             item(key = "attendance") {
                 Button(
-                    onClick = onOpenWebsite,
+                    onClick = onAssets,
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(24.dp),
                 ) {
@@ -138,25 +152,16 @@ fun ProfileScreen(
                     )
                 }
             }
+            // The content menu now points at real screens. 主题帖 / 评论 / 收藏 are the space page's own
+            // tabs, so they open it on the right one rather than opening three near-identical screens.
             item(key = "content-menu") {
                 ProfileMenuGroup(
                     items =
                     listOf(
-                        ProfileMenuItem(
-                            R.string.profile_topics,
-                            Icons.Default.Home,
-                            onOpenWebsite,
-                        ),
-                        ProfileMenuItem(
-                            R.string.profile_comments,
-                            Icons.Default.Person,
-                            onOpenWebsite,
-                        ),
-                        ProfileMenuItem(
-                            R.string.profile_bookmarks,
-                            Icons.Default.Check,
-                            onOpenWebsite,
-                        ),
+                        ProfileMenuItem(R.string.profile_space, Icons.Default.Person, onOpenSpace),
+                        ProfileMenuItem(R.string.profile_follow, NodeSeekIcons.Group, onFollow),
+                        ProfileMenuItem(R.string.profile_assets, NodeSeekIcons.Wallet, onAssets),
+                        ProfileMenuItem(R.string.profile_tools, NodeSeekIcons.MenuBook, onTools),
                     ),
                 )
             }
@@ -164,6 +169,11 @@ fun ProfileScreen(
                 ProfileMenuGroup(
                     items =
                     listOf(
+                        ProfileMenuItem(
+                            R.string.profile_account_settings,
+                            Icons.Default.Person,
+                            onAccountSettings,
+                        ),
                         ProfileMenuItem(R.string.settings_title, Icons.Default.Settings, onSettings),
                         ProfileMenuItem(
                             R.string.profile_open_web,
@@ -185,7 +195,7 @@ fun ProfileScreen(
 @Composable
 private fun ProfileHeader(
     state: ProfileUiState,
-    onEditProfile: () -> Unit,
+    onOpenSpace: () -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -227,7 +237,7 @@ private fun ProfileHeader(
             )
         }
         IconButton(
-            onClick = onEditProfile,
+            onClick = onOpenSpace,
             modifier =
             Modifier
                 .size(48.dp)
@@ -236,7 +246,7 @@ private fun ProfileHeader(
         ) {
             Icon(
                 imageVector = NodeSeekIcons.Edit,
-                contentDescription = stringResource(R.string.profile_edit),
+                contentDescription = stringResource(R.string.profile_space),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(20.dp),
             )
@@ -245,7 +255,10 @@ private fun ProfileHeader(
 }
 
 @Composable
-private fun ResourceCards(state: ProfileUiState) {
+private fun ResourceCards(
+    state: ProfileUiState,
+    onAssets: () -> Unit,
+) {
     Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
         ResourceCard(
             value = state.chickenCount?.toString() ?: "—",
@@ -254,6 +267,7 @@ private fun ResourceCards(state: ProfileUiState) {
             shape = RoundedCornerShape(18.dp, 5.dp, 5.dp, 18.dp),
             color = MaterialTheme.colorScheme.tertiaryContainer,
             contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            onClick = onAssets,
         )
         ResourceCard(
             value = state.starCount?.toString() ?: "—",
@@ -262,6 +276,7 @@ private fun ResourceCards(state: ProfileUiState) {
             shape = RoundedCornerShape(5.dp),
             color = MaterialTheme.colorScheme.primaryContainer,
             contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            onClick = onAssets,
         )
         ResourceCard(
             value = state.streakDays?.toString() ?: "—",
@@ -270,6 +285,7 @@ private fun ResourceCards(state: ProfileUiState) {
             shape = RoundedCornerShape(5.dp, 18.dp, 18.dp, 5.dp),
             color = MaterialTheme.colorScheme.secondaryContainer,
             contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            onClick = onAssets,
         )
     }
 }
@@ -281,9 +297,15 @@ private fun ResourceCard(
     shape: RoundedCornerShape,
     color: androidx.compose.ui.graphics.Color,
     contentColor: androidx.compose.ui.graphics.Color,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(modifier = modifier, shape = shape, color = color, contentColor = contentColor) {
+    Surface(
+        modifier = modifier.clickable(onClick = onClick),
+        shape = shape,
+        color = color,
+        contentColor = contentColor,
+    ) {
         Column(Modifier.padding(horizontal = Spacing.lg, vertical = 14.dp)) {
             Text(value, style = MaterialTheme.typography.titleLarge)
             Text(label, style = MaterialTheme.typography.labelSmall)
@@ -297,37 +319,18 @@ private data class ProfileMenuItem(
     val onClick: () -> Unit,
 )
 
+/** Renders through the shared grouped-list components so 我的 matches the screens it links to. */
 @Composable
 private fun ProfileMenuGroup(items: List<ProfileMenuItem>) {
-    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+    GroupedColumn {
         items.forEachIndexed { index, item ->
-            val first = index == 0
-            val last = index == items.lastIndex
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainer,
-                shape =
-                RoundedCornerShape(
-                    topStart = if (first) 18.dp else 5.dp,
-                    topEnd = if (first) 18.dp else 5.dp,
-                    bottomEnd = if (last) 18.dp else 5.dp,
-                    bottomStart = if (last) 18.dp else 5.dp,
-                ),
-                modifier = Modifier.clickable(onClick = item.onClick),
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(Spacing.lg),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.md),
-                ) {
-                    Icon(item.icon, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant)
-                    Text(
-                        stringResource(item.title),
-                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
-                        modifier = Modifier.weight(1f),
-                    )
-                    Text("›", color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-            }
+            GroupedRow(
+                title = stringResource(item.title),
+                first = index == 0,
+                last = index == items.lastIndex,
+                icon = item.icon,
+                onClick = item.onClick,
+            )
         }
     }
 }
@@ -352,7 +355,11 @@ private fun ProfileSignedInPreview() {
             onRetry = {},
             onSettings = {},
             onOpenWebsite = {},
-            onEditProfile = {},
+            onOpenSpace = {},
+            onAssets = {},
+            onFollow = {},
+            onTools = {},
+            onAccountSettings = {},
         )
     }
 }
@@ -368,7 +375,11 @@ private fun ProfileSignedOutPreview() {
             onRetry = {},
             onSettings = {},
             onOpenWebsite = {},
-            onEditProfile = {},
+            onOpenSpace = {},
+            onAssets = {},
+            onFollow = {},
+            onTools = {},
+            onAccountSettings = {},
         )
     }
 }

--- a/app/src/main/java/io/github/nsreader/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/profile/ProfileViewModel.kt
@@ -65,7 +65,7 @@ class ProfileViewModel(
         loadJob =
             viewModelScope.launch {
                 _uiState.update { it.copy(isSignedIn = true, isLoading = true, error = null) }
-                runCatchingExceptCancellation { profileRepository.profile() }
+                runCatchingExceptCancellation { profileRepository.profile(refresh = true) }
                     .onSuccess { profile -> _uiState.value = profile.toUiState() }
                     .onFailure { throwable ->
                         _uiState.update {

--- a/app/src/main/java/io/github/nsreader/ui/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/search/SearchScreen.kt
@@ -91,9 +91,8 @@ fun SearchRoute(
         onPostClick = onPostClick,
         onUserClick = onUserClick,
         onRetry = viewModel::retry,
-        onOpenBrowser = { error ->
-            if (error == NodeSeekError.LoginRequired) onSignIn() else onVerify(viewModel.challengeUrl())
-        },
+        onSignIn = onSignIn,
+        onVerify = { onVerify(viewModel.challengeUrl()) },
         modifier = modifier,
     )
 }
@@ -111,7 +110,8 @@ fun SearchScreen(
     onPostClick: (Long) -> Unit,
     onUserClick: (Long) -> Unit,
     onRetry: () -> Unit,
-    onOpenBrowser: (NodeSeekError) -> Unit,
+    onSignIn: () -> Unit,
+    onVerify: () -> Unit,
     modifier: Modifier = Modifier,
     onBoardsChange: (Set<String>) -> Unit = {},
     onSortChange: (SearchSort) -> Unit = {},
@@ -222,7 +222,8 @@ fun SearchScreen(
                 onPostClick = onPostClick,
                 onUserClick = onUserClick,
                 onRetry = onRetry,
-                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                onVerify = onVerify,
             )
         }
     }
@@ -265,7 +266,8 @@ private fun SearchContent(
     onPostClick: (Long) -> Unit,
     onUserClick: (Long) -> Unit,
     onRetry: () -> Unit,
-    onOpenBrowser: (NodeSeekError) -> Unit,
+    onSignIn: () -> Unit,
+    onVerify: () -> Unit,
 ) {
     if (state.submittedQuery == null) {
         SearchHistory(
@@ -287,7 +289,9 @@ private fun SearchContent(
             NodeSeekErrorState(
                 error = loadState.error,
                 onRetry = onRetry,
-                onOpenBrowser = { onOpenBrowser(loadState.error) },
+                onOpenBrowser = onVerify,
+                onSignIn = onSignIn,
+                onVerify = onVerify,
             )
 
         SearchLoadState.Success -> {
@@ -538,7 +542,8 @@ private fun SearchPreview() {
             onPostClick = {},
             onUserClick = {},
             onRetry = {},
-            onOpenBrowser = {},
+            onSignIn = {},
+            onVerify = {},
         )
     }
 }

--- a/app/src/main/java/io/github/nsreader/ui/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/settings/AccountSettingsScreen.kt
@@ -1,0 +1,244 @@
+package io.github.nsreader.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.ui.common.GroupedColumn
+import io.github.nsreader.ui.common.GroupedRow
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.SectionLabel
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun AccountSettingsRoute(
+    viewModel: AccountSettingsViewModel,
+    onBack: () -> Unit,
+    onOpenSetting: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    AccountSettingsScreen(
+        state = state,
+        onBack = onBack,
+        onOpenSetting = onOpenSetting,
+        onSignOut = viewModel::signOut,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 账号设置 — the seven groups `/setting` has, in its order.
+ *
+ * Every row opens the site's own page at the matching hash instead of a native form. That is a decision,
+ * not a shortcut: these rows change a password, enrol two-factor, edit contact details and unblock
+ * people, and NodeSeek exposes no API for any of them. A native form would mean guessing at field names
+ * and submitting credential changes we cannot verify — the one place in this app where a wrong guess is
+ * worse than a web view.
+ *
+ * App-side display preferences stay in [SettingsScreen]; this screen never mixes the two, so "where do I
+ * change this" has one answer per setting.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccountSettingsScreen(
+    state: AccountSettingsUiState,
+    onBack: () -> Unit,
+    onOpenSetting: (String) -> Unit,
+    onSignOut: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.account_settings_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            SectionLabel(stringResource(R.string.account_group_profile))
+            GroupedColumn {
+                GroupedRow(
+                    title = stringResource(R.string.account_avatar),
+                    icon = Icons.Default.AccountCircle,
+                    first = true,
+                    onClick = { onOpenSetting(NodeSeekSite.SETTING_INTRODUCTION) },
+                    trailing = {
+                        UserAvatar(url = state.avatarUrl, name = state.name, size = 30.dp)
+                    },
+                )
+                GroupedRow(
+                    title = stringResource(R.string.account_bio),
+                    icon = Icons.Default.Person,
+                    value = state.bio,
+                    onClick = { onOpenSetting(NodeSeekSite.SETTING_INTRODUCTION) },
+                )
+                GroupedRow(
+                    title = stringResource(R.string.account_signature),
+                    icon = Icons.Default.Create,
+                    value = stringResource(R.string.account_signature_value),
+                    onClick = { onOpenSetting(NodeSeekSite.SETTING_INTRODUCTION) },
+                )
+                GroupedRow(
+                    title = stringResource(R.string.account_readme),
+                    icon = Icons.Default.List,
+                    value = state.readmeLength?.let { stringResource(R.string.account_readme_value, it) },
+                    last = true,
+                    onClick = { onOpenSetting(NodeSeekSite.SETTING_INTRODUCTION) },
+                )
+            }
+
+            SectionLabel(stringResource(R.string.account_group_security))
+            GroupedRow(
+                title = stringResource(R.string.account_password),
+                icon = Icons.Default.Lock,
+                first = true,
+                last = true,
+                onClick = { onOpenSetting(NodeSeekSite.SETTING_SECURITY) },
+            )
+
+            SectionLabel(stringResource(R.string.account_group_two_factor))
+            GroupedRow(
+                title = stringResource(R.string.account_two_factor),
+                icon = NodeSeekIcons.Shield,
+                first = true,
+                last = true,
+                onClick = { onOpenSetting(NodeSeekSite.SETTING_TWO_FACTOR) },
+            )
+
+            SectionLabel(stringResource(R.string.account_group_contact))
+            GroupedRow(
+                title = stringResource(R.string.account_email),
+                icon = Icons.Default.Email,
+                first = true,
+                last = true,
+                onClick = { onOpenSetting(NodeSeekSite.SETTING_CONTACT) },
+            )
+
+            SectionLabel(stringResource(R.string.account_group_block))
+            GroupedRow(
+                title = stringResource(R.string.account_block_list),
+                icon = NodeSeekIcons.Block,
+                first = true,
+                last = true,
+                onClick = { onOpenSetting(NodeSeekSite.SETTING_BLOCK) },
+            )
+
+            SectionLabel(stringResource(R.string.account_group_preference))
+            GroupedRow(
+                title = stringResource(R.string.account_preference),
+                icon = Icons.Default.Settings,
+                first = true,
+                last = true,
+                onClick = { onOpenSetting(NodeSeekSite.SETTING_PREFERENCE) },
+            )
+
+            SectionLabel(stringResource(R.string.account_group_homepage))
+            GroupedRow(
+                title = stringResource(R.string.account_homepage_boards),
+                icon = Icons.Default.Home,
+                first = true,
+                last = true,
+                onClick = { onOpenSetting(NodeSeekSite.SETTING_HOMEPAGE) },
+            )
+
+            Text(
+                text = stringResource(R.string.account_web_only),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = Spacing.xs, vertical = Spacing.sm),
+            )
+
+            GroupedRow(
+                title = stringResource(R.string.action_sign_out),
+                icon = Icons.AutoMirrored.Filled.ExitToApp,
+                iconTint = MaterialTheme.colorScheme.error,
+                titleColor = MaterialTheme.colorScheme.error,
+                first = true,
+                last = true,
+                onClick = onSignOut,
+                showChevron = false,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8g 账号设置")
+@Composable
+private fun AccountSettingsPreview() {
+    NodeSeekTheme {
+        AccountSettingsScreen(
+            state =
+            AccountSettingsUiState(
+                name = "花田错不错",
+                bio = "常驻杭州",
+                readmeLength = 238,
+            ),
+            onBack = {},
+            onOpenSetting = {},
+            onSignOut = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8g 账号设置 · dark")
+@Composable
+private fun AccountSettingsDarkPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        AccountSettingsScreen(
+            state = AccountSettingsUiState(name = "花田错不错"),
+            onBack = {},
+            onOpenSetting = {},
+            onSignOut = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/settings/AccountSettingsViewModel.kt
@@ -1,0 +1,82 @@
+package io.github.nsreader.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.PostRepository
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.session.SessionRepository
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * What the account-settings list can say about the account today.
+ *
+ * Only the four values the account endpoint publishes are here. Password state, 2FA enrolment, the
+ * email address and the block list all live on `/setting`, which renders client-side; their rows show
+ * no current value rather than a plausible one.
+ */
+data class AccountSettingsUiState(
+    val name: String = "",
+    val avatarUrl: String? = null,
+    val bio: String? = null,
+    val readmeLength: Int? = null,
+)
+
+class AccountSettingsViewModel(
+    private val profileRepository: ProfileRepository,
+    private val postRepository: PostRepository,
+    private val session: SessionRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(AccountSettingsUiState())
+    val uiState: StateFlow<AccountSettingsUiState> = _uiState.asStateFlow()
+
+    private var signOutJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            runCatchingExceptCancellation { profileRepository.profile() }
+                .onSuccess { profile ->
+                    _uiState.update {
+                        it.copy(
+                            name = profile.name,
+                            avatarUrl = profile.avatarUrl,
+                            bio = profile.bio,
+                            readmeLength = profile.readme?.length,
+                        )
+                    }
+                }
+        }
+    }
+
+    /** Same order as 我的: private content is dropped before the signed-out state is published. */
+    fun signOut() {
+        if (signOutJob?.isActive == true) return
+        signOutJob =
+            viewModelScope.launch {
+                postRepository.clearSessionData()
+                session.signOut()
+            }
+    }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    AccountSettingsViewModel(
+                        profileRepository = container.profileRepository,
+                        postRepository = container.postRepository,
+                        session = container.sessionRepository,
+                    )
+                }
+            }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/space/FollowScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/space/FollowScreen.kt
@@ -1,0 +1,306 @@
+package io.github.nsreader.ui.space
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.FollowUser
+import io.github.nsreader.ui.common.LoadingState
+import io.github.nsreader.ui.common.NodeSeekErrorState
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.StatusView
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.StatusShapes
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+
+@Composable
+fun FollowRoute(
+    viewModel: FollowViewModel,
+    onBack: () -> Unit,
+    onUserClick: (Long) -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    FollowScreen(
+        state = state,
+        onBack = onBack,
+        onTabSelected = viewModel::selectTab,
+        onUserClick = onUserClick,
+        onRetry = viewModel::retry,
+        onOpenBrowser = onOpenBrowser,
+        onSignIn = onSignIn,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FollowScreen(
+    state: FollowUiState,
+    onBack: () -> Unit,
+    onTabSelected: (FollowTab) -> Unit,
+    onUserClick: (Long) -> Unit,
+    onRetry: (FollowTab) -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val tabs = FollowTab.entries
+    val list = state.listFor(state.selectedTab)
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.follow_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(Modifier.padding(padding).fillMaxSize()) {
+            PrimaryTabRow(selectedTabIndex = tabs.indexOf(state.selectedTab)) {
+                tabs.forEach { tab ->
+                    Tab(
+                        selected = tab == state.selectedTab,
+                        onClick = { onTabSelected(tab) },
+                        text = {
+                            Text(
+                                stringResource(
+                                    when (tab) {
+                                        FollowTab.FOLLOWING -> R.string.follow_tab_following
+                                        FollowTab.FOLLOWERS -> R.string.follow_tab_followers
+                                    },
+                                ),
+                            )
+                        },
+                    )
+                }
+            }
+
+            when {
+                list.isLoading && list.items.isEmpty() -> LoadingState()
+
+                list.error != null && list.items.isEmpty() ->
+                    NodeSeekErrorState(
+                        error = list.error,
+                        onRetry = { onRetry(state.selectedTab) },
+                        onOpenBrowser = {
+                            onOpenBrowser(
+                                NodeSeekSite.BASE_URL +
+                                    NodeSeekSite.fansPath(state.selectedTab == FollowTab.FOLLOWERS),
+                            )
+                        },
+                        onSignIn = onSignIn,
+                    )
+
+                list.items.isEmpty() -> FollowEmptyState(state.selectedTab)
+
+                else ->
+                    LazyColumn(Modifier.fillMaxSize()) {
+                        items(count = list.items.size, key = { list.items[it].uid }) { index ->
+                            val user = list.items[index]
+                            FollowRow(user = user, onClick = { onUserClick(user.uid) })
+                        }
+                        item(key = "footer") {
+                            Text(
+                                text =
+                                stringResource(
+                                    when (state.selectedTab) {
+                                        FollowTab.FOLLOWING -> R.string.follow_end_following
+                                        FollowTab.FOLLOWERS -> R.string.follow_end_followers
+                                    },
+                                    list.items.size,
+                                ),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 22.dp),
+                            )
+                        }
+                    }
+            }
+        }
+    }
+}
+
+/**
+ * The empty state uses the site's own sentence — "暂时没有用户关注您" — and offers no button.
+ *
+ * There is nothing to press: you cannot make someone follow you, and every other empty state in this
+ * app has an action precisely because it has one to offer.
+ */
+@Composable
+private fun FollowEmptyState(tab: FollowTab) {
+    StatusView(
+        icon = NodeSeekIcons.Group,
+        shape = StatusShapes.Empty,
+        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        iconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        title =
+        stringResource(
+            when (tab) {
+                FollowTab.FOLLOWING -> R.string.follow_empty_following_title
+                FollowTab.FOLLOWERS -> R.string.follow_empty_followers_title
+            },
+        ),
+        description =
+        stringResource(
+            when (tab) {
+                FollowTab.FOLLOWING -> R.string.follow_empty_following_body
+                FollowTab.FOLLOWERS -> R.string.follow_empty_followers_body
+            },
+        ),
+    )
+}
+
+@Composable
+private fun FollowRow(
+    user: FollowUser,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = Spacing.lg, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        UserAvatar(url = user.avatarUrl, name = user.name, size = 44.dp)
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                text = user.name,
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = stringResource(R.string.space_uid, user.uid),
+                style = MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+private val previewFollowing =
+    listOf(
+        FollowUser(4471, "nssk", null),
+        FollowUser(302, "酒神", null),
+        FollowUser(18754, "demain", null),
+        FollowUser(27093, "羽落无声", null),
+        FollowUser(9856, "ifreedom", null),
+        FollowUser(33120, "jswcph", null),
+    )
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8c 我的关注")
+@Composable
+private fun FollowListPreview() {
+    NodeSeekTheme {
+        FollowScreen(
+            state =
+            FollowUiState(
+                selectedTab = FollowTab.FOLLOWING,
+                following = SpaceListState(items = previewFollowing, loaded = true),
+            ),
+            onBack = {},
+            onTabSelected = {},
+            onUserClick = {},
+            onRetry = {},
+            onOpenBrowser = {},
+            onSignIn = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8c 我的粉丝 · 空态")
+@Composable
+private fun FollowEmptyPreview() {
+    NodeSeekTheme {
+        FollowScreen(
+            state =
+            FollowUiState(
+                selectedTab = FollowTab.FOLLOWERS,
+                followers = SpaceListState(loaded = true),
+            ),
+            onBack = {},
+            onTabSelected = {},
+            onUserClick = {},
+            onRetry = {},
+            onOpenBrowser = {},
+            onSignIn = {},
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8c 接口待接入")
+@Composable
+private fun FollowNotWiredPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        FollowScreen(
+            state =
+            FollowUiState(
+                followers = SpaceListState(),
+                following = SpaceListState(error = NodeSeekError.NotWired),
+            ),
+            onBack = {},
+            onTabSelected = {},
+            onUserClick = {},
+            onRetry = {},
+            onOpenBrowser = {},
+            onSignIn = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/space/FollowViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/space/FollowViewModel.kt
@@ -1,0 +1,104 @@
+package io.github.nsreader.ui.space
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.FollowRepository
+import io.github.nsreader.data.FollowUser
+import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+enum class FollowTab {
+    FOLLOWING,
+    FOLLOWERS,
+}
+
+data class FollowUiState(
+    val selectedTab: FollowTab = FollowTab.FOLLOWING,
+    val following: SpaceListState<FollowUser> = SpaceListState(),
+    val followers: SpaceListState<FollowUser> = SpaceListState(),
+) {
+    fun listFor(tab: FollowTab): SpaceListState<FollowUser> =
+        when (tab) {
+            FollowTab.FOLLOWING -> following
+            FollowTab.FOLLOWERS -> followers
+        }
+}
+
+/**
+ * 我的关注 / 我的粉丝 — the signed-in user's, and only theirs.
+ *
+ * Both tabs are lists of accounts and nothing else: no follow button, no 互关 badge, no counts. The
+ * site has the two lists but exposes no action to change them, so a button here would be a control
+ * that cannot work.
+ */
+class FollowViewModel(
+    private val repository: FollowRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(FollowUiState())
+    val uiState: StateFlow<FollowUiState> = _uiState.asStateFlow()
+
+    private val jobs = mutableMapOf<FollowTab, Job>()
+
+    init {
+        load(FollowTab.FOLLOWING)
+    }
+
+    fun selectTab(tab: FollowTab) {
+        _uiState.update { it.copy(selectedTab = tab) }
+        val list = _uiState.value.listFor(tab)
+        if (!list.loaded && !list.isLoading) load(tab)
+    }
+
+    fun retry(tab: FollowTab) = load(tab)
+
+    private fun load(tab: FollowTab) {
+        jobs[tab]?.cancel()
+        jobs[tab] =
+            viewModelScope.launch {
+                _uiState.update { it.write(tab, it.listFor(tab).copy(isLoading = true, error = null)) }
+                runCatchingExceptCancellation {
+                    when (tab) {
+                        FollowTab.FOLLOWING -> repository.following()
+                        FollowTab.FOLLOWERS -> repository.followers()
+                    }
+                }.onSuccess { users ->
+                    _uiState.update {
+                        it.write(
+                            tab,
+                            SpaceListState(items = users, page = 1, hasNextPage = false, loaded = true),
+                        )
+                    }
+                }.onFailure { throwable ->
+                    _uiState.update {
+                        it.write(
+                            tab,
+                            it.listFor(tab).copy(isLoading = false, error = throwable.toNodeSeekError()),
+                        )
+                    }
+                }
+            }
+    }
+
+    private fun FollowUiState.write(tab: FollowTab, list: SpaceListState<FollowUser>): FollowUiState =
+        when (tab) {
+            FollowTab.FOLLOWING -> copy(following = list)
+            FollowTab.FOLLOWERS -> copy(followers = list)
+        }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { FollowViewModel(container.followRepository) }
+            }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/space/UserSpaceScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/space/UserSpaceScreen.kt
@@ -1,0 +1,744 @@
+package io.github.nsreader.ui.space
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.SpaceComment
+import io.github.nsreader.data.SpacePost
+import io.github.nsreader.ui.common.BoardTag
+import io.github.nsreader.ui.common.LoadingState
+import io.github.nsreader.ui.common.NodeSeekErrorState
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.UserAvatar
+import io.github.nsreader.ui.composer.parseMarkdown
+import io.github.nsreader.ui.richtext.RichContent
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun UserSpaceRoute(
+    viewModel: UserSpaceViewModel,
+    onBack: () -> Unit,
+    onPostClick: (Long, String?) -> Unit,
+    onMessage: (Long) -> Unit,
+    onEditProfile: () -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    UserSpaceScreen(
+        state = state,
+        onBack = onBack,
+        onTabSelected = viewModel::selectTab,
+        onPostClick = onPostClick,
+        onLoadMore = viewModel::loadMore,
+        onRetryTab = viewModel::retryTab,
+        onRetryProfile = viewModel::refreshProfile,
+        onMessage = { onMessage(state.uid) },
+        onEditProfile = onEditProfile,
+        onOpenBrowser = onOpenBrowser,
+        onSignIn = onSignIn,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UserSpaceScreen(
+    state: UserSpaceUiState,
+    onBack: () -> Unit,
+    onTabSelected: (SpaceTab) -> Unit,
+    onPostClick: (Long, String?) -> Unit,
+    onLoadMore: (SpaceTab) -> Unit,
+    onRetryTab: (SpaceTab) -> Unit,
+    onRetryProfile: () -> Unit,
+    onMessage: () -> Unit,
+    onEditProfile: () -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spaceUrl = NodeSeekSite.BASE_URL + NodeSeekSite.spacePath(state.uid)
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                actions = {
+                    if (state.isSelf) {
+                        IconButton(onClick = onEditProfile) {
+                            Icon(
+                                NodeSeekIcons.Edit,
+                                contentDescription = stringResource(R.string.profile_edit),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+                    SpaceOverflowMenu(onOpenBrowser = { onOpenBrowser(spaceUrl) })
+                },
+            )
+        },
+    ) { padding ->
+        if (state.isLoadingProfile && !state.hasProfile) {
+            LoadingState(Modifier.padding(padding))
+            return@Scaffold
+        }
+        if (state.error != null && !state.hasProfile) {
+            NodeSeekErrorState(
+                error = state.error,
+                onRetry = onRetryProfile,
+                onOpenBrowser = { onOpenBrowser(spaceUrl) },
+                onSignIn = onSignIn,
+                modifier = Modifier.padding(padding),
+            )
+            return@Scaffold
+        }
+
+        Column(
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth(),
+        ) {
+            SpaceHeader(state = state, onMessage = onMessage)
+            SpaceStatsRow(state)
+            PrimaryTabRow(selectedTabIndex = state.tabs.indexOf(state.selectedTab).coerceAtLeast(0)) {
+                state.tabs.forEach { tab ->
+                    Tab(
+                        selected = tab == state.selectedTab,
+                        onClick = { onTabSelected(tab) },
+                        text = { Text(stringResource(tab.labelRes())) },
+                    )
+                }
+            }
+            SpaceTabContent(
+                state = state,
+                onPostClick = onPostClick,
+                onLoadMore = onLoadMore,
+                onRetryTab = onRetryTab,
+                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpaceOverflowMenu(onOpenBrowser: () -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { open = true }) {
+            Icon(
+                NodeSeekIcons.OpenInNew,
+                contentDescription = stringResource(R.string.action_more),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.action_open_in_browser)) },
+                onClick = {
+                    open = false
+                    onOpenBrowser()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpaceHeader(
+    state: UserSpaceUiState,
+    onMessage: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.padding(start = Spacing.xl, end = Spacing.xl, bottom = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            UserAvatar(url = state.avatarUrl, name = state.name, size = 60.dp)
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = state.name,
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    state.level?.let { level ->
+                        Surface(
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            shape = RoundedCornerShape(7.dp),
+                            modifier = Modifier.padding(start = 6.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.assets_level, level),
+                                style =
+                                MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 1.dp),
+                            )
+                        }
+                    }
+                }
+                Text(
+                    text =
+                    state.bio
+                        ?.let { stringResource(R.string.space_uid_bio, state.uid, it) }
+                        ?: stringResource(R.string.space_uid, state.uid),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        // The site's only action on someone else's space. There is no follow button to add: the
+        // relationship endpoints exist but nothing on the site exposes them.
+        if (!state.isSelf) {
+            OutlinedButton(
+                onClick = onMessage,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp),
+            ) {
+                Icon(Icons.Default.Email, contentDescription = null, modifier = Modifier.size(19.dp))
+                Text(
+                    stringResource(R.string.space_message),
+                    modifier = Modifier.padding(start = 6.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The five statistics the site actually publishes for an account.
+ *
+ * Not four, not seven: 加入天数 / 等级 / 鸡腿 / 主题帖 / 评论. Follower and like counts were on an
+ * earlier draft of this screen and do not exist anywhere on NodeSeek, so a placeholder for them would
+ * have been a number we invented.
+ */
+@Composable
+private fun SpaceStatsRow(state: UserSpaceUiState) {
+    Row(Modifier.padding(horizontal = 10.dp)) {
+        SpaceStat(state.joinedDays?.toString(), stringResource(R.string.space_stat_joined_days))
+        SpaceStat(
+            state.level?.let { stringResource(R.string.assets_level, it) },
+            stringResource(R.string.space_stat_level),
+        )
+        SpaceStat(state.chickenCount?.formatted(), stringResource(R.string.space_stat_chicken))
+        SpaceStat(state.topicCount?.formatted(), stringResource(R.string.space_stat_topics))
+        SpaceStat(state.commentCount?.formatted(), stringResource(R.string.space_stat_comments))
+    }
+}
+
+@Composable
+private fun RowScope.SpaceStat(
+    value: String?,
+    label: String,
+) {
+    Column(
+        modifier = Modifier
+            .weight(1f)
+            .padding(bottom = 14.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = value ?: UNKNOWN_VALUE,
+            style =
+            MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.ExtraBold,
+                fontFeatureSettings = TABULAR_FIGURES,
+            ),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private const val UNKNOWN_VALUE = "—"
+
+private fun Int.formatted(): String = if (this >= 1_000) "%,d".format(this) else toString()
+
+@Composable
+private fun SpaceTabContent(
+    state: UserSpaceUiState,
+    onPostClick: (Long, String?) -> Unit,
+    onLoadMore: (SpaceTab) -> Unit,
+    onRetryTab: (SpaceTab) -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (state.selectedTab) {
+        SpaceTab.GENERAL -> GeneralTab(state, onOpenBrowser, modifier)
+
+        SpaceTab.TOPICS ->
+            SpaceListTab(
+                list = state.topics,
+                tab = SpaceTab.TOPICS,
+                emptyText = stringResource(R.string.space_empty_topics),
+                endTextRes = R.string.space_end_topics,
+                onLoadMore = onLoadMore,
+                onRetryTab = onRetryTab,
+                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                key = { _, post -> post.postId },
+                modifier = modifier,
+            ) { post ->
+                SpacePostRow(post = post, onClick = { onPostClick(post.postId, null) })
+            }
+
+        SpaceTab.COMMENTS ->
+            SpaceListTab(
+                list = state.comments,
+                tab = SpaceTab.COMMENTS,
+                emptyText = stringResource(R.string.space_empty_comments),
+                endTextRes = R.string.space_end_comments,
+                onLoadMore = onLoadMore,
+                onRetryTab = onRetryTab,
+                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                // The payload's own id when it has one; the position only for the rare row without.
+                key = { index, comment -> comment.commentId ?: "comment-$index" },
+                modifier = modifier,
+            ) { comment ->
+                // The floor rides along so the thread opens at this very comment.
+                SpaceCommentRow(
+                    comment = comment,
+                    onClick = { onPostClick(comment.postId, comment.floor) },
+                )
+            }
+
+        SpaceTab.COLLECTIONS ->
+            SpaceListTab(
+                list = state.collections,
+                tab = SpaceTab.COLLECTIONS,
+                emptyText = stringResource(R.string.space_empty_collections),
+                endTextRes = R.string.space_end_collections,
+                onLoadMore = onLoadMore,
+                onRetryTab = onRetryTab,
+                onOpenBrowser = onOpenBrowser,
+                onSignIn = onSignIn,
+                key = { _, post -> post.postId },
+                modifier = modifier,
+            ) { post ->
+                SpacePostRow(post = post, onClick = { onPostClick(post.postId, null) })
+            }
+    }
+}
+
+/** 概况: one sentence of Bio, then the Readme the user wrote in Markdown. */
+@Composable
+private fun GeneralTab(
+    state: UserSpaceUiState,
+    onOpenBrowser: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var readmeExpanded by rememberSaveable(state.uid) { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = Spacing.lg, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        state.bio?.let { bio ->
+            SpaceCard(title = stringResource(R.string.space_bio)) {
+                Text(bio, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        SpaceCard(title = stringResource(R.string.space_readme)) {
+            val readme = state.readme?.takeIf { it.isNotBlank() }
+            if (readme == null) {
+                // The site's own empty state, emoji included. Writing our own would have been a
+                // worse sentence and a less familiar one.
+                Text(
+                    stringResource(R.string.space_readme_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                val nodes = remember(readme, readmeExpanded) {
+                    val markdown =
+                        if (readmeExpanded) readme else readme.lines().take(README_COLLAPSED_LINES).joinToString("\n")
+                    parseMarkdown(markdown)
+                }
+                RichContent(
+                    nodes = nodes,
+                    onLinkClick = onOpenBrowser,
+                    onImageClick = onOpenBrowser,
+                    textStyle = MaterialTheme.typography.bodyMedium,
+                )
+                if (readme.lines().size > README_COLLAPSED_LINES) {
+                    TextButton(onClick = { readmeExpanded = !readmeExpanded }) {
+                        Text(
+                            stringResource(
+                                if (readmeExpanded) {
+                                    R.string.space_readme_collapse
+                                } else {
+                                    R.string.space_readme_expand
+                                },
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private const val README_COLLAPSED_LINES = 8
+
+@Composable
+private fun SpaceCard(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(18.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = Spacing.lg, vertical = 14.dp),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            content()
+        }
+    }
+}
+
+/**
+ * The list tabs, which differ only in their row and their end-of-list sentence.
+ *
+ * Paging is by "load more" rather than by Paging 3: these lists are short (five topics, ninety-six
+ * comments) and the endpoints are page-numbered XHRs, so a RemoteMediator would add a Room table and a
+ * cache-invalidation question to save nothing.
+ */
+@Composable
+private fun <T> SpaceListTab(
+    list: SpaceListState<T>,
+    tab: SpaceTab,
+    emptyText: String,
+    endTextRes: Int,
+    onLoadMore: (SpaceTab) -> Unit,
+    onRetryTab: (SpaceTab) -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    /** Stable row identity, so a page-1 replace recomposes only the rows that actually changed. */
+    key: (index: Int, item: T) -> Any,
+    modifier: Modifier = Modifier,
+    row: @Composable (T) -> Unit,
+) {
+    if (list.items.isEmpty()) {
+        when {
+            list.isLoading -> LoadingState(modifier)
+
+            list.error != null ->
+                NodeSeekErrorState(
+                    error = list.error,
+                    onRetry = { onRetryTab(tab) },
+                    onOpenBrowser = { onOpenBrowser(NodeSeekSite.BASE_URL) },
+                    onSignIn = onSignIn,
+                    modifier = modifier,
+                )
+
+            else ->
+                Box(modifier, contentAlignment = Alignment.Center) {
+                    Text(
+                        emptyText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = 72.dp),
+                    )
+                }
+        }
+        return
+    }
+
+    LazyColumn(modifier) {
+        items(count = list.items.size, key = { key(it, list.items[it]) }) { index ->
+            row(list.items[index])
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        }
+        listFooter(list = list, tab = tab, endTextRes = endTextRes, onLoadMore = onLoadMore)
+    }
+}
+
+private fun <T> LazyListScope.listFooter(
+    list: SpaceListState<T>,
+    tab: SpaceTab,
+    endTextRes: Int,
+    onLoadMore: (SpaceTab) -> Unit,
+) {
+    item(key = "footer") {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 22.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            when {
+                list.isLoading -> CircularProgressIndicator(Modifier.size(22.dp))
+
+                list.hasNextPage ->
+                    TextButton(onClick = { onLoadMore(tab) }) {
+                        Text(stringResource(R.string.space_load_more))
+                    }
+
+                else ->
+                    Text(
+                        text = stringResource(endTextRes, list.items.size),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpacePostRow(
+    post: SpacePost,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = Spacing.lg, vertical = 11.dp),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Text(
+            text = post.title,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            post.categoryTitle?.let { BoardTag(title = it, slug = post.categorySlug) }
+            post.authorName?.let { RowMeta(it) }
+            post.commentCount?.let { RowMeta(stringResource(R.string.post_reply_count, it)) }
+            post.viewCount?.let { RowMeta(stringResource(R.string.post_view_count, it)) }
+            post.createdAtText?.let { RowMeta(it) }
+        }
+    }
+}
+
+@Composable
+private fun SpaceCommentRow(
+    comment: SpaceComment,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = Spacing.lg, vertical = 11.dp),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Text(
+            text = comment.excerpt,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+            comment.postTitle?.let {
+                RowMeta(stringResource(R.string.space_comment_in, it), weighted = true)
+            }
+            comment.createdAtText?.let { RowMeta(it) }
+        }
+    }
+}
+
+@Composable
+private fun RowMeta(
+    text: String,
+    weighted: Boolean = false,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall.copy(fontFeatureSettings = TABULAR_FIGURES),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = if (weighted) Modifier.fillMaxWidth(0.7f) else Modifier,
+    )
+}
+
+private fun SpaceTab.labelRes(): Int =
+    when (this) {
+        SpaceTab.GENERAL -> R.string.space_tab_general
+        SpaceTab.TOPICS -> R.string.space_tab_topics
+        SpaceTab.COMMENTS -> R.string.space_tab_comments
+        SpaceTab.COLLECTIONS -> R.string.space_tab_collections
+    }
+
+// -------------------------------------------------------------------------------------------------
+
+private val previewTopics =
+    listOf(
+        SpacePost(1, "第一次用 nftables 做端口转发，记录一下踩的坑", "技术", "tech", null, 12, 843, "3天前"),
+        SpacePost(2, "签到鸡腿是随机的吗？连续七天都是 6 个", "日常", "daily", null, 18, 976, "上周"),
+        SpacePost(3, "求推荐一台香港小鸡，跑 uptime 监控用", "日常", "daily", null, 21, 1024, "6月11日"),
+        SpacePost(4, "【出】甲骨文 ARM 一台求接手", "交易", "trade", null, 6, 412, "5月2日"),
+        SpacePost(5, "Debian 12 升 13 之后 ss 命令输出格式变了？", "技术", "tech", null, 9, 655, "4月20日"),
+    )
+
+private val previewSelfState =
+    UserSpaceUiState(
+        uid = 12043,
+        isSelf = true,
+        isLoadingProfile = false,
+        name = "花田错不错",
+        level = 1,
+        bio = "用一句话介绍自己",
+        joinedDays = 143,
+        chickenCount = 344,
+        topicCount = 5,
+        commentCount = 96,
+        selectedTab = SpaceTab.TOPICS,
+        topics = SpaceListState(items = previewTopics, loaded = true),
+    )
+
+private val previewPublicState =
+    UserSpaceUiState(
+        uid = 4471,
+        isSelf = false,
+        isLoadingProfile = false,
+        name = "nssk",
+        level = 4,
+        bio = "写点脚本，养几只小鸡。",
+        readme =
+        """
+        ## 关于我
+        常年折腾 Debian 与低延迟线路，偶尔写测评。
+
+        - 交易只走论坛担保，不接私下转账
+        - 博客：[blog.nssk.dev](https://blog.nssk.dev)
+        - 探针：[ping.nssk.dev](https://ping.nssk.dev)
+        """.trimIndent(),
+        joinedDays = 745,
+        chickenCount = 2041,
+        topicCount = 128,
+        commentCount = 1904,
+        selectedTab = SpaceTab.GENERAL,
+    )
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8a 我的主页 · 主题帖")
+@Composable
+private fun UserSpaceSelfPreview() {
+    NodeSeekTheme { PreviewScreen(previewSelfState) }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8b 公开用户页 · 概况")
+@Composable
+private fun UserSpacePublicPreview() {
+    NodeSeekTheme { PreviewScreen(previewPublicState) }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8a 我的主页 · dark")
+@Composable
+private fun UserSpaceSelfDarkPreview() {
+    NodeSeekTheme(darkTheme = true) { PreviewScreen(previewSelfState) }
+}
+
+@Composable
+private fun PreviewScreen(state: UserSpaceUiState) {
+    UserSpaceScreen(
+        state = state,
+        onBack = {},
+        onTabSelected = {},
+        onPostClick = { _, _ -> },
+        onLoadMore = {},
+        onRetryTab = {},
+        onRetryProfile = {},
+        onMessage = {},
+        onEditProfile = {},
+        onOpenBrowser = {},
+        onSignIn = {},
+    )
+}

--- a/app/src/main/java/io/github/nsreader/ui/space/UserSpaceViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/space/UserSpaceViewModel.kt
@@ -1,0 +1,273 @@
+package io.github.nsreader.ui.space
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.AppClock
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.data.SpaceComment
+import io.github.nsreader.data.SpacePage
+import io.github.nsreader.data.SpacePost
+import io.github.nsreader.data.UserProfile
+import io.github.nsreader.data.UserSpaceRepository
+import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+enum class SpaceTab {
+    GENERAL,
+    TOPICS,
+    COMMENTS,
+    COLLECTIONS,
+}
+
+/**
+ * One tab's list.
+ *
+ * [loaded] is not `items.isNotEmpty()`: an account with no topics has loaded successfully and must not
+ * be re-fetched every time the tab is selected, which is exactly the loop that flag prevents.
+ */
+data class SpaceListState<T>(
+    val items: List<T> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: NodeSeekError? = null,
+    val page: Int = 0,
+    val hasNextPage: Boolean = false,
+    val loaded: Boolean = false,
+)
+
+data class UserSpaceUiState(
+    val uid: Long,
+    val isSelf: Boolean,
+    val isLoadingProfile: Boolean = true,
+    val error: NodeSeekError? = null,
+    val name: String = "",
+    val avatarUrl: String? = null,
+    val level: Int? = null,
+    val bio: String? = null,
+    val readme: String? = null,
+    val joinedDays: Int? = null,
+    val chickenCount: Int? = null,
+    val topicCount: Int? = null,
+    val commentCount: Int? = null,
+    val selectedTab: SpaceTab = SpaceTab.GENERAL,
+    val topics: SpaceListState<SpacePost> = SpaceListState(),
+    val comments: SpaceListState<SpaceComment> = SpaceListState(),
+    val collections: SpaceListState<SpacePost> = SpaceListState(),
+) {
+    /** Others have no 收藏 tab: the site publishes nobody else's collections. */
+    val tabs: List<SpaceTab>
+        get() =
+            if (isSelf) {
+                listOf(SpaceTab.GENERAL, SpaceTab.TOPICS, SpaceTab.COMMENTS, SpaceTab.COLLECTIONS)
+            } else {
+                listOf(SpaceTab.GENERAL, SpaceTab.TOPICS, SpaceTab.COMMENTS)
+            }
+
+    val hasProfile: Boolean get() = name.isNotBlank()
+
+    /** `null` for 概况, which has no list of its own. */
+    fun listFor(tab: SpaceTab): SpaceListState<*>? =
+        when (tab) {
+            SpaceTab.GENERAL -> null
+            SpaceTab.TOPICS -> topics
+            SpaceTab.COMMENTS -> comments
+            SpaceTab.COLLECTIONS -> collections
+        }
+}
+
+/**
+ * State holder for a user's space, ours or anyone's.
+ *
+ * The header and each tab load independently. That is deliberate: the profile call decides whether the
+ * screen can be drawn at all, while a tab failing — or being a page the site only renders client-side —
+ * has to stay contained inside that tab instead of blanking the header the user came to read.
+ */
+class UserSpaceViewModel(
+    private val uid: Long,
+    isSelf: Boolean,
+    private val profileRepository: ProfileRepository,
+    private val spaceRepository: UserSpaceRepository,
+    private val clock: AppClock,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(UserSpaceUiState(uid = uid, isSelf = isSelf))
+    val uiState: StateFlow<UserSpaceUiState> = _uiState.asStateFlow()
+
+    private var profileJob: Job? = null
+    private val tabJobs = mutableMapOf<SpaceTab, Job>()
+
+    init {
+        refreshProfile()
+        // Your own space opens on 主题帖 — you know who you are; a stranger's opens on 概况, which is
+        // the reason to be there. Either way the first tab starts loading immediately.
+        selectTab(if (isSelf) SpaceTab.TOPICS else SpaceTab.GENERAL)
+    }
+
+    fun refreshProfile() {
+        profileJob?.cancel()
+        profileJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoadingProfile = true, error = null) }
+                runCatchingExceptCancellation { profileRepository.profile(uid) }
+                    .onSuccess { profile -> _uiState.update { it.withProfile(profile) } }
+                    .onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(isLoadingProfile = false, error = throwable.toNodeSeekError())
+                        }
+                    }
+            }
+    }
+
+    fun selectTab(tab: SpaceTab) {
+        _uiState.update { it.copy(selectedTab = tab) }
+        val list = _uiState.value.listFor(tab) ?: return
+        if (!list.loaded && !list.isLoading) load(tab, page = 1)
+    }
+
+    fun loadMore(tab: SpaceTab) {
+        val list = _uiState.value.listFor(tab) ?: return
+        if (list.isLoading || !list.hasNextPage) return
+        load(tab, page = list.page + 1)
+    }
+
+    fun retryTab(tab: SpaceTab) = load(tab, page = 1)
+
+    private fun load(tab: SpaceTab, page: Int) {
+        tabJobs[tab]?.cancel()
+        tabJobs[tab] =
+            viewModelScope.launch {
+                when (tab) {
+                    SpaceTab.GENERAL -> Unit
+
+                    SpaceTab.TOPICS ->
+                        loadInto(
+                            page = page,
+                            read = { topics },
+                            write = { copy(topics = it) },
+                            fetch = { spaceRepository.topics(uid, page) },
+                        )
+
+                    SpaceTab.COMMENTS ->
+                        loadInto(
+                            page = page,
+                            read = { comments },
+                            write = { copy(comments = it) },
+                            fetch = { spaceRepository.comments(uid, page) },
+                        )
+
+                    SpaceTab.COLLECTIONS ->
+                        loadInto(
+                            page = page,
+                            read = { collections },
+                            write = { copy(collections = it) },
+                            fetch = { spaceRepository.collections(page) },
+                        )
+                }
+            }
+    }
+
+    /**
+     * The one load routine, given a lens onto whichever list is being filled.
+     *
+     * Passing the accessors rather than switching on the tab inside is what keeps the item type real:
+     * casting a shared list field to make one function fit three types is how a comment ends up in the
+     * topics tab after a refactor.
+     */
+    private suspend fun <T> loadInto(
+        page: Int,
+        read: UserSpaceUiState.() -> SpaceListState<T>,
+        write: UserSpaceUiState.(SpaceListState<T>) -> UserSpaceUiState,
+        fetch: suspend () -> SpacePage<T>,
+    ) {
+        _uiState.update { it.write(it.read().copy(isLoading = true, error = null)) }
+        runCatchingExceptCancellation { fetch() }
+            .onSuccess { result ->
+                _uiState.update { state ->
+                    val current = state.read()
+                    state.write(
+                        current.copy(
+                            // Page 1 replaces rather than appends, so a retry cannot double every row.
+                            items = if (page == 1) result.items else current.items + result.items,
+                            isLoading = false,
+                            error = null,
+                            page = page,
+                            hasNextPage = result.hasNextPage,
+                            loaded = true,
+                        ),
+                    )
+                }
+            }.onFailure { throwable ->
+                _uiState.update { state ->
+                    state.write(
+                        state.read().copy(isLoading = false, error = throwable.toNodeSeekError()),
+                    )
+                }
+            }
+    }
+
+    private fun UserSpaceUiState.withProfile(profile: UserProfile): UserSpaceUiState =
+        copy(
+            isLoadingProfile = false,
+            error = null,
+            name = profile.name,
+            avatarUrl = profile.avatarUrl,
+            level = profile.rank,
+            bio = profile.bio,
+            readme = profile.readme,
+            joinedDays = joinedDays(profile.createdAt, clock.nowMillis()),
+            chickenCount = profile.chickenCount,
+            topicCount = profile.topicCount,
+            commentCount = profile.commentCount,
+        )
+
+    companion object {
+        fun factory(
+            container: AppContainer,
+            uid: Long,
+            isSelf: Boolean,
+        ): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    UserSpaceViewModel(
+                        uid = uid,
+                        isSelf = isSelf,
+                        profileRepository = container.profileRepository,
+                        spaceRepository = container.userSpaceRepository,
+                        clock = container.clock,
+                    )
+                }
+            }
+    }
+}
+
+/**
+ * Days since registration, which is the site's own headline statistic for an account.
+ *
+ * `created_at` is an ISO instant on some accounts and a plain date on others, so only the date part is
+ * read. An unparseable value yields null and the stat renders as "—" rather than as a wrong number.
+ */
+internal fun joinedDays(createdAt: String?, nowMillis: Long): Int? {
+    val datePart = createdAt?.take(10)?.takeIf { it.length == 10 } ?: return null
+    val joined =
+        try {
+            LocalDate.parse(datePart)
+        } catch (_: DateTimeParseException) {
+            return null
+        }
+    val today = Instant.ofEpochMilli(nowMillis).atZone(ZoneId.systemDefault()).toLocalDate()
+    return ChronoUnit.DAYS.between(joined, today).toInt().coerceAtLeast(0)
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/AwardScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/AwardScreen.kt
@@ -1,0 +1,235 @@
+package io.github.nsreader.ui.tools
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.FeedPost
+import io.github.nsreader.model.PostSummary
+import io.github.nsreader.ui.common.LoadingState
+import io.github.nsreader.ui.common.NodeSeekErrorState
+import io.github.nsreader.ui.common.NumericPager
+import io.github.nsreader.ui.postlist.PostRow
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun AwardRoute(
+    viewModel: AwardViewModel,
+    onBack: () -> Unit,
+    onPostClick: (Long) -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    AwardScreen(
+        state = state,
+        onBack = onBack,
+        onPostClick = onPostClick,
+        onPageSelected = viewModel::load,
+        onRetry = viewModel::retry,
+        onOpenBrowser = { onOpenBrowser(NodeSeekSite.BASE_URL + NodeSeekSite.awardPath(state.page)) },
+        onSignIn = onSignIn,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 推荐阅读.
+ *
+ * The row is the home feed's row, imported rather than reimplemented: this is the same kind of list, and
+ * a second implementation would drift — read state, pinned tint, the meta line's order.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AwardScreen(
+    state: AwardUiState,
+    onBack: () -> Unit,
+    onPostClick: (Long) -> Unit,
+    onPageSelected: (Int) -> Unit,
+    onRetry: () -> Unit,
+    onOpenBrowser: () -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+    // A new page starts at its top: keeping the old offset would drop the reader into the middle of
+    // content they have not seen.
+    LaunchedEffect(state.page) { listState.scrollToItem(0) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.award_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth(),
+        ) {
+            when {
+                state.isLoading && state.posts.isEmpty() -> LoadingState(Modifier.fillMaxSize())
+
+                state.error != null && state.posts.isEmpty() ->
+                    NodeSeekErrorState(
+                        error = state.error,
+                        onRetry = onRetry,
+                        onOpenBrowser = onOpenBrowser,
+                        onSignIn = onSignIn,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+
+                state.posts.isEmpty() ->
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            stringResource(R.string.award_empty),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                else ->
+                    LazyColumn(state = listState, modifier = Modifier.weight(1f)) {
+                        items(count = state.posts.size, key = { state.posts[it].postId }) { index ->
+                            val summary = state.posts[index]
+                            PostRow(
+                                post = FeedPost(summary = summary, isRead = false, newCommentCount = 0),
+                                onClick = { onPostClick(summary.postId) },
+                            )
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                        }
+                    }
+            }
+            NumericPager(
+                page = state.page,
+                totalPages = state.totalPages,
+                onPageSelected = onPageSelected,
+            )
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+private fun previewSummary(
+    id: Long,
+    title: String,
+    author: String,
+    board: String,
+    slug: String,
+    replies: Int,
+    views: Int,
+    time: String,
+) = PostSummary(
+    postId = id,
+    title = title,
+    authorName = author,
+    authorUid = id,
+    avatarUrl = null,
+    categoryTitle = board,
+    categorySlug = slug,
+    viewCount = views,
+    commentCount = replies,
+    lastActiveText = time,
+    lastActiveTitle = null,
+)
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "9b 推荐阅读")
+@Composable
+private fun AwardPreview() {
+    NodeSeekTheme {
+        AwardScreen(
+            state =
+            AwardUiState(
+                isLoading = false,
+                page = 1,
+                totalPages = 18,
+                posts =
+                listOf(
+                    previewSummary(
+                        1,
+                        "写了个小工具，把 NodeSeek 的帖子同步到 RSS",
+                        "nssk",
+                        "Dev",
+                        "dev",
+                        126,
+                        8_432,
+                        "2天前",
+                    ),
+                    previewSummary(
+                        2,
+                        "从零搭一套自用的探针与告警，踩坑全记录",
+                        "羽落无声",
+                        "技术",
+                        "tech",
+                        88,
+                        6_204,
+                        "3天前",
+                    ),
+                    previewSummary(
+                        3,
+                        "2026 年低价 VPS 选购避坑指南",
+                        "ifreedom",
+                        "测评",
+                        "review",
+                        243,
+                        19_051,
+                        "上周",
+                    ),
+                    previewSummary(
+                        4,
+                        "科普：为什么你的 IPv6 隧道延迟这么高",
+                        "jswcph",
+                        "技术",
+                        "tech",
+                        57,
+                        4_118,
+                        "上周",
+                    ),
+                ),
+            ),
+            onBack = {},
+            onPostClick = {},
+            onPageSelected = {},
+            onRetry = {},
+            onOpenBrowser = {},
+            onSignIn = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/AwardViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/AwardViewModel.kt
@@ -1,0 +1,84 @@
+package io.github.nsreader.ui.tools
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.AwardRepository
+import io.github.nsreader.di.AppContainer
+import io.github.nsreader.model.PostSummary
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AwardUiState(
+    val isLoading: Boolean = true,
+    val error: NodeSeekError? = null,
+    val posts: List<PostSummary> = emptyList(),
+    val page: Int = 1,
+    val totalPages: Int = 1,
+)
+
+/**
+ * 推荐阅读 — the curated threads, one page at a time.
+ *
+ * Page-numbered rather than infinitely scrolled, matching the site: eighteen pages of hand-picked
+ * threads are something people come back to at a remembered position, and a pager keeps that possible.
+ */
+class AwardViewModel(
+    private val repository: AwardRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(AwardUiState())
+    val uiState: StateFlow<AwardUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    /** The page the user last asked for — [AwardUiState.page] only moves on success. */
+    private var requestedPage = 1
+
+    init {
+        load(1)
+    }
+
+    fun load(page: Int) {
+        requestedPage = page
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                runCatchingExceptCancellation { repository.page(page) }
+                    .onSuccess { result ->
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                error = null,
+                                posts = result.posts,
+                                page = result.page,
+                                totalPages = result.totalPages,
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(isLoading = false, error = throwable.toNodeSeekError())
+                        }
+                    }
+            }
+    }
+
+    // Retries the page that just failed, not the one still on screen from the last success.
+    fun retry() = load(requestedPage)
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { AwardViewModel(container.awardRepository) }
+            }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/CommunityToolsScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/CommunityToolsScreen.kt
@@ -1,0 +1,178 @@
+package io.github.nsreader.ui.tools
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.github.nsreader.R
+import io.github.nsreader.ui.common.GroupedColumn
+import io.github.nsreader.ui.common.GroupedRow
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.SectionLabel
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+/**
+ * 社区工具 — the six links NodeSeek keeps in its quick-access strip, grouped by what they are for.
+ *
+ * All six live behind one entry in 我的 rather than in the bottom bar: none of them is a daily
+ * destination, and the four tabs are worth more to reading than to tools.
+ *
+ * The subtitles describe *form*, never state. An earlier draft claimed things like "今日还有 3 次抽奖"
+ * and "邀请码余量 2" — numbers the site does not publish anywhere. A subtitle that says what a page is
+ * ("加精帖列表 · 与首页同款") stays true without a request.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CommunityToolsScreen(
+    onBack: () -> Unit,
+    onAward: () -> Unit,
+    onProviders: () -> Unit,
+    onFriends: () -> Unit,
+    onLucky: () -> Unit,
+    onInvite: () -> Unit,
+    onRuling: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            LargeTopAppBar(
+                title = { Text(stringResource(R.string.tools_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(Spacing.lg),
+        ) {
+            Column {
+                SectionLabel(stringResource(R.string.tools_group_browse))
+                GroupedColumn {
+                    GroupedRow(
+                        title = stringResource(R.string.tools_award),
+                        subtitle = stringResource(R.string.tools_award_subtitle),
+                        icon = NodeSeekIcons.MenuBook,
+                        first = true,
+                        onClick = onAward,
+                    )
+                    GroupedRow(
+                        title = stringResource(R.string.tools_providers),
+                        subtitle = stringResource(R.string.tools_providers_subtitle),
+                        icon = Icons.Default.ShoppingCart,
+                        onClick = onProviders,
+                    )
+                    GroupedRow(
+                        title = stringResource(R.string.tools_friends),
+                        subtitle = stringResource(R.string.tools_friends_subtitle),
+                        icon = NodeSeekIcons.Link,
+                        last = true,
+                        onClick = onFriends,
+                    )
+                }
+            }
+
+            Column {
+                SectionLabel(stringResource(R.string.tools_group_play))
+                GroupedColumn {
+                    GroupedRow(
+                        title = stringResource(R.string.tools_lucky),
+                        subtitle = stringResource(R.string.tools_lucky_subtitle),
+                        icon = NodeSeekIcons.Casino,
+                        first = true,
+                        onClick = onLucky,
+                    )
+                    GroupedRow(
+                        title = stringResource(R.string.tools_invite),
+                        subtitle = stringResource(R.string.tools_invite_subtitle),
+                        icon = NodeSeekIcons.ConfirmationNumber,
+                        last = true,
+                        onClick = onInvite,
+                    )
+                }
+            }
+
+            Column {
+                SectionLabel(stringResource(R.string.tools_group_watch))
+                GroupedRow(
+                    title = stringResource(R.string.tools_ruling),
+                    subtitle = stringResource(R.string.tools_ruling_subtitle),
+                    icon = NodeSeekIcons.Gavel,
+                    first = true,
+                    last = true,
+                    onClick = onRuling,
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.tools_footnote),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "9a 社区工具")
+@Composable
+private fun CommunityToolsPreview() {
+    NodeSeekTheme {
+        CommunityToolsScreen(
+            onBack = {},
+            onAward = {},
+            onProviders = {},
+            onFriends = {},
+            onLucky = {},
+            onInvite = {},
+            onRuling = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "9a 社区工具 · dark")
+@Composable
+private fun CommunityToolsDarkPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        CommunityToolsScreen(
+            onBack = {},
+            onAward = {},
+            onProviders = {},
+            onFriends = {},
+            onLucky = {},
+            onInvite = {},
+            onRuling = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/InviteScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/InviteScreen.kt
@@ -1,0 +1,179 @@
+package io.github.nsreader.ui.tools
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.ui.assets.InviteConfirmDialog
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun InviteRoute(
+    viewModel: InviteViewModel,
+    onBack: () -> Unit,
+    onBuyOnSite: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val chickenCount by viewModel.chickenCount.collectAsStateWithLifecycle()
+    InviteScreen(
+        chickenCount = chickenCount,
+        onBack = onBack,
+        onBuy = onBuyOnSite,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 邀请好友 — one sentence and one button, which is all the site's own page has.
+ *
+ * There is no invite-code list to show: NodeSeek generates a code, shows it once and keeps no history
+ * the app can read. Adding "已邀请 N 人" or a code list would be inventing a feature.
+ *
+ * The chicken balance is shown next to the button rather than only inside the confirmation, because
+ * whether 1000 is affordable is the first thing anyone wants to know here.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InviteScreen(
+    chickenCount: Int?,
+    onBack: () -> Unit,
+    onBuy: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var confirming by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.invite_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .padding(horizontal = Spacing.lg),
+        ) {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                shape = RoundedCornerShape(18.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier.padding(Spacing.lg),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.md),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                    ) {
+                        Icon(
+                            NodeSeekIcons.Group,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(26.dp),
+                        )
+                        Text(
+                            text = stringResource(R.string.invite_body),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Button(
+                        onClick = { confirming = true },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp),
+                        shape = RoundedCornerShape(24.dp),
+                    ) {
+                        Icon(
+                            NodeSeekIcons.ConfirmationNumber,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Text(
+                            stringResource(R.string.invite_buy),
+                            modifier = Modifier.padding(start = Spacing.sm),
+                        )
+                    }
+                    chickenCount?.let {
+                        Text(
+                            text = stringResource(R.string.invite_chicken_balance, it),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (confirming) {
+        InviteConfirmDialog(
+            chickenCount = chickenCount,
+            onConfirm = {
+                confirming = false
+                onBuy()
+            },
+            onDismiss = { confirming = false },
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 500, name = "9d 邀请好友")
+@Composable
+private fun InvitePreview() {
+    NodeSeekTheme {
+        InviteScreen(chickenCount = 344, onBack = {}, onBuy = {})
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 500, name = "9d 邀请好友 · dark")
+@Composable
+private fun InviteDarkPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        InviteScreen(chickenCount = 1_240, onBack = {}, onBuy = {})
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/InviteViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/InviteViewModel.kt
@@ -1,0 +1,46 @@
+package io.github.nsreader.ui.tools
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.ProfileRepository
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * The invite screen needs exactly one number — the chicken balance behind the confirm dialog — so it
+ * gets its own sliver of a ViewModel rather than borrowing [io.github.nsreader.ui.assets.AssetsViewModel]:
+ * borrowing shipped that screen's sign-in side effects and full growth load into a flow that shows
+ * one figure, and coupled the two screens' evolution.
+ */
+class InviteViewModel(
+    private val profileRepository: ProfileRepository,
+) : ViewModel() {
+
+    private val _chickenCount = MutableStateFlow<Int?>(null)
+
+    /** Null while loading or when the balance could not be read; the screen renders that honestly. */
+    val chickenCount: StateFlow<Int?> = _chickenCount.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _chickenCount.value =
+                runCatchingExceptCancellation { profileRepository.profile() }
+                    .getOrNull()
+                    ?.chickenCount
+        }
+    }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { InviteViewModel(container.profileRepository) }
+            }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/LuckyScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/LuckyScreen.kt
@@ -1,0 +1,499 @@
+package io.github.nsreader.ui.tools
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.LuckyDraw
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.rememberClipboardCopy
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+import io.github.nsreader.ui.theme.readableWidth
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+@Composable
+fun LuckyRoute(
+    viewModel: LuckyViewModel,
+    onBack: () -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    LuckyScreen(
+        state = state,
+        onBack = onBack,
+        onPostIdChange = viewModel::setPostId,
+        onDrawAtChange = viewModel::setDrawAt,
+        onPrizeCountChange = viewModel::setPrizeCount,
+        onStartFloorChange = viewModel::setStartFloor,
+        onDedupeChange = viewModel::setDedupeFloors,
+        onGenerate = viewModel::generate,
+        onOpenBrowser = onOpenBrowser,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 幸运抽奖 — a form, not a wheel.
+ *
+ * The site's `/lucky` is a notary for T-floor giveaways: you declare the thread, the closing time, how
+ * many prizes, which floor counting starts at and whether one user can win twice, and it hands back a
+ * public link. An earlier design had a spinning wheel and a stardust cost; neither exists, and the whole
+ * value of the real thing is that it costs nothing and commits to the rules *before* the draw.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LuckyScreen(
+    state: LuckyUiState,
+    onBack: () -> Unit,
+    onPostIdChange: (String) -> Unit,
+    onDrawAtChange: (Long) -> Unit,
+    onPrizeCountChange: (String) -> Unit,
+    onStartFloorChange: (String) -> Unit,
+    onDedupeChange: (Boolean) -> Unit,
+    onGenerate: () -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var pickingDate by remember { mutableStateOf(false) }
+    var pickingTime by remember { mutableStateOf(false) }
+    val copy = rememberClipboardCopy()
+    val copyLabel = stringResource(R.string.lucky_title)
+    val copiedText = stringResource(R.string.lucky_link_copied)
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.lucky_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                shape = RoundedCornerShape(14.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.lucky_intro),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = Spacing.md),
+                )
+            }
+
+            OutlinedTextField(
+                value = state.postId,
+                onValueChange = onPostIdChange,
+                label = { Text(stringResource(R.string.lucky_post_id)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            DrawTimeRow(
+                millis = state.drawAtMillis,
+                onPickDate = { pickingDate = true },
+                onPickTime = { pickingTime = true },
+            )
+
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                OutlinedTextField(
+                    value = state.prizeCount,
+                    onValueChange = onPrizeCountChange,
+                    label = { Text(stringResource(R.string.lucky_prize_count)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                )
+                OutlinedTextField(
+                    value = state.startFloor,
+                    onValueChange = onStartFloorChange,
+                    label = { Text(stringResource(R.string.lucky_start_floor)) },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 14.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text(
+                            stringResource(R.string.lucky_dedupe),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Text(
+                            stringResource(R.string.lucky_dedupe_hint),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Switch(checked = state.dedupeFloors, onCheckedChange = onDedupeChange)
+                }
+            }
+
+            Button(
+                onClick = onGenerate,
+                enabled = state.canGenerate,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(24.dp),
+            ) {
+                Icon(NodeSeekIcons.Link, contentDescription = null, modifier = Modifier.size(20.dp))
+                Text(
+                    stringResource(R.string.lucky_generate),
+                    modifier = Modifier.padding(start = Spacing.sm),
+                )
+            }
+            if (!state.canGenerate) {
+                Text(
+                    text = stringResource(R.string.lucky_needs_post_id),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            TextButton(
+                onClick = { onOpenBrowser(NodeSeekSite.BASE_URL + NodeSeekSite.LUCKY_PATH) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.lucky_principle))
+            }
+
+            state.generatedLink?.let { link ->
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                GeneratedLinkCard(
+                    link = link,
+                    onCopy = { copy(copyLabel, link, copiedText) },
+                    onOpen = { onOpenBrowser(link) },
+                )
+            }
+        }
+    }
+
+    if (pickingDate) {
+        DrawDatePicker(
+            millis = state.drawAtMillis,
+            onDismiss = { pickingDate = false },
+            onPicked = { picked ->
+                pickingDate = false
+                onDrawAtChange(picked)
+            },
+        )
+    }
+    if (pickingTime) {
+        DrawTimePicker(
+            millis = state.drawAtMillis,
+            onDismiss = { pickingTime = false },
+            onPicked = { picked ->
+                pickingTime = false
+                onDrawAtChange(picked)
+            },
+        )
+    }
+}
+
+@Composable
+private fun DrawTimeRow(
+    millis: Long,
+    onPickDate: () -> Unit,
+    onPickTime: () -> Unit,
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            Text(
+                stringResource(R.string.lucky_draw_time),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = LuckyDraw.formatDrawTime(millis),
+                    style =
+                    MaterialTheme.typography.titleSmall.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        fontFeatureSettings = TABULAR_FIGURES,
+                    ),
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onPickDate) {
+                    Icon(
+                        Icons.Default.DateRange,
+                        contentDescription = stringResource(R.string.lucky_pick_date),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(19.dp),
+                    )
+                }
+                TextButton(onClick = onPickTime) {
+                    Text(stringResource(R.string.lucky_pick_time))
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DrawDatePicker(
+    millis: Long,
+    onDismiss: () -> Unit,
+    onPicked: (Long) -> Unit,
+) {
+    val pickerState = rememberDatePickerState(initialSelectedDateMillis = millis)
+    DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val selected = pickerState.selectedDateMillis
+                    // Only the date changes; the time already chosen is preserved deliberately, so
+                    // picking a day does not silently reset the closing hour to midnight.
+                    onPicked(selected?.let { combineDate(it, millis) } ?: millis)
+                },
+            ) {
+                Text(stringResource(R.string.action_done))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
+    ) {
+        DatePicker(state = pickerState)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DrawTimePicker(
+    millis: Long,
+    onDismiss: () -> Unit,
+    onPicked: (Long) -> Unit,
+) {
+    val current = remember(millis) { millis.toLocalDateTime() }
+    val pickerState =
+        rememberTimePickerState(
+            initialHour = current.hour,
+            initialMinute = current.minute,
+            is24Hour = true,
+        )
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.lucky_pick_time)) },
+        text = { TimePicker(state = pickerState) },
+        confirmButton = {
+            TextButton(onClick = { onPicked(combineTime(millis, pickerState.hour, pickerState.minute)) }) {
+                Text(stringResource(R.string.action_done))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
+    )
+}
+
+@Composable
+private fun GeneratedLinkCard(
+    link: String,
+    onCopy: () -> Unit,
+    onOpen: () -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+            text = stringResource(R.string.lucky_result),
+            style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(14.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = link,
+                        style =
+                        MaterialTheme.typography.labelLarge.copy(fontFamily = FontFamily.Monospace),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = onCopy) {
+                        Icon(
+                            NodeSeekIcons.ContentCopy,
+                            contentDescription = stringResource(R.string.action_copy_link),
+                            modifier = Modifier.size(19.dp),
+                        )
+                    }
+                }
+                FilledTonalButton(
+                    onClick = onOpen,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(44.dp),
+                ) {
+                    Icon(
+                        NodeSeekIcons.OpenInNew,
+                        contentDescription = null,
+                        modifier = Modifier.size(19.dp),
+                    )
+                    Text(
+                        stringResource(R.string.lucky_open_web),
+                        modifier = Modifier.padding(start = 7.dp),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.lucky_result_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private fun Long.toLocalDateTime(): LocalDateTime =
+    LocalDateTime.ofInstant(Instant.ofEpochMilli(this), ZoneId.systemDefault())
+
+/**
+ * The picker reports a UTC midnight; the closing time has to stay the one already chosen.
+ *
+ * Reading the date back in UTC rather than in the device zone is what keeps "27 日" from becoming the
+ * 26th for anyone west of Greenwich — Material's date picker is documented to return midnight UTC.
+ */
+private fun combineDate(pickedUtcMillis: Long, currentMillis: Long): Long {
+    val date: LocalDate = Instant.ofEpochMilli(pickedUtcMillis).atZone(ZoneId.of("UTC")).toLocalDate()
+    val time: LocalTime = currentMillis.toLocalDateTime().toLocalTime()
+    return date.atTime(time).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+}
+
+private fun combineTime(currentMillis: Long, hour: Int, minute: Int): Long =
+    currentMillis
+        .toLocalDateTime()
+        .toLocalDate()
+        .atTime(hour, minute)
+        .atZone(ZoneId.systemDefault())
+        .toInstant()
+        .toEpochMilli()
+
+// -------------------------------------------------------------------------------------------------
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 950, name = "9c 幸运抽奖")
+@Composable
+private fun LuckyPreview() {
+    NodeSeekTheme {
+        LuckyScreen(
+            state =
+            LuckyUiState(
+                postId = "286417",
+                // 2026-07-27 20:00 UTC+8, the sample from the design.
+                drawAtMillis = 1_785_153_600_000L,
+                prizeCount = "3",
+                startFloor = "1",
+                dedupeFloors = true,
+                generatedLink =
+                "https://www.nodeseek.com/lucky?post=286417&time=2026-07-27%2020:00&n=3&start=1&unique=1",
+            ),
+            onBack = {},
+            onPostIdChange = {},
+            onDrawAtChange = {},
+            onPrizeCountChange = {},
+            onStartFloorChange = {},
+            onDedupeChange = {},
+            onGenerate = {},
+            onOpenBrowser = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/LuckyViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/LuckyViewModel.kt
@@ -1,0 +1,98 @@
+package io.github.nsreader.ui.tools
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.AppClock
+import io.github.nsreader.core.LuckyDraw
+import io.github.nsreader.core.LuckyDrawParams
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+data class LuckyUiState(
+    val postId: String = "",
+    val drawAtMillis: Long = 0L,
+    val prizeCount: String = "1",
+    val startFloor: String = "1",
+    val dedupeFloors: Boolean = true,
+    val generatedLink: String? = null,
+) {
+    val postIdValue: Long? get() = postId.trim().toLongOrNull()?.takeIf { it > 0 }
+    val prizeCountValue: Int? get() = prizeCount.trim().toIntOrNull()?.takeIf { it in 1..LuckyDraw.MAX_PRIZE_COUNT }
+    val startFloorValue: Int? get() = startFloor.trim().toIntOrNull()?.takeIf { it >= 0 }
+
+    val canGenerate: Boolean get() = postIdValue != null && prizeCountValue != null && startFloorValue != null
+}
+
+/**
+ * 幸运抽奖 — the T-floor notary form.
+ *
+ * Entirely local: filling it in makes no request and spends nothing. What comes out is a link that
+ * declares the rules before the draw happens, which is the whole point of the tool — the fairness comes
+ * from having published the parameters in advance, not from anything the app computes.
+ */
+class LuckyViewModel(
+    clock: AppClock,
+) : ViewModel() {
+    private val _uiState =
+        MutableStateFlow(LuckyUiState(drawAtMillis = defaultDrawTime(clock.nowMillis())))
+    val uiState: StateFlow<LuckyUiState> = _uiState.asStateFlow()
+
+    fun setPostId(value: String) = update { copy(postId = value.digitsOnly()) }
+
+    fun setDrawAt(millis: Long) = update { copy(drawAtMillis = millis) }
+
+    fun setPrizeCount(value: String) = update { copy(prizeCount = value.digitsOnly()) }
+
+    fun setStartFloor(value: String) = update { copy(startFloor = value.digitsOnly()) }
+
+    fun setDedupeFloors(value: Boolean) = update { copy(dedupeFloors = value) }
+
+    fun generate() {
+        val state = _uiState.value
+        val postId = state.postIdValue ?: return
+        val link =
+            LuckyDraw.link(
+                LuckyDrawParams(
+                    postId = postId,
+                    drawAtMillis = state.drawAtMillis,
+                    prizeCount = state.prizeCountValue ?: 1,
+                    startFloor = state.startFloorValue ?: 1,
+                    dedupeFloors = state.dedupeFloors,
+                ),
+            )
+        _uiState.update { it.copy(generatedLink = link) }
+    }
+
+    /** Any edit invalidates the generated link, so a stale URL can never be pasted into a thread. */
+    private fun update(transform: LuckyUiState.() -> LuckyUiState) =
+        _uiState.update { state -> state.transform().copy(generatedLink = null) }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { LuckyViewModel(container.clock) }
+            }
+    }
+}
+
+private fun String.digitsOnly(): String = filter(Char::isDigit).take(MAX_FIELD_LENGTH)
+
+private const val MAX_FIELD_LENGTH = 12
+
+/** Tomorrow, on the hour. A draw closing in the past is the one default that is always wrong. */
+private fun defaultDrawTime(nowMillis: Long): Long =
+    Instant
+        .ofEpochMilli(nowMillis)
+        .plus(1, ChronoUnit.DAYS)
+        .atZone(ZoneId.systemDefault())
+        .truncatedTo(ChronoUnit.HOURS)
+        .toInstant()
+        .toEpochMilli()

--- a/app/src/main/java/io/github/nsreader/ui/tools/RulingScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/RulingScreen.kt
@@ -1,0 +1,319 @@
+package io.github.nsreader.ui.tools
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.nsreader.R
+import io.github.nsreader.core.NodeSeekSite
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.data.RulingKind
+import io.github.nsreader.data.RulingRecord
+import io.github.nsreader.ui.common.LoadingState
+import io.github.nsreader.ui.common.NodeSeekErrorState
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.common.NumericPager
+import io.github.nsreader.ui.theme.NodeSeekTheme
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+import io.github.nsreader.ui.theme.readableWidth
+
+@Composable
+fun RulingRoute(
+    viewModel: RulingViewModel,
+    onBack: () -> Unit,
+    onOpenBrowser: (String) -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    RulingScreen(
+        state = state,
+        onBack = onBack,
+        onPageSelected = viewModel::load,
+        onRetry = viewModel::retry,
+        onOpenBrowser = { onOpenBrowser(NodeSeekSite.BASE_URL + NodeSeekSite.RULING_PATH) },
+        onSignIn = onSignIn,
+        modifier = modifier,
+    )
+}
+
+/**
+ * 管理记录.
+ *
+ * The site presents this as a five-column table, which a 360dp screen cannot carry. Each decision
+ * becomes a two-line row instead: who and why on the first line, what was done and by whom on the
+ * second. The compound action stays joined by "+" rather than split into badges — "扣 20 鸡腿 + 移动版块
+ * 至 促销 + 锁定修改" is one decision and reads as one sentence.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RulingScreen(
+    state: RulingUiState,
+    onBack: () -> Unit,
+    onPageSelected: (Int) -> Unit,
+    onRetry: () -> Unit,
+    onOpenBrowser: () -> Unit,
+    onSignIn: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Column {
+                        Text(stringResource(R.string.ruling_title))
+                        Text(
+                            text = stringResource(R.string.ruling_subtitle),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .readableWidth(),
+        ) {
+            when {
+                state.isLoading && state.records.isEmpty() -> LoadingState(Modifier.fillMaxSize())
+
+                state.error != null && state.records.isEmpty() ->
+                    NodeSeekErrorState(
+                        error = state.error,
+                        onRetry = onRetry,
+                        onOpenBrowser = onOpenBrowser,
+                        onSignIn = onSignIn,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+
+                else ->
+                    LazyColumn(Modifier.weight(1f)) {
+                        items(count = state.records.size, key = { state.records[it].id }) { index ->
+                            RulingRow(state.records[index])
+                            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                        }
+                    }
+            }
+            NumericPager(
+                page = state.page,
+                totalPages = state.totalPages,
+                onPageSelected = onPageSelected,
+                approximateTotal = state.totalPages >= APPROXIMATE_TOTAL_THRESHOLD,
+            )
+        }
+    }
+}
+
+private const val APPROXIMATE_TOTAL_THRESHOLD = 100
+
+@Composable
+private fun RulingRow(record: RulingRecord) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = 11.dp),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(34.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerLow),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = record.kind.icon(),
+                contentDescription = null,
+                tint = record.kind.tint(),
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            // Built as an annotated string rather than one format string so the user name can carry the
+            // weight — it is what the eye scans for in a log of other people's punishments.
+            val targetKind = stringResource(R.string.ruling_target_kind, record.targetKind)
+            val reason = record.reason?.let { stringResource(R.string.ruling_reason, it) }
+            Text(
+                text =
+                buildAnnotatedString {
+                    withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) { append(record.targetName) }
+                    append(targetKind)
+                    reason?.let(::append)
+                },
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = record.metaLine(),
+                style = MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RulingRecord.metaLine(): String {
+    val actions = actions.joinToString(" + ").ifBlank { "—" }
+    val time = timeText.orEmpty()
+    return moderatorName
+        ?.let { stringResource(R.string.ruling_meta, actions, it, time) }
+        ?: stringResource(R.string.ruling_meta_no_moderator, actions, time)
+}
+
+private fun RulingKind.icon(): ImageVector =
+    when (this) {
+        RulingKind.PENALTY -> NodeSeekIcons.Gavel
+        RulingKind.BAN -> NodeSeekIcons.Block
+        RulingKind.MOVE -> NodeSeekIcons.SwapVert
+        RulingKind.PERMISSION -> NodeSeekIcons.Visibility
+        RulingKind.REWARD -> NodeSeekIcons.ChickenLeg
+    }
+
+@Composable
+private fun RulingKind.tint() =
+    when (this) {
+        RulingKind.BAN -> MaterialTheme.colorScheme.error
+        RulingKind.REWARD -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+// -------------------------------------------------------------------------------------------------
+
+private val previewRecords =
+    listOf(
+        RulingRecord(
+            1,
+            "深蓝色的天",
+            "帖子",
+            "无意义灌水",
+            listOf("扣 10 鸡腿", "锁定修改"),
+            "kanata",
+            "2026/7/25 21:40",
+            RulingKind.PENALTY,
+        ),
+        RulingRecord(
+            2,
+            "bigxiang",
+            "评论",
+            "人身攻击",
+            listOf("扣 30 鸡腿", "禁言 3 天"),
+            "nsadmin",
+            "2026/7/25 18:12",
+            RulingKind.BAN,
+        ),
+        RulingRecord(
+            3,
+            "jswcph",
+            "帖子",
+            "发卡站未发推广区",
+            listOf("扣 20 鸡腿", "移动版块至 促销", "锁定修改"),
+            "kanata",
+            "2026/7/24 09:31",
+            RulingKind.MOVE,
+        ),
+        RulingRecord(
+            4,
+            "wh1te",
+            "帖子",
+            "涉及敏感信息",
+            listOf("阅读权限改为 Lv 1", "锁定修改"),
+            "kanata",
+            "2026/7/23 15:02",
+            RulingKind.PERMISSION,
+        ),
+        RulingRecord(
+            5,
+            "haiqing123",
+            "帖子",
+            "优质技术分享",
+            listOf("加 50 鸡腿"),
+            "nsadmin",
+            "2026/7/22 20:18",
+            RulingKind.REWARD,
+        ),
+        RulingRecord(
+            6,
+            "terrywei",
+            "评论",
+            "引战言论",
+            listOf("扣 15 鸡腿", "禁言 1 天"),
+            "kanata",
+            "2026/7/22 11:47",
+            RulingKind.PENALTY,
+        ),
+    )
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "9d 管理记录")
+@Composable
+private fun RulingPreview() {
+    NodeSeekTheme {
+        RulingScreen(
+            state = RulingUiState(isLoading = false, records = previewRecords, page = 1, totalPages = 104),
+            onBack = {},
+            onPageSelected = {},
+            onRetry = {},
+            onOpenBrowser = {},
+            onSignIn = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "9d 管理记录 · 接口待接入")
+@Composable
+private fun RulingNotWiredPreview() {
+    NodeSeekTheme(darkTheme = true) {
+        RulingScreen(
+            state = RulingUiState(isLoading = false, error = NodeSeekError.NotWired),
+            onBack = {},
+            onPageSelected = {},
+            onRetry = {},
+            onOpenBrowser = {},
+            onSignIn = {},
+        )
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/tools/RulingViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/tools/RulingViewModel.kt
@@ -1,0 +1,79 @@
+package io.github.nsreader.ui.tools
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.runCatchingExceptCancellation
+import io.github.nsreader.data.RulingRecord
+import io.github.nsreader.data.RulingRepository
+import io.github.nsreader.di.AppContainer
+import io.github.nsreader.ui.postlist.toNodeSeekError
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class RulingUiState(
+    val isLoading: Boolean = true,
+    val error: NodeSeekError? = null,
+    val records: List<RulingRecord> = emptyList(),
+    val page: Int = 1,
+    val totalPages: Int = 1,
+)
+
+/** 管理记录 — the public log of penalties and rewards, paged by number like the site's table. */
+class RulingViewModel(
+    private val repository: RulingRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(RulingUiState())
+    val uiState: StateFlow<RulingUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    /** The page the user last asked for — [RulingUiState.page] only moves on success. */
+    private var requestedPage = 1
+
+    init {
+        load(1)
+    }
+
+    fun load(page: Int) {
+        requestedPage = page
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+                runCatchingExceptCancellation { repository.records(page) }
+                    .onSuccess { result ->
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                error = null,
+                                records = result.records,
+                                page = result.page,
+                                totalPages = result.totalPages,
+                            )
+                        }
+                    }.onFailure { throwable ->
+                        _uiState.update {
+                            it.copy(isLoading = false, error = throwable.toNodeSeekError())
+                        }
+                    }
+            }
+    }
+
+    // Retries the page that just failed, not the one still on screen from the last success.
+    fun retry() = load(requestedPage)
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { RulingViewModel(container.rulingRepository) }
+            }
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/viewer/ImageSaver.kt
+++ b/app/src/main/java/io/github/nsreader/ui/viewer/ImageSaver.kt
@@ -1,0 +1,160 @@
+package io.github.nsreader.ui.viewer
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.os.Build
+import android.provider.MediaStore
+import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.toBitmap
+import io.github.nsreader.core.AppDispatchers
+import io.github.nsreader.core.runCatchingExceptCancellation
+import kotlinx.coroutines.withContext
+import java.io.OutputStream
+
+/** Why a save did not happen, so the screen can say something more useful than "失败". */
+enum class SaveOutcome {
+    SAVED,
+    UNSUPPORTED_OS,
+    FAILED,
+}
+
+/**
+ * Writes a viewed image into the shared image collection.
+ *
+ * The bytes come from Coil rather than from a fresh request: the image is already on screen, and
+ * re-fetching it would need the same cookies and browser headers that only the app's OkHttp client
+ * carries — which is exactly what Coil is configured with. The disk cache's original encoded bytes
+ * are preferred over the decoded bitmap: copying them keeps the source format and file size, where
+ * re-encoding a large photo as PNG costs seconds of CPU and a file several times bigger. The bitmap
+ * path survives only as the fallback for an image the cache cannot hand back.
+ *
+ * Scoped storage only. On Android 10 and above `RELATIVE_PATH` puts the file in `Pictures/NodeSeek`
+ * with no permission at all; below that the same write needs `WRITE_EXTERNAL_STORAGE`, a broad,
+ * device-wide grant to add one screenshot to the gallery. That trade is not worth making, so older
+ * versions are told to use 分享 instead.
+ */
+suspend fun saveImageToGallery(
+    context: Context,
+    url: String,
+    dispatchers: AppDispatchers,
+): SaveOutcome {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return SaveOutcome.UNSUPPORTED_OS
+
+    return withContext(dispatchers.io) {
+        runCatchingExceptCancellation {
+            val bytes = encodedBytes(context, url)
+            val mimeType = bytes?.let(::sniffImageMime)
+            if (bytes != null && mimeType != null) {
+                writeToGallery(context, url.toFileName(mimeType.extension), mimeType.value) { stream ->
+                    stream.write(bytes)
+                    true
+                }
+            } else {
+                val request = ImageRequest.Builder(context).data(url).build()
+                val result = SingletonImageLoader.get(context).execute(request)
+                val bitmap =
+                    (result as? SuccessResult)?.image?.toBitmap()
+                        ?: return@runCatchingExceptCancellation false
+                writeToGallery(context, url.toFileName("png"), "image/png") { stream ->
+                    // PNG is lossless; the mandatory quality argument is ignored by this format.
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                }
+            }
+        }.fold(
+            onSuccess = { saved -> if (saved) SaveOutcome.SAVED else SaveOutcome.FAILED },
+            onFailure = { SaveOutcome.FAILED },
+        )
+    }
+}
+
+/**
+ * The image's original encoded bytes from Coil's disk cache, populated by a request when cold.
+ *
+ * Null when the cache cannot produce them (cache disabled, or the request was served from memory
+ * without ever touching disk) — the caller then falls back to re-encoding the decoded bitmap.
+ */
+private suspend fun encodedBytes(context: Context, url: String): ByteArray? {
+    val loader = SingletonImageLoader.get(context)
+    val cache = loader.diskCache ?: return null
+
+    fun fromCache(): ByteArray? =
+        cache.openSnapshot(url)?.use { snapshot ->
+            cache.fileSystem.read(snapshot.data) { readByteArray() }
+        }
+
+    fromCache()?.let { return it }
+    val result = loader.execute(ImageRequest.Builder(context).data(url).build())
+    if (result !is SuccessResult) return null
+    return fromCache()
+}
+
+/**
+ * Inserts a pending row, hands [write] the stream, and either publishes or deletes the row.
+ * A row without bytes is a zero-length ghost in the gallery, so failure takes it back out.
+ */
+private fun writeToGallery(
+    context: Context,
+    fileName: String,
+    mimeType: String,
+    write: (OutputStream) -> Boolean,
+): Boolean {
+    val values =
+        ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+            put(MediaStore.Images.Media.MIME_TYPE, mimeType)
+            put(MediaStore.Images.Media.RELATIVE_PATH, "Pictures/NodeSeek")
+            // Hidden from the gallery until the bytes are actually there.
+            put(MediaStore.Images.Media.IS_PENDING, 1)
+        }
+    val resolver = context.contentResolver
+    val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values) ?: return false
+    var written = false
+    try {
+        resolver.openOutputStream(uri)?.use { stream -> written = write(stream) }
+    } finally {
+        if (written) {
+            values.clear()
+            values.put(MediaStore.Images.Media.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+        } else {
+            resolver.delete(uri, null, null)
+        }
+    }
+    return written
+}
+
+internal class ImageMime(val value: String, val extension: String)
+
+/** Format from the magic bytes: the URL's extension lies often enough not to be trusted. */
+internal fun sniffImageMime(bytes: ByteArray): ImageMime? {
+    fun ascii(from: Int, until: Int): String? =
+        if (bytes.size >= until) String(bytes, from, until - from, Charsets.US_ASCII) else null
+    return when {
+        bytes.size >= 2 && bytes[0] == 0xFF.toByte() && bytes[1] == 0xD8.toByte() ->
+            ImageMime("image/jpeg", "jpg")
+
+        bytes.size >= 4 && bytes[0] == 0x89.toByte() && ascii(1, 4) == "PNG" ->
+            ImageMime("image/png", "png")
+
+        ascii(0, 6) == "GIF87a" || ascii(0, 6) == "GIF89a" -> ImageMime("image/gif", "gif")
+
+        ascii(0, 4) == "RIFF" && ascii(8, 12) == "WEBP" -> ImageMime("image/webp", "webp")
+
+        else -> null
+    }
+}
+
+/** The site's own filename when the URL has one, so the gallery entry is recognisable. */
+internal fun String.toFileName(extension: String = "png"): String {
+    val candidate = substringBefore('?').substringAfterLast('/').trim()
+    val safe = candidate.filter { it.isLetterOrDigit() || it in "-_." }
+    return when {
+        safe.isEmpty() -> "nodeseek-image.$extension"
+        safe.endsWith(".$extension", ignoreCase = true) -> safe
+        safe.contains('.') -> safe.substringBeforeLast('.') + ".$extension"
+        else -> "$safe.$extension"
+    }
+}

--- a/app/src/main/java/io/github/nsreader/ui/viewer/ImageViewerScreen.kt
+++ b/app/src/main/java/io/github/nsreader/ui/viewer/ImageViewerScreen.kt
@@ -1,0 +1,439 @@
+package io.github.nsreader.ui.viewer
+
+import android.content.Intent
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
+import io.github.nsreader.R
+import io.github.nsreader.ui.common.NodeSeekIcons
+import io.github.nsreader.ui.theme.Spacing
+import io.github.nsreader.ui.theme.TABULAR_FIGURES
+import kotlin.math.abs
+
+/**
+ * Full-screen image viewer.
+ *
+ * Its own screen rather than a dialog: it takes over the window, keeps its own back behaviour, and
+ * survives rotation with the page it was on. The background is #0E0E11 rather than pure black — against
+ * an OLED's true black a dark screenshot has no visible edge, and the gesture surface stops being legible.
+ *
+ * Three gestures, in the order they are checked: pinch to zoom, double-tap to toggle 2.5×, and — only
+ * while unzoomed — a downward drag to dismiss. Paging is disabled while zoomed, or a pan across a
+ * magnified screenshot would flick to the next image instead.
+ */
+@Composable
+fun ImageViewerScreen(
+    urls: List<String>,
+    initialIndex: Int,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    onOpenBrowser: (String) -> Unit = {},
+    saveOutcome: SaveOutcome? = null,
+    onSave: (String) -> Unit = {},
+) {
+    if (urls.isEmpty()) {
+        LaunchedEffect(Unit) { onClose() }
+        return
+    }
+
+    val context = LocalContext.current
+    val pagerState = rememberPagerState(initialPage = initialIndex.coerceIn(0, urls.lastIndex)) { urls.size }
+    var zoomed by remember { mutableStateOf(false) }
+
+    val notice =
+        when (saveOutcome) {
+            null -> null
+            SaveOutcome.SAVED -> stringResource(R.string.viewer_saved)
+            SaveOutcome.UNSUPPORTED_OS -> stringResource(R.string.viewer_save_unsupported)
+            SaveOutcome.FAILED -> stringResource(R.string.viewer_save_failed)
+        }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(VIEWER_BACKGROUND),
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            userScrollEnabled = !zoomed,
+            modifier = Modifier.fillMaxSize(),
+        ) { page ->
+            ZoomableImage(
+                url = urls[page],
+                onDismiss = onClose,
+                onZoomChange = { isZoomed -> if (page == pagerState.currentPage) zoomed = isZoomed },
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .systemBarsPadding()
+                .align(Alignment.TopCenter),
+        ) {
+            ViewerTopBar(
+                page = pagerState.currentPage + 1,
+                total = urls.size,
+                onClose = onClose,
+                onOpenBrowser = { onOpenBrowser(urls[pagerState.currentPage]) },
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .systemBarsPadding(),
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            if (urls.size > 1) PageDots(count = urls.size, current = pagerState.currentPage)
+            notice?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = VIEWER_SECONDARY_CONTENT,
+                    modifier = Modifier.padding(horizontal = Spacing.lg),
+                )
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                ViewerAction(
+                    icon = NodeSeekIcons.Download,
+                    label = stringResource(R.string.viewer_save),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    onSave(urls[pagerState.currentPage])
+                }
+                ViewerAction(
+                    icon = Icons.Default.Share,
+                    label = stringResource(R.string.action_share),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    // Shares the address rather than the bytes: NodeSeek attachments are hosted URLs,
+                    // and a link stays a link for the person receiving it.
+                    val share =
+                        Intent(Intent.ACTION_SEND).apply {
+                            type = "text/plain"
+                            putExtra(Intent.EXTRA_TEXT, urls[pagerState.currentPage])
+                        }
+                    context.startActivity(Intent.createChooser(share, null))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ViewerTopBar(
+    page: Int,
+    total: Int,
+    onClose: () -> Unit,
+    onOpenBrowser: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onClose) {
+            Icon(
+                Icons.Default.Close,
+                contentDescription = stringResource(R.string.action_close),
+                tint = VIEWER_CONTENT,
+            )
+        }
+        Text(
+            text = stringResource(R.string.viewer_page, page, total),
+            style =
+            MaterialTheme.typography.labelLarge.copy(
+                fontWeight = FontWeight.SemiBold,
+                fontFeatureSettings = TABULAR_FIGURES,
+            ),
+            color = VIEWER_CONTENT,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onOpenBrowser) {
+            Icon(
+                NodeSeekIcons.OpenInNew,
+                contentDescription = stringResource(R.string.action_open_in_browser),
+                tint = VIEWER_CONTENT,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PageDots(
+    count: Int,
+    current: Int,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterHorizontally),
+    ) {
+        repeat(count) { index ->
+            val active = index == current
+            Box(
+                Modifier
+                    .width(if (active) 18.dp else 6.dp)
+                    .height(6.dp)
+                    .clip(CircleShape)
+                    .background(if (active) VIEWER_CONTENT else VIEWER_INACTIVE_DOT),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ViewerAction(
+    icon: ImageVector,
+    label: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        color = VIEWER_ACTION_CONTAINER,
+        contentColor = VIEWER_CONTENT,
+        shape = RoundedCornerShape(24.dp),
+        modifier = modifier.height(48.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(20.dp))
+            Text(label, style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}
+
+/**
+ * One page: the image, its gestures, and the failure state that replaces it.
+ *
+ * A failed load keeps the filename and offers 重试. A blank black screen would leave the user unable to
+ * tell a broken link from a slow one, and unable to do anything about either.
+ */
+@Composable
+private fun ZoomableImage(
+    url: String,
+    onDismiss: () -> Unit,
+    onZoomChange: (Boolean) -> Unit,
+) {
+    var scale by remember(url) { mutableFloatStateOf(1f) }
+    var offset by remember(url) { mutableStateOf(Offset.Zero) }
+    var dragY by remember(url) { mutableFloatStateOf(0f) }
+    var retryToken by remember(url) { mutableIntStateOf(0) }
+
+    val animatedScale by animateFloatAsState(targetValue = scale, label = "viewer-scale")
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(url) {
+                detectTapGestures(
+                    onDoubleTap = {
+                        scale = if (scale > 1f) 1f else DOUBLE_TAP_SCALE
+                        offset = Offset.Zero
+                        onZoomChange(scale > 1f)
+                    },
+                )
+            }.pointerInput(url) {
+                /*
+                 * Hand-rolled rather than detectTransformGestures, because that detector consumes
+                 * every position change once past touch slop — including a one-finger swipe on an
+                 * unzoomed image, which is the pager's page-turn. Consuming only on a second finger
+                 * or on an already-zoomed image is what lets the swipe reach the pager at all.
+                 */
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false)
+                    do {
+                        val event = awaitPointerEvent()
+                        val pinching = event.changes.count { it.pressed } > 1
+                        if (pinching || scale > 1f) {
+                            val zoom = event.calculateZoom()
+                            val pan = event.calculatePan()
+                            scale = (scale * zoom).coerceIn(1f, MAX_SCALE)
+                            offset = if (scale > 1f) offset + pan else Offset.Zero
+                            onZoomChange(scale > 1f)
+                            event.changes.forEach { if (it.positionChanged()) it.consume() }
+                        }
+                    } while (event.changes.any { it.pressed })
+                }
+            }.pointerInput(url, scale > 1f) {
+                if (scale > 1f) return@pointerInput
+                detectVerticalDragGestures(
+                    onDragEnd = {
+                        if (abs(dragY) > DISMISS_DRAG_PX) onDismiss() else dragY = 0f
+                    },
+                    onDragCancel = { dragY = 0f },
+                ) { _, delta -> dragY += delta }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        key(retryToken) {
+            val painter = rememberAsyncImagePainter(model = url)
+            val state by painter.state.collectAsState()
+
+            when (state) {
+                is AsyncImagePainter.State.Error -> ImageFailure(url = url, onRetry = { retryToken++ })
+
+                else ->
+                    Image(
+                        painter = painter,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = Spacing.sm)
+                            .graphicsLayer(
+                                scaleX = animatedScale,
+                                scaleY = animatedScale,
+                                translationX = offset.x,
+                                translationY = offset.y + dragY,
+                            ),
+                    )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImageFailure(
+    url: String,
+    onRetry: () -> Unit,
+) {
+    Surface(
+        color = VIEWER_ACTION_CONTAINER,
+        contentColor = VIEWER_CONTENT,
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier.padding(horizontal = Spacing.lg),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = Spacing.lg, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            Icon(
+                Icons.Default.Warning,
+                contentDescription = null,
+                tint = VIEWER_WARNING,
+                modifier = Modifier.size(20.dp),
+            )
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    stringResource(R.string.viewer_load_failed),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(
+                    url.toFileName(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = VIEWER_SECONDARY_CONTENT,
+                )
+            }
+            Surface(
+                onClick = onRetry,
+                color = VIEWER_RETRY_CONTAINER,
+                contentColor = VIEWER_CONTENT,
+                shape = RoundedCornerShape(17.dp),
+            ) {
+                Text(
+                    stringResource(R.string.action_retry),
+                    style = MaterialTheme.typography.labelMedium,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+/*
+ * Fixed colours rather than theme roles: this screen is the same near-black in light and dark mode,
+ * because it is a lightbox — the image is the content and everything else steps out of its way.
+ */
+private val VIEWER_BACKGROUND = Color(0xFF0E0E11)
+private val VIEWER_CONTENT = Color(0xFFE9E9EE)
+private val VIEWER_SECONDARY_CONTENT = Color(0xFFC9C9D2)
+private val VIEWER_INACTIVE_DOT = Color(0xFF5A5A64)
+private val VIEWER_ACTION_CONTAINER = Color(0x1AFFFFFF)
+private val VIEWER_RETRY_CONTAINER = Color(0x24FFFFFF)
+private val VIEWER_WARNING = Color(0xFFF2B8B5)
+
+private const val DOUBLE_TAP_SCALE = 2.5f
+private const val MAX_SCALE = 5f
+private const val DISMISS_DRAG_PX = 220f
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800, name = "8h 图片查看器")
+@Composable
+private fun ImageViewerPreview() {
+    ImageViewerScreen(
+        urls = listOf("https://www.nodeseek.com/static/nft-list-ruleset.png"),
+        initialIndex = 0,
+        onClose = {},
+    )
+}

--- a/app/src/main/java/io/github/nsreader/ui/viewer/ImageViewerViewModel.kt
+++ b/app/src/main/java/io/github/nsreader/ui/viewer/ImageViewerViewModel.kt
@@ -1,0 +1,46 @@
+package io.github.nsreader.ui.viewer
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nsreader.core.AppDispatchers
+import io.github.nsreader.di.AppContainer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the gallery-save side effect so it outlives the composition: launched from the screen's own
+ * scope, a rotation mid-write cancelled the download and dropped the outcome the user was owed.
+ */
+class ImageViewerViewModel(
+    private val appContext: Context,
+    private val dispatchers: AppDispatchers,
+) : ViewModel() {
+
+    private val _saveOutcome = MutableStateFlow<SaveOutcome?>(null)
+
+    /** Null until a save has run; then the latest save's outcome, for the screen to word. */
+    val saveOutcome: StateFlow<SaveOutcome?> = _saveOutcome.asStateFlow()
+
+    fun save(url: String) {
+        viewModelScope.launch {
+            _saveOutcome.value = saveImageToGallery(appContext, url, dispatchers)
+        }
+    }
+
+    companion object {
+        fun factory(container: AppContainer): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer {
+                    val application =
+                        checkNotNull(this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
+                    ImageViewerViewModel(application, container.dispatchers)
+                }
+            }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="action_share">分享</string>
     <string name="action_more">更多</string>
     <string name="action_cancel">取消</string>
+    <string name="action_done">确定</string>
     <string name="action_sort">排序方式</string>
     <string name="action_show_all_boards">全部版块</string>
     <string name="action_hide_all_boards">收起版块</string>
@@ -152,9 +153,6 @@
     <string name="profile_stars">星辰</string>
     <string name="profile_streak">连续签到</string>
     <string name="profile_attendance">今日签到 · 领鸡腿</string>
-    <string name="profile_topics">我的主题</string>
-    <string name="profile_comments">我的评论</string>
-    <string name="profile_bookmarks">我的收藏</string>
     <string name="profile_open_web">在网页中打开个人主页</string>
 
     <!-- Settings -->
@@ -217,5 +215,211 @@
     <string name="status_coming_soon_title">%1$s 还在做</string>
     <string name="status_coming_soon_body">这个页面的设计稿还没定，先用首页凑合一下。</string>
 
+    <string name="status_not_wired_title">这一页还没接进 App</string>
+    <string name="status_not_wired_body">NodeSeek 这一页是网页端渲染的，没有可读的接口，App 不会拿猜出来的数据糊弄你。先到网页里看，接口对上就会补进来。</string>
+
     <string name="image_description_sticker">表情</string>
+
+    <!-- Two-pane home on tablets and unfolded foldables -->
+    <string name="home_pane_empty">选一个帖子，正文会显示在这里</string>
+
+    <!-- Pagination for the lists the site indexes by page number -->
+    <string name="pager_total_approx">共 %1$d+ 页</string>
+
+    <!-- User space (8a 我的主页 / 8b 公开用户页) -->
+    <string name="space_tab_general">概况</string>
+    <string name="space_tab_topics">主题帖</string>
+    <string name="space_tab_comments">评论</string>
+    <string name="space_tab_collections">收藏</string>
+    <string name="space_stat_joined_days">加入天数</string>
+    <string name="space_stat_level">等级</string>
+    <string name="space_stat_chicken">鸡腿</string>
+    <string name="space_stat_topics">主题帖</string>
+    <string name="space_stat_comments">评论</string>
+    <string name="space_message">私信</string>
+    <string name="space_uid">UID %1$d</string>
+    <string name="space_uid_bio">UID %1$d · %2$s</string>
+    <string name="space_bio">Bio</string>
+    <string name="space_readme">Readme</string>
+    <string name="space_readme_empty">没有找到readme 🙄</string>
+    <string name="space_readme_expand">展开全部</string>
+    <string name="space_readme_collapse">收起</string>
+    <string name="space_end_topics">已经到底了 · 共 %1$d 篇主题帖</string>
+    <string name="space_end_comments">已经到底了 · 共 %1$d 条评论</string>
+    <string name="space_end_collections">已经到底了 · 共 %1$d 条收藏</string>
+    <string name="space_empty_topics">还没有发过主题帖</string>
+    <string name="space_empty_comments">还没有发过评论</string>
+    <string name="space_empty_collections">收藏夹是空的</string>
+    <string name="space_load_more">加载更多</string>
+    <string name="space_comment_in">回复于 %1$s</string>
+
+    <!-- Assets and growth (8d) -->
+    <string name="assets_title">账户与成长</string>
+    <string name="assets_level">Lv %1$d</string>
+    <string name="assets_level_progress">鸡腿 %1$d / %2$d</string>
+    <string name="assets_level_remaining">还差 %1$d 鸡腿到 Lv %2$d · 等级进度即鸡腿总数</string>
+    <string name="assets_level_no_threshold">站点只公开了 Lv 1 → Lv 2 的门槛（400 鸡腿）</string>
+    <string name="assets_daily_title">今日额度</string>
+    <string name="assets_quota_post">今日发帖可得鸡腿</string>
+    <string name="assets_quota_comment">今日评论可得鸡腿</string>
+    <string name="assets_quota_attendance">今日签到获得鸡腿</string>
+    <string name="assets_quota_feeding">今日免费投喂额度</string>
+    <string name="assets_quota_value">%1$d / %2$d</string>
+    <string name="assets_quota_value_unknown">— / %1$d</string>
+    <string name="assets_chicken_count">鸡腿 %1$d</string>
+    <string name="assets_quota_hint">今日额度来自 /progress，那一页是网页端渲染的，App 暂时只能显示上限。</string>
+    <string name="assets_chicken">鸡腿</string>
+    <string name="assets_stars">星辰</string>
+    <string name="assets_ledger">流水</string>
+    <string name="assets_ledger_transfer">流水 / 转账</string>
+    <string name="assets_sign_in">今日签到 · 领鸡腿</string>
+    <string name="assets_sign_in_choice_title">今日签到</string>
+    <string name="assets_sign_in_random">随机数量 · 拼手气</string>
+    <string name="assets_sign_in_fixed">固定 5 个鸡腿</string>
+    <string name="assets_sign_in_choice_hint">与网页端一致：随机模式可能高于也可能低于 5 个。</string>
+    <string name="assets_board">今日签到榜</string>
+    <string name="assets_board_subtitle">看看今天谁的手气最好</string>
+    <string name="assets_board_gain">+%1$d</string>
+    <string name="assets_board_failed">签到榜加载失败</string>
+    <string name="assets_signed_in">今日已签 +%1$d 鸡腿</string>
+    <string name="assets_signing_in">签到中…</string>
+
+    <!-- Stardust ledger and transfer (8e / 8f) -->
+    <string name="stardust_title">星辰</string>
+    <string name="stardust_balance">当前余额</string>
+    <string name="stardust_balance_hint">唯一来源：评论被点赞（+1 / 次）· 唯一用途：转账</string>
+    <string name="stardust_entry_title">点赞 · 评论被点赞</string>
+    <string name="stardust_entry_balance">余额 %1$d</string>
+    <string name="stardust_entry_comment">Comment %1$d</string>
+    <string name="stardust_entry_amount">+%1$d</string>
+    <string name="stardust_end">没有更多记录了</string>
+    <string name="transfer_action">转账</string>
+    <string name="transfer_title">转账星辰</string>
+    <string name="transfer_amount">数额</string>
+    <string name="transfer_recipient">收款人 UID</string>
+    <string name="transfer_ref">Ref ID</string>
+    <string name="transfer_hint">站点没有「UID 转昵称」的接口，提交前请再核对一次收款人 UID。</string>
+    <string name="transfer_next">下一步</string>
+    <string name="transfer_confirm_title">确认转账 %1$d 星辰？</string>
+    <string name="transfer_amount_value">%1$d 星辰</string>
+    <string name="transfer_balance_after">转账后余额</string>
+    <string name="transfer_balance_change">%1$d → %2$d</string>
+    <string name="transfer_caution">星辰转账一旦提交无法撤销，请确认收款人 UID 与 Ref ID 无误。</string>
+    <string name="transfer_confirm">确认转账</string>
+    <string name="transfer_shortfall">还差 %1$d 星辰</string>
+    <string name="transfer_opened_web">App 还没有对接转账接口，已在网页中打开转账页。</string>
+    <string name="spend_current_balance">当前余额</string>
+
+    <!-- Account settings (8g) -->
+    <string name="account_settings_title">账号设置</string>
+    <string name="account_group_profile">个人信息</string>
+    <string name="account_group_security">安全</string>
+    <string name="account_group_two_factor">双因素验证</string>
+    <string name="account_group_contact">联系方式</string>
+    <string name="account_group_block">屏蔽用户</string>
+    <string name="account_group_preference">常用偏好</string>
+    <string name="account_group_homepage">首页版块</string>
+    <string name="account_avatar">头像</string>
+    <string name="account_bio">Bio</string>
+    <string name="account_signature">签名</string>
+    <string name="account_signature_value">帖子内容下显示 · 支持 Markdown</string>
+    <string name="account_readme">Readme</string>
+    <string name="account_readme_value">%1$d 字</string>
+    <string name="account_password">修改密码</string>
+    <string name="account_two_factor">两步验证（2FA）</string>
+    <string name="account_email">邮箱</string>
+    <string name="account_block_list">已屏蔽列表</string>
+    <string name="account_preference">浏览与显示偏好</string>
+    <string name="account_homepage_boards">首页显示的版块</string>
+    <string name="account_web_only">这些设置只在网页端可改，点开会跳到站点对应的分组。App 内的显示偏好在「设置」里。</string>
+
+    <!-- Follows and followers (8c) -->
+    <string name="follow_title">关注与粉丝</string>
+    <string name="follow_tab_following">我的关注</string>
+    <string name="follow_tab_followers">我的粉丝</string>
+    <string name="follow_end_following">已经到底了 · 共 %1$d 位关注</string>
+    <string name="follow_end_followers">已经到底了 · 共 %1$d 位粉丝</string>
+    <string name="follow_empty_following_title">还没有关注任何人</string>
+    <string name="follow_empty_following_body">关注过的用户会出现在这里</string>
+    <string name="follow_empty_followers_title">暂时没有用户关注您</string>
+    <string name="follow_empty_followers_body">关注你的用户会出现在这里</string>
+
+    <!-- Image viewer (8h) -->
+    <string name="viewer_page">%1$d / %2$d</string>
+    <string name="viewer_save">保存</string>
+    <string name="viewer_saved">已保存到相册</string>
+    <string name="viewer_save_failed">保存失败，稍后再试</string>
+    <string name="viewer_save_unsupported">Android 10 以下不能免权限写相册，可用「分享」发到其他应用</string>
+    <string name="viewer_load_failed">图片加载失败</string>
+
+    <!-- Community tools (9a) -->
+    <string name="tools_title">社区工具</string>
+    <string name="tools_group_browse">逛</string>
+    <string name="tools_group_play">玩</string>
+    <string name="tools_group_watch">看</string>
+    <string name="tools_award">推荐阅读</string>
+    <string name="tools_award_subtitle">加精帖列表 · 与首页同款</string>
+    <string name="tools_providers">合作商家</string>
+    <string name="tools_providers_subtitle">商家列表 · 官网外链跳转</string>
+    <string name="tools_friends">友站</string>
+    <string name="tools_friends_subtitle">友情站点列表 · 网页打开</string>
+    <string name="tools_lucky">幸运抽奖</string>
+    <string name="tools_lucky_subtitle">T 楼抽奖公证工具 · 生成开奖链接</string>
+    <string name="tools_invite">邀请好友</string>
+    <string name="tools_invite_subtitle">花费 1000 鸡腿购买一个邀请码</string>
+    <string name="tools_ruling">管理记录</string>
+    <string name="tools_ruling_subtitle">处罚与奖励公示表格</string>
+    <string name="tools_footnote">工具都从这里进，不占用底部四项主导航；副文案只写形态，不写实时数字。</string>
+
+    <!-- Curated reading (9b) -->
+    <string name="award_title">推荐阅读</string>
+    <string name="award_empty">还没有加精的帖子</string>
+
+    <!-- Lucky draw (9c) -->
+    <string name="lucky_title">幸运抽奖</string>
+    <string name="lucky_intro">T 楼抽奖公证工具：填入帖子参数生成公开链接，任何人都能打开验证开奖结果。不消耗鸡腿或星辰。</string>
+    <string name="lucky_post_id">主题帖 ID</string>
+    <string name="lucky_draw_time">开奖时间</string>
+    <string name="lucky_prize_count">奖品数目</string>
+    <string name="lucky_start_floor">起始楼层</string>
+    <string name="lucky_dedupe">楼层去重</string>
+    <string name="lucky_dedupe_hint">同一用户多个楼层只算一次</string>
+    <string name="lucky_generate">生成抽奖链接</string>
+    <string name="lucky_principle">抽奖如何保证公平？查看原理</string>
+    <string name="lucky_result">生成结果</string>
+    <string name="lucky_open_web">打开网页查看开奖</string>
+    <string name="lucky_result_hint">把链接贴进帖子正文即可公示；到开奖时间后同一链接展示中奖楼层。</string>
+    <string name="lucky_link_copied">链接已复制</string>
+    <string name="lucky_pick_date">选择开奖日期</string>
+    <string name="lucky_pick_time">选择开奖时间</string>
+    <string name="lucky_needs_post_id">先填帖子 ID 才能生成链接</string>
+
+    <!-- Invite (9d) -->
+    <string name="invite_title">邀请好友</string>
+    <string name="invite_body">NodeSeek 注册需要邀请码。购买后会生成一个邀请码，发给朋友即可注册。</string>
+    <string name="invite_buy">花费 1000 鸡腿购买一个邀请码</string>
+    <string name="invite_confirm_title">确认花费 1000 鸡腿？</string>
+    <string name="invite_cost">花费</string>
+    <string name="invite_cost_value">1000 鸡腿</string>
+    <string name="invite_balance_after">购买后余额</string>
+    <string name="invite_caution">邀请码一经生成即扣除鸡腿，无法退还；一个邀请码只能注册一个账号。</string>
+    <string name="invite_confirm">确认购买</string>
+    <string name="invite_shortfall">还差 %1$d 鸡腿</string>
+    <string name="invite_opened_web">App 还没有对接购码接口，已在网页中打开邀请页。</string>
+    <string name="invite_chicken_balance">当前鸡腿 %1$d</string>
+
+    <!-- Moderation log (9d) -->
+    <string name="ruling_title">管理记录</string>
+    <string name="ruling_subtitle">处罚与奖励公示</string>
+    <string name="ruling_target_kind"> 的%1$s</string>
+    <string name="ruling_reason"> · 因「%1$s」</string>
+    <string name="ruling_meta">%1$s · 管理员 %2$s · %3$s</string>
+    <string name="ruling_meta_no_moderator">%1$s · %2$s</string>
+
+    <!-- Profile menu entries added by the 8/9 batch -->
+    <string name="profile_space">我的主页</string>
+    <string name="profile_assets">账户与成长</string>
+    <string name="profile_follow">关注与粉丝</string>
+    <string name="profile_tools">社区工具</string>
+    <string name="profile_account_settings">账号设置</string>
 </resources>

--- a/app/src/test/java/io/github/nsreader/core/LuckyDrawTest.kt
+++ b/app/src/test/java/io/github/nsreader/core/LuckyDrawTest.kt
@@ -1,0 +1,80 @@
+package io.github.nsreader.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneId
+
+/**
+ * The draw link is pasted into a public thread and opened by other people, so its shape is a contract.
+ *
+ * A fixed zone rather than the device's: the formatted closing time is part of the URL, and a test that
+ * passes only in UTC+8 would hide the bug where it does not.
+ */
+class LuckyDrawTest {
+    private val shanghai = ZoneId.of("Asia/Shanghai")
+
+    // 2026-07-27 20:00 +08:00
+    private val drawAt = 1_785_153_600_000L
+
+    @Test
+    fun `builds the link with the five parameters the site's form has`() {
+        val link =
+            LuckyDraw.link(
+                LuckyDrawParams(
+                    postId = 286417,
+                    drawAtMillis = drawAt,
+                    prizeCount = 3,
+                    startFloor = 1,
+                    dedupeFloors = true,
+                ),
+                zone = shanghai,
+            )
+
+        assertEquals(
+            "https://www.nodeseek.com/lucky?post=286417&time=2026-07-27%2020%3A00&n=3&start=1&unique=1",
+            link,
+        )
+    }
+
+    @Test
+    fun `writes dedupe off as zero rather than omitting it`() {
+        val link =
+            LuckyDraw.link(
+                LuckyDrawParams(
+                    postId = 1,
+                    drawAtMillis = drawAt,
+                    prizeCount = 1,
+                    startFloor = 0,
+                    dedupeFloors = false,
+                ),
+                zone = shanghai,
+            )
+
+        assertTrue(link.endsWith("&start=0&unique=0"))
+    }
+
+    /** A zero prize count would produce a draw nobody can win; the builder floors it at one. */
+    @Test
+    fun `never generates a draw with no prizes`() {
+        val link =
+            LuckyDraw.link(
+                LuckyDrawParams(
+                    postId = 9,
+                    drawAtMillis = drawAt,
+                    prizeCount = 0,
+                    startFloor = -4,
+                    dedupeFloors = true,
+                ),
+                zone = shanghai,
+            )
+
+        assertTrue(link.contains("&n=1&"))
+        assertTrue(link.contains("&start=0&"))
+    }
+
+    @Test
+    fun `formats the closing time the way the form displays it`() {
+        assertEquals("2026/7/27 20:00", LuckyDraw.formatDrawTime(drawAt, shanghai))
+    }
+}

--- a/app/src/test/java/io/github/nsreader/core/html/PostListParserTest.kt
+++ b/app/src/test/java/io/github/nsreader/core/html/PostListParserTest.kt
@@ -41,6 +41,25 @@ class PostListParserTest {
         assertTrue(page.hasNextPage)
     }
 
+    /** The last pager position renders as "..100"; the digits are the total. */
+    @Test
+    fun `reads the page total from the pager`() {
+        assertEquals(100, page.totalPages)
+    }
+
+    /** A pager whose positions carry no digits must degrade to the page we are on, not to 1. */
+    @Test
+    fun `falls back to the current page when the pager is unreadable`() {
+        val html =
+            """
+            <html><body><div role="navigation" aria-label="pagination">
+              <span class="pager-pos pager-cur">…</span>
+            </div></body></html>
+            """.trimIndent()
+
+        assertEquals(3, PostListParser.parse(html, page = 3).totalPages)
+    }
+
     @Test
     fun `every row carries an id, title and author`() {
         page.posts.forEach { post ->

--- a/app/src/test/java/io/github/nsreader/data/AssetsRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/AssetsRepositoryTest.kt
@@ -1,0 +1,120 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.AppDispatchers
+import io.github.nsreader.core.net.JsonPostResponse
+import io.github.nsreader.core.net.JsonSource
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.net.NodeSeekJsonClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the attendance contract verified on the live site — above all the quirk that a repeat
+ * sign-in answers **HTTP 500 with a meaningful JSON body**. A cleanup that checks the status before
+ * the body would silently break repeat-sign-in messaging; these tests are what would fail instead.
+ */
+class AssetsRepositoryTest {
+    private val dispatchers =
+        AppDispatchers(io = Dispatchers.Unconfined, default = Dispatchers.Unconfined)
+
+    private fun repository(source: JsonSource) =
+        NetworkAssetsRepository(UnusedProfileRepository, source, dispatchers)
+
+    @Test
+    fun `parses a successful sign-in and requests the chosen mode`() =
+        runTest {
+            val source =
+                FakePostJsonSource(
+                    code = 200,
+                    body = """{"success":true,"message":"签到收益5个鸡腿","gain":5,"current":344}""",
+                )
+
+            val result = repository(source).signInForToday(AttendanceMode.RANDOM)
+
+            assertEquals(NodeSeekJsonClient.attendancePath("true"), source.requestedPath)
+            assertEquals(5, result.gain)
+            assertEquals("签到收益5个鸡腿", result.message)
+        }
+
+    /** The live site answers a repeat sign-in with HTTP 500 plus the sentence the user needs. */
+    @Test
+    fun `reports the repeat sign-in sentence despite its 500 status`() =
+        runTest {
+            val source =
+                FakePostJsonSource(
+                    code = 500,
+                    body = """{"success":false,"message":"今天已完成签到，请勿重复操作"}""",
+                )
+
+            val result = repository(source).signInForToday(AttendanceMode.FIXED_FIVE)
+
+            assertEquals("今天已完成签到，请勿重复操作", result.message)
+            assertNull(result.gain)
+        }
+
+    /** `current` carries the account balance; showing it as today's gain would be worse than nothing. */
+    @Test
+    fun `never mistakes the balance for the day's gain`() =
+        runTest {
+            val source =
+                FakePostJsonSource(
+                    code = 200,
+                    body = """{"success":true,"message":"已签到","current":4071}""",
+                )
+
+            val result = repository(source).signInForToday(AttendanceMode.RANDOM)
+
+            assertNull(result.gain)
+        }
+
+    /** A bare refusal carries nothing to show, so it must not read as a completed sign-in. */
+    @Test
+    fun `treats a bare refusal as unparsable rather than success`() =
+        runTest {
+            val source = FakePostJsonSource(code = 200, body = """{"success":false}""")
+
+            val exception =
+                runCatching { repository(source).signInForToday(AttendanceMode.RANDOM) }
+                    .exceptionOrNull()
+
+            assertEquals(NodeSeekError.Unparsable, (exception as? NodeSeekException)?.error)
+        }
+
+    @Test
+    fun `maps an unauthenticated sign-in to LoginRequired`() =
+        runTest {
+            val source = FakePostJsonSource(code = 401, body = "")
+
+            val exception =
+                runCatching { repository(source).signInForToday(AttendanceMode.RANDOM) }
+                    .exceptionOrNull()
+
+            assertEquals(NodeSeekError.LoginRequired, (exception as? NodeSeekException)?.error)
+        }
+}
+
+private class FakePostJsonSource(
+    private val code: Int,
+    private val body: String,
+) : JsonSource {
+    var requestedPath: String? = null
+        private set
+
+    override suspend fun getJson(path: String, referer: String): String =
+        error("These tests only POST")
+
+    override suspend fun postJson(path: String, referer: String): JsonPostResponse {
+        requestedPath = path
+        return JsonPostResponse(code, body)
+    }
+}
+
+private object UnusedProfileRepository : ProfileRepository {
+    override suspend fun profile(refresh: Boolean): UserProfile = error("These tests never load a profile")
+
+    override suspend fun profile(uid: Long): UserProfile = error("These tests never load a profile")
+}

--- a/app/src/test/java/io/github/nsreader/data/ProfileRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/ProfileRepositoryTest.kt
@@ -1,5 +1,6 @@
 package io.github.nsreader.data
 
+import io.github.nsreader.core.AppClock
 import io.github.nsreader.core.html.Fixtures
 import io.github.nsreader.core.net.HtmlSource
 import io.github.nsreader.core.net.JsonSource
@@ -26,6 +27,7 @@ class ProfileRepositoryTest {
                 NetworkProfileRepository(
                     htmlSource = FakeProfileHtmlSource(Fixtures.load("page-1.html")),
                     jsonSource = jsonSource,
+                    clock = AppClock { 0L },
                 )
 
             val profile = repository.profile()
@@ -49,6 +51,7 @@ class ProfileRepositoryTest {
                     FakeProfileJsonSource(
                         error = NodeSeekException(NodeSeekError.Http(500)),
                     ),
+                    clock = AppClock { 0L },
                 )
 
             val profile = repository.profile()
@@ -60,12 +63,33 @@ class ProfileRepositoryTest {
             assertEquals(2, profile.starCount)
         }
 
+    /** The profile-area screens each ask on entry; a minute-long cache keeps that to one fetch. */
+    @Test
+    fun `serves repeat profile calls from the cache until refreshed`() =
+        runTest {
+            val htmlSource = FakeProfileHtmlSource(Fixtures.load("page-1.html"))
+            val repository =
+                NetworkProfileRepository(
+                    htmlSource = htmlSource,
+                    jsonSource = FakeProfileJsonSource(error = NodeSeekException(NodeSeekError.Http(500))),
+                    clock = AppClock { 0L },
+                )
+
+            repository.profile()
+            repository.profile()
+            assertEquals(1, htmlSource.callCount)
+
+            repository.profile(refresh = true)
+            assertEquals(2, htmlSource.callCount)
+        }
+
     @Test(expected = NodeSeekException::class)
     fun `rejects a page without signed in profile data`() =
         runTest {
             NetworkProfileRepository(
                 htmlSource = FakeProfileHtmlSource("<html><body></body></html>"),
                 jsonSource = FakeProfileJsonSource(response = "{}"),
+                clock = AppClock { 0L },
             ).profile()
         }
 }
@@ -73,7 +97,13 @@ class ProfileRepositoryTest {
 private class FakeProfileHtmlSource(
     private val response: String,
 ) : HtmlSource {
-    override suspend fun getHtml(path: String): String = response
+    var callCount = 0
+        private set
+
+    override suspend fun getHtml(path: String): String {
+        callCount++
+        return response
+    }
 }
 
 private class FakeProfileJsonSource(

--- a/app/src/test/java/io/github/nsreader/data/UserSpaceRepositoryTest.kt
+++ b/app/src/test/java/io/github/nsreader/data/UserSpaceRepositoryTest.kt
@@ -1,0 +1,178 @@
+package io.github.nsreader.data
+
+import io.github.nsreader.core.AppDispatchers
+import io.github.nsreader.core.net.JsonSource
+import io.github.nsreader.core.net.NodeSeekError
+import io.github.nsreader.core.net.NodeSeekException
+import io.github.nsreader.core.net.NodeSeekJsonClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * These endpoints are the site's own XHRs, not a published API, so the repository reads fields by
+ * candidate name. What the tests pin down is the tolerance itself: a renamed key must not empty a tab,
+ * and a payload we cannot recognise at all must be reported rather than shown as "nothing here".
+ */
+class UserSpaceRepositoryTest {
+    private val dispatchers =
+        AppDispatchers(io = Dispatchers.Unconfined, default = Dispatchers.Unconfined)
+
+    @Test
+    fun `reads topics wrapped in a data envelope`() =
+        runTest {
+            val source =
+                FakeSpaceJsonSource(
+                    """
+                    {"success":true,"data":{"discussions":[
+                      {"post_id":286417,"title":"第一次用 nftables 做端口转发","category":"tech",
+                       "category_title":"技术","comments":12,"views":843,"created_at_str":"3天前"}
+                    ],"totalPage":1}}
+                    """.trimIndent(),
+                )
+            val repository = NetworkUserSpaceRepository(source, dispatchers)
+
+            val page = repository.topics(uid = 12043, page = 1)
+
+            assertEquals(NodeSeekJsonClient.discussionListPath(12043, 1), source.requestedPath)
+            assertEquals(1, page.items.size)
+            val topic = page.items.first()
+            assertEquals(286417L, topic.postId)
+            assertEquals("第一次用 nftables 做端口转发", topic.title)
+            assertEquals("技术", topic.categoryTitle)
+            assertEquals("tech", topic.categorySlug)
+            assertEquals(12, topic.commentCount)
+            assertEquals(843, topic.viewCount)
+            assertFalse(page.hasNextPage)
+        }
+
+    /** `pid` / `nComment` / `click` are the other spellings the site uses for the same three fields. */
+    @Test
+    fun `accepts the alternative field names and string ids`() =
+        runTest {
+            val source =
+                FakeSpaceJsonSource(
+                    """
+                    {"postList":[
+                      {"pid":"9001","subject":"标题","nComment":"7","click":"120"}
+                    ]}
+                    """.trimIndent(),
+                )
+
+            val topic = NetworkUserSpaceRepository(source, dispatchers).topics(1, 1).items.single()
+
+            assertEquals(9001L, topic.postId)
+            assertEquals("标题", topic.title)
+            assertEquals(7, topic.commentCount)
+            assertEquals(120, topic.viewCount)
+        }
+
+    @Test
+    fun `flattens comment markup into a one line excerpt`() =
+        runTest {
+            val source =
+                FakeSpaceJsonSource(
+                    """
+                    {"comments":[
+                      {"post_id":700,"comment_id":866042,"post_title":"求教如何改用户名",
+                       "content":"<p>还没有这个功能，其实可以考虑<strong>花费星辰</strong></p>",
+                       "created_at_str":"19小时前"}
+                    ]}
+                    """.trimIndent(),
+                )
+
+            val comment = NetworkUserSpaceRepository(source, dispatchers).comments(1, 1).items.single()
+
+            assertEquals(700L, comment.postId)
+            assertEquals(866042L, comment.commentId)
+            assertEquals("还没有这个功能，其实可以考虑花费星辰", comment.excerpt)
+        }
+
+    /** An empty list is a real answer and must not look like a failure. */
+    @Test
+    fun `treats an empty list as an empty tab`() =
+        runTest {
+            val page =
+                NetworkUserSpaceRepository(FakeSpaceJsonSource("""{"discussions":[]}"""), dispatchers)
+                    .topics(1, 1)
+
+            assertTrue(page.items.isEmpty())
+            assertFalse(page.hasNextPage)
+        }
+
+    @Test
+    fun `reports an unrecognisable payload instead of showing it as empty`() =
+        runTest {
+            val exception =
+                runCatching {
+                    NetworkUserSpaceRepository(FakeSpaceJsonSource("""{"success":false}"""), dispatchers)
+                        .collections(1)
+                }.exceptionOrNull()
+
+            assertEquals(NodeSeekError.Unparsable, (exception as? NodeSeekException)?.error)
+        }
+
+    /** With no paging metadata, a full-looking page is assumed to have a successor. */
+    @Test
+    fun `offers a next page when the response fills one`() =
+        runTest {
+            val rows = (1..20).joinToString(",") { """{"post_id":$it,"title":"t$it"}""" }
+            val page =
+                NetworkUserSpaceRepository(FakeSpaceJsonSource("""{"list":[$rows]}"""), dispatchers)
+                    .collections(1)
+
+            assertEquals(20, page.items.size)
+            assertTrue(page.hasNextPage)
+        }
+
+    /**
+     * Regression: guessing "no more pages" from a row-count threshold silently truncated every list
+     * whose real page size was below the guess. Any non-empty page without metadata offers more.
+     */
+    @Test
+    fun `offers a next page even when a metadata-less page is short`() =
+        runTest {
+            val rows = (1..3).joinToString(",") { """{"post_id":$it,"title":"t$it"}""" }
+            val page =
+                NetworkUserSpaceRepository(FakeSpaceJsonSource("""{"list":[$rows]}"""), dispatchers)
+                    .collections(1)
+
+            assertEquals(3, page.items.size)
+            assertTrue(page.hasNextPage)
+        }
+
+    /**
+     * Regression: with several unrecognised arrays the walk must not gamble on one — handing back a
+     * sibling block (badges, a pager) would render a confident empty tab from the wrong array.
+     */
+    @Test
+    fun `refuses to choose between several unrecognised arrays`() =
+        runTest {
+            val payload =
+                """
+                {"badges":[{"badge_id":1,"label":"元老"}],
+                 "rows":[{"post_id":1,"title":"t1"}]}
+                """.trimIndent()
+            val exception =
+                runCatching {
+                    NetworkUserSpaceRepository(FakeSpaceJsonSource(payload), dispatchers).collections(1)
+                }.exceptionOrNull()
+
+            assertEquals(NodeSeekError.Unparsable, (exception as? NodeSeekException)?.error)
+        }
+}
+
+private class FakeSpaceJsonSource(
+    private val response: String,
+) : JsonSource {
+    var requestedPath: String? = null
+        private set
+
+    override suspend fun getJson(path: String, referer: String): String {
+        requestedPath = path
+        return response
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/common/NumericPagerTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/common/NumericPagerTest.kt
@@ -1,0 +1,41 @@
+package io.github.nsreader.ui.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The pager has to stay one row wide at 104 pages while always offering page 1, the neighbours of the
+ * current page, and the last page. `null` is the ellipsis.
+ */
+class NumericPagerTest {
+    @Test
+    fun `shows every page when they fit`() {
+        assertEquals(listOf(1, 2, 3, 4, 5), pageWindow(page = 2, totalPages = 5))
+    }
+
+    @Test
+    fun `collapses the middle on the first page`() {
+        assertEquals(listOf(1, 2, 3, null, 104), pageWindow(page = 1, totalPages = 104))
+    }
+
+    @Test
+    fun `keeps the head, the neighbours and the tail`() {
+        assertEquals(listOf(1, 2, 3, null, 49, 50, 51, null, 104), pageWindow(page = 50, totalPages = 104))
+    }
+
+    @Test
+    fun `has no gap when the current page adjoins the head`() {
+        assertEquals(listOf(1, 2, 3, 4, null, 104), pageWindow(page = 3, totalPages = 104))
+    }
+
+    @Test
+    fun `has no trailing gap on the last page`() {
+        assertEquals(listOf(1, 2, 3, null, 103, 104), pageWindow(page = 104, totalPages = 104))
+    }
+
+    /** A page number from a restored state can be out of range; it must not drop the pager's tail. */
+    @Test
+    fun `clamps a page outside the range`() {
+        assertEquals(listOf(1, 2, 3, null, 17, 18), pageWindow(page = 999, totalPages = 18))
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/postdetail/PostDetailImagesTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/postdetail/PostDetailImagesTest.kt
@@ -1,0 +1,86 @@
+package io.github.nsreader.ui.postdetail
+
+import io.github.nsreader.model.InlineNode
+import io.github.nsreader.model.PostContent
+import io.github.nsreader.model.RichNode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The image viewer pages through whatever this returns, so its order *is* the "2 / 4" the user reads.
+ */
+class PostDetailImagesTest {
+    private fun content(vararg nodes: RichNode) =
+        PostContent(
+            commentId = null,
+            floor = null,
+            authorName = "tester",
+            authorUid = null,
+            avatarUrl = null,
+            isOriginalPoster = false,
+            badges = emptyList(),
+            createdAtText = null,
+            createdAtTitle = null,
+            categoryTitle = null,
+            nodes = nodes.toList(),
+        )
+
+    private fun image(url: String) = RichNode.BlockImage(url = url, alt = null)
+
+    @Test
+    fun `collects images from the body then the comments in reading order`() {
+        val state =
+            PostDetailUiState(
+                body = content(image("a.png"), RichNode.Divider, image("b.png")),
+                comments = listOf(content(image("c.png")), content(image("d.png"))),
+            )
+
+        assertEquals(listOf("a.png", "b.png", "c.png", "d.png"), state.imageUrls())
+    }
+
+    @Test
+    fun `reaches images nested in quotes and lists`() {
+        val state =
+            PostDetailUiState(
+                body =
+                content(
+                    RichNode.Quote(children = listOf(image("quoted.png"))),
+                    RichNode.ListBlock(ordered = false, items = listOf(listOf(image("listed.png")))),
+                ),
+            )
+
+        assertEquals(listOf("quoted.png", "listed.png"), state.imageUrls())
+    }
+
+    /** A screenshot quoted by three people is one image, or the page count would lie. */
+    @Test
+    fun `keeps one entry per url`() {
+        val state =
+            PostDetailUiState(
+                body = content(image("same.png")),
+                comments = listOf(content(image("same.png")), content(image("other.png"))),
+            )
+
+        assertEquals(listOf("same.png", "other.png"), state.imageUrls())
+    }
+
+    @Test
+    fun `ignores inline stickers`() {
+        val state =
+            PostDetailUiState(
+                body =
+                content(
+                    RichNode.Paragraph(
+                        inlines =
+                        listOf(
+                            InlineNode.Text("哈哈"),
+                            InlineNode.Sticker(url = "sticker.gif", alt = "笑"),
+                        ),
+                    ),
+                    image("real.png"),
+                ),
+            )
+
+        assertEquals(listOf("real.png"), state.imageUrls())
+    }
+}

--- a/app/src/test/java/io/github/nsreader/ui/profile/ProfileScreenTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/profile/ProfileScreenTest.kt
@@ -36,7 +36,11 @@ class ProfileScreenTest {
                     onRetry = {},
                     onSettings = {},
                     onOpenWebsite = {},
-                    onEditProfile = {},
+                    onOpenSpace = {},
+                    onAssets = {},
+                    onFollow = {},
+                    onTools = {},
+                    onAccountSettings = {},
                 )
             }
         }
@@ -60,7 +64,11 @@ class ProfileScreenTest {
                     onRetry = {},
                     onSettings = {},
                     onOpenWebsite = {},
-                    onEditProfile = {},
+                    onOpenSpace = {},
+                    onAssets = {},
+                    onFollow = {},
+                    onTools = {},
+                    onAccountSettings = {},
                 )
             }
         }
@@ -69,7 +77,7 @@ class ProfileScreenTest {
     }
 
     @Test
-    fun `edit profile button invokes its callback`() {
+    fun `header avatar action opens the space page`() {
         var clicked = false
         composeRule.setContent {
             NodeSeekTheme {
@@ -80,12 +88,16 @@ class ProfileScreenTest {
                     onRetry = {},
                     onSettings = {},
                     onOpenWebsite = {},
-                    onEditProfile = { clicked = true },
+                    onOpenSpace = { clicked = true },
+                    onAssets = {},
+                    onFollow = {},
+                    onTools = {},
+                    onAccountSettings = {},
                 )
             }
         }
 
-        composeRule.onNodeWithContentDescription("编辑个人主页").performClick()
+        composeRule.onNodeWithContentDescription("我的主页").performClick()
 
         check(clicked)
     }

--- a/app/src/test/java/io/github/nsreader/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/profile/ProfileViewModelTest.kt
@@ -106,10 +106,12 @@ private class FakeProfileRepository(
     private val profile: UserProfile? = null,
     private val error: Throwable? = null,
 ) : ProfileRepository {
-    override suspend fun profile(): UserProfile {
+    override suspend fun profile(refresh: Boolean): UserProfile {
         error?.let { throw it }
         return requireNotNull(profile)
     }
+
+    override suspend fun profile(uid: Long): UserProfile = profile()
 }
 
 private object NoOpPostRepository : PostRepository {

--- a/app/src/test/java/io/github/nsreader/ui/space/JoinedDaysTest.kt
+++ b/app/src/test/java/io/github/nsreader/ui/space/JoinedDaysTest.kt
@@ -1,0 +1,45 @@
+package io.github.nsreader.ui.space
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * 加入天数 is the site's headline statistic for an account, and the endpoint gives it in two shapes.
+ *
+ * The expected values are derived from the same clock the code reads, so the test does not go stale a
+ * day after it is written.
+ */
+class JoinedDaysTest {
+    private val now = 1_784_000_000_000L
+    private val today: LocalDate =
+        java.time.Instant.ofEpochMilli(now).atZone(ZoneId.systemDefault()).toLocalDate()
+
+    @Test
+    fun `counts days from an ISO instant`() {
+        val joined = today.minusDays(143)
+        assertEquals(143, joinedDays("${joined}T14:29:22.000Z", now))
+    }
+
+    @Test
+    fun `counts days from a plain date`() {
+        val joined = today.minusDays(7)
+        assertEquals(7, joinedDays(joined.toString(), now))
+    }
+
+    @Test
+    fun `returns null rather than a wrong number for an unusable value`() {
+        assertNull(joinedDays(null, now))
+        assertNull(joinedDays("", now))
+        assertNull(joinedDays("昨天", now))
+        assertNull(joinedDays("2026-13-45", now))
+    }
+
+    /** A registration date in the future is a clock disagreement, not a negative age. */
+    @Test
+    fun `never reports a negative age`() {
+        assertEquals(0, joinedDays(today.plusDays(3).toString(), now))
+    }
+}


### PR DESCRIPTION
## 问题与方案

本批实现个人区的纵向功能集，并落实随后两轮代码审查的全部 22 项确认发现。

**新增功能**
- 我的主页（概况 / 主题 / 评论 / 收藏 tab，`/api/content` 与 `/api/statistics` XHR 端点）
- 关注/粉丝（端点未知，NotWired 哨兵占位 + 网页回退）
- 账户与成长、星辰（余额、成长进度、签到板）、原生签到（`/api/attendance`）
- 社区工具：邀请好友、抽奖公证（LuckyDraw 链接生成）、送分贴、处刑记录
- 全屏图片查看器：缩放/双击/下滑关闭、翻页、保存相册、分享
- 共享组件：GroupedRows、NumericPager、SpendConfirmDialog、JsonFields 候选键读取器

**审查修复要点**（第一轮 10 项 + 第二轮 12 项）
- 正确性：签到失败响应误报成功、Cloudflare「去验证」误走外部浏览器、双栏首页旋转丢失在读帖子与 pane ViewModel 无限累积、星辰转账 uid 未就绪跳首页、500-未登录契约落地为共享客户端映射、搜索打开自己主页 isSelf 错误、保存失败误报已保存、分页静默截断、多候选数组拒绝
- 机制统一：`JsonSource.postJson`（统一 XHR 头与挑战分类，含 cf-mitigated 头检查）、`NodeSeekErrorState` 增加 `onSignIn`/`onVerify` 参数并删除 10+ 处手写分支、`profile()` 60 秒 TTL 缓存 + `refresh` 旁路
- 规范：图片保存迁入 ImageViewerViewModel（UDF）、注入 AppDispatchers、保存优先流式拷贝 Coil 磁盘缓存原始字节（保留原格式，PNG 重编码仅兜底）

## 审阅者须知（按仓库规约显式声明）

- **会话相关**：新增 `WebViewGoal.MANAGE`，认证 WebView 现用于私信、鸡腿流水、星辰转账、账户设置页；`isTrustedWebViewUrl` 域名白名单**未变更**。`postJson` 复用既有 OkHttp Cookie 桥。
- **抓取选择器**：无新增选择器；`PostListParser.totalPages` 解析改为提取页码内数字（站点渲染 `..100` 形态）。
- **Room schema / 依赖锁**：无变更。
- UI 截图：本会话在无模拟器环境完成，未附前后截图，建议合并前在模拟器上过一遍主要新屏幕（沙箱 curl 会被 Cloudflare 403，需真机/模拟器验证真实报文形状，尤其签到 gain 字段与空间列表真实页大小）。

## 验证

- `./gradlew :app:testDebugUnitTest` — 214 项通过（新增：签到 500-携带-成功怪癖 5 例、分页短页/多候选拒绝 2 例、profile 缓存 1 例、pager 总页数/退化 2 例等）
- `./gradlew spotlessCheck` — 通过
- `./gradlew :app:lintDebug` — 通过（警告即错）

🤖 Generated with [Claude Code](https://claude.com/claude-code)