### PR TITLE
把自造实现换回官方组件，编辑器迁到 TextFieldState

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,22 @@ android {
     }
 
     buildTypes {
+        /*
+         * A separate applicationId so a debug build and an installed release build can coexist.
+         *
+         * The two are signed with different keys, and Android refuses to replace an APK with one
+         * whose signature differs — the only ways out are uninstalling the release copy first or
+         * giving the debug build an id of its own. This is the second.
+         *
+         * Safe to suffix here because nothing pins the package name: the one manifest authority is
+         * written as `${applicationId}`, `buildConfig` is off so no code reads APPLICATION_ID, and
+         * AGP derives the instrumentation test id from this value too. The launcher name follows in
+         * `src/debug/res/values/strings.xml`, so the two are also told apart on the home screen.
+         */
+        debug {
+            applicationIdSuffix = ".debug"
+        }
+
         release {
             isMinifyEnabled = true
             isShrinkResources = true

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Debug-only overrides of the app's own name.
+
+    A build-type resource wins over the same name in `main`, so the launcher entry, the task switcher
+    and the About screen all read Nodyssey·D without the release build knowing this file exists.
+
+    The name is only half of what keeps the two builds apart — the debug build also carries an
+    `applicationIdSuffix`, which is what actually lets a debug-signed and a release-signed copy be
+    installed at the same time. See `app/build.gradle.kts`.
+-->
+<resources>
+    <string name="app_name">Nodyssey·D</string>
+    <string name="about_app_name">Nodyssey·D</string>
+</resources>

--- a/app/src/main/java/io/github/nodyssey/core/TerminalColumns.kt
+++ b/app/src/main/java/io/github/nodyssey/core/TerminalColumns.kt
@@ -1,0 +1,71 @@
+package io.github.nodyssey.core
+
+/**
+ * Character widths as a terminal counts them.
+ *
+ * The benchmark reports posted in 测评 are laid out by padding with spaces on the assumption that a
+ * CJK glyph or an emoji occupies two cells and everything else one. Any code that has to recover
+ * that layout — measuring how wide a report is, or working out which column a table cell sits under
+ * — has to count the same way, because counting characters instead reports a 80-column report as
+ * fitting in fifty.
+ */
+object TerminalColumns {
+
+    /** Total width of [text] in cells, taking the widest line when it spans several. */
+    fun widthOf(text: String): Int {
+        var widest = 0
+        var current = 0
+        forEachCodePoint(text) { codePoint ->
+            if (codePoint == '\n'.code) {
+                widest = maxOf(widest, current)
+                current = 0
+            } else {
+                current += cellsFor(codePoint)
+            }
+        }
+        return maxOf(widest, current)
+    }
+
+    /**
+     * Column at which the character at [charIndex] of a single line begins.
+     *
+     * Used to line a table's cells up with the header above it: both were padded in cells, so their
+     * character offsets only agree when neither contains CJK.
+     */
+    fun columnAt(line: String, charIndex: Int): Int {
+        var column = 0
+        var index = 0
+        while (index < charIndex && index < line.length) {
+            val codePoint = line.codePointAt(index)
+            column += cellsFor(codePoint)
+            index += Character.charCount(codePoint)
+        }
+        return column
+    }
+
+    private inline fun forEachCodePoint(text: String, action: (Int) -> Unit) {
+        var index = 0
+        while (index < text.length) {
+            val codePoint = text.codePointAt(index)
+            action(codePoint)
+            index += Character.charCount(codePoint)
+        }
+    }
+
+    private fun cellsFor(codePoint: Int): Int = if (isWide(codePoint)) 2 else 1
+
+    private fun isWide(codePoint: Int): Boolean =
+        codePoint in 0x1100..0x115F ||
+            codePoint in 0x2E80..0x303E ||
+            codePoint in 0x3041..0x33FF ||
+            codePoint in 0x3400..0x4DBF ||
+            codePoint in 0x4E00..0x9FFF ||
+            codePoint in 0xA000..0xA4CF ||
+            codePoint in 0xAC00..0xD7A3 ||
+            codePoint in 0xF900..0xFAFF ||
+            codePoint in 0xFE30..0xFE6F ||
+            codePoint in 0xFF00..0xFF60 ||
+            codePoint in 0xFFE0..0xFFE6 ||
+            codePoint in 0x1F300..0x1FAFF ||
+            codePoint in 0x20000..0x3FFFD
+}

--- a/app/src/main/java/io/github/nodyssey/core/html/AnsiParser.kt
+++ b/app/src/main/java/io/github/nodyssey/core/html/AnsiParser.kt
@@ -1,0 +1,167 @@
+package io.github.nodyssey.core.html
+
+import io.github.nodyssey.core.TerminalColumns
+import io.github.nodyssey.model.AnsiSpan
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+
+/**
+ * Recovers the terminal output NodeSeek hides inside `<code class="language-ansi">`.
+ *
+ * The site cannot put a raw `ESC` in its HTML, so it encodes every control character as an empty
+ * `<span data-ansicode="27">` and leaves the rest of the sequence as ordinary text. Jsoup's
+ * `wholeText()` drops empty elements, which is why reading the code element as text yields a stream
+ * with the escapes missing and their parameters left behind — the literal `[36m` that leaks into
+ * the post body today. The fix is to read the element, not its text: [sourceOf] walks the children
+ * and turns each `data-ansicode` back into the character it stands for, and only then is there an
+ * ANSI stream to [decode].
+ */
+object AnsiParser {
+
+    private const val CONTROL_CODE_ATTR = "data-ansicode"
+    private const val ESC = '\u001B'
+
+    /** A CSI sequence runs until the first byte in this range, which also says what it does. */
+    private val FINAL_BYTE = '@'..'~'
+
+    data class Decoded(
+        val text: String,
+        val spans: List<AnsiSpan>,
+        val columns: Int,
+    )
+
+    /** Reassembles the escape-bearing source of a `<pre>`/`<code>` element. */
+    fun sourceOf(element: Element): String = buildString { appendSource(element) }
+
+    private fun StringBuilder.appendSource(node: Node) {
+        for (child in node.childNodes()) {
+            when (child) {
+                is TextNode -> append(child.wholeText)
+
+                is Element -> {
+                    val code = child.attr(CONTROL_CODE_ATTR).toIntOrNull()
+                    // These carry the control character in an attribute and are empty otherwise, so
+                    // recursing into one would add nothing.
+                    if (code != null) append(code.toChar()) else appendSource(child)
+                }
+
+                else -> Unit
+            }
+        }
+    }
+
+    /**
+     * Strips the escape sequences and returns what they were saying about the text they enclosed.
+     *
+     * Ordinary code goes through this unchanged apart from stray control characters, so there is no
+     * need to know in advance whether a block is a terminal report.
+     */
+    fun decode(source: String): Decoded {
+        val text = StringBuilder(source.length)
+        val spans = mutableListOf<AnsiSpan>()
+
+        var fg: Int? = null
+        var bg: Int? = null
+        var bold = false
+        var underline = false
+        var runStart = 0
+
+        fun closeRun() {
+            val end = text.length
+            if (end > runStart && (fg != null || bg != null || bold || underline)) {
+                spans += AnsiSpan(runStart, end, fg, bg, bold, underline)
+            }
+            runStart = end
+        }
+
+        fun applySgr(parameters: String) {
+            // `ESC[m` is `ESC[0m`, and so is any parameter we cannot read.
+            parameters.split(';').forEach { parameter ->
+                when (val code = parameter.trim().toIntOrNull() ?: 0) {
+                    0 -> {
+                        fg = null
+                        bg = null
+                        bold = false
+                        underline = false
+                    }
+
+                    1 -> bold = true
+
+                    4 -> underline = true
+
+                    22 -> bold = false
+
+                    24 -> underline = false
+
+                    39 -> fg = null
+
+                    49 -> bg = null
+
+                    in 30..37 -> fg = code - 30
+
+                    in 40..47 -> bg = code - 40
+
+                    in 90..97 -> fg = code - 90 + BRIGHT_OFFSET
+
+                    in 100..107 -> bg = code - 100 + BRIGHT_OFFSET
+
+                    // Italic is parsed and dropped: Chinese has no italic form, which is the same
+                    // reason `InlineStyle.italic` becomes weight rather than slant.
+                    else -> Unit
+                }
+            }
+        }
+
+        var index = 0
+        while (index < source.length) {
+            val char = source[index]
+            when {
+                char == ESC && source.getOrNull(index + 1) == '[' -> {
+                    var end = index + 2
+                    while (end < source.length && source[end] !in FINAL_BYTE) end++
+                    // A sequence running off the end of the source is truncated output, and the
+                    // parameters behind it are not text either.
+                    if (end >= source.length) break
+
+                    if (source[end] == 'm') {
+                        closeRun()
+                        applySgr(source.substring(index + 2, end))
+                    }
+                    index = end + 1
+                }
+
+                char == '\n' || char == '\t' -> {
+                    text.append(char)
+                    index++
+                }
+
+                // Backspace, carriage return and the rest are overstrike instructions a Compose
+                // text layout cannot honour; drawn literally they are worse than absent.
+                char.code < 0x20 || char.code == 0x7F -> index++
+
+                else -> {
+                    text.append(char)
+                    index++
+                }
+            }
+        }
+        closeRun()
+
+        val trimmed = text.toString().trimEnd()
+        return Decoded(
+            text = trimmed,
+            spans = spans.mapNotNull { span -> span.clampedTo(trimmed.length) },
+            columns = TerminalColumns.widthOf(trimmed),
+        )
+    }
+
+    private fun AnsiSpan.clampedTo(length: Int): AnsiSpan? = when {
+        start >= length -> null
+        end > length -> copy(end = length)
+        else -> this
+    }
+
+    /** Palette indices 8–15 are the bright half of the sixteen. */
+    private const val BRIGHT_OFFSET = 8
+}

--- a/app/src/main/java/io/github/nodyssey/core/html/RichContentParser.kt
+++ b/app/src/main/java/io/github/nodyssey/core/html/RichContentParser.kt
@@ -18,6 +18,17 @@ object RichContentParser {
     /** NodeSeek's built-in emoji are `<img class="sticker">` and must stay inline with the text. */
     private const val STICKER_CLASS = "sticker"
 
+    /**
+     * The site's own tab extension, which the review board uses for benchmark reports.
+     *
+     * The titles and the bodies are siblings rather than nested — the site's stylesheet pairs each
+     * title with the body that immediately follows it — so the grouping only exists if the parser
+     * reconstructs it.
+     */
+    private const val MAGIC_TABS_CLASS = "nsk-magic-tabs"
+    private const val TAB_TITLE_CLASS = "nsk-magic-tab-title"
+    private const val TAB_BODY_CLASS = "nsk-magic-tab-body"
+
     fun parse(article: Element?): List<RichNode> {
         if (article == null) return emptyList()
         return parseBlocks(article.childNodes())
@@ -80,10 +91,10 @@ object RichContentParser {
         "table" -> listOf(table(element))
 
         "div" ->
-            if (element.hasClass("quote")) {
-                listOf(RichNode.Quote(parseBlocks(element.childNodes())))
-            } else {
-                paragraphBlocks(element)
+            when {
+                element.hasClass("quote") -> listOf(RichNode.Quote(parseBlocks(element.childNodes())))
+                element.hasClass(MAGIC_TABS_CLASS) -> magicTabs(element)
+                else -> paragraphBlocks(element)
             }
 
         "img" -> if (isSticker(element)) null else listOf(blockImage(element))
@@ -134,15 +145,64 @@ object RichContentParser {
         return RichNode.BlockImage(url = url, alt = element.attr("alt").ifBlank { null })
     }
 
+    /**
+     * Splits a `nsk-magic-tabs` group back into titled tabs.
+     *
+     * Anything that is neither a title nor a body joins the tab being built — the site's own
+     * stylesheet writes off such children as an authoring mistake, and dropping them here would
+     * lose post content over one.
+     */
+    private fun magicTabs(element: Element): List<RichNode> {
+        val tabs = mutableListOf<RichNode.Tabs.Tab>()
+        // Content before the first title belongs to no tab, and is kept ahead of the group.
+        val orphans = mutableListOf<Node>()
+        var title: String? = null
+        val body = mutableListOf<Node>()
+
+        fun flush() {
+            val pending = title ?: return
+            tabs += RichNode.Tabs.Tab(title = pending, children = parseBlocks(body.toList()))
+            title = null
+            body.clear()
+        }
+
+        for (child in element.children()) {
+            when {
+                child.hasClass(TAB_TITLE_CLASS) -> {
+                    flush()
+                    title = child.text().trim()
+                }
+
+                // `add`/`addAll` rather than `+=`: an `Element` is itself iterable, so `+=` reads as
+                // "append its children" to the compiler.
+                child.hasClass(TAB_BODY_CLASS) -> body.addAll(child.childNodes())
+
+                title == null -> orphans.add(child)
+
+                else -> body.add(child)
+            }
+        }
+        flush()
+
+        // A group whose titles the site renamed is still a group of content; falling back to the
+        // old flattening beats rendering an empty tab strip.
+        if (tabs.isEmpty()) return paragraphBlocks(element)
+        return parseBlocks(orphans) + RichNode.Tabs(tabs)
+    }
+
     private fun codeBlock(element: Element): RichNode {
         val code = element.selectFirst("code")
         val language = code?.classNames()
             ?.firstOrNull { it.startsWith("language-") }
             ?.removePrefix("language-")
-        // `wholeText` keeps the original newlines that `text()` would collapse.
+        // Read through [AnsiParser] rather than `wholeText()`: the escapes NodeSeek encodes as empty
+        // elements are invisible to it, which leaves their parameters behind as literal `[36m`.
+        val decoded = AnsiParser.decode(AnsiParser.sourceOf(code ?: element))
         return RichNode.CodeBlock(
-            code = (code ?: element).wholeText().trimEnd(),
+            code = decoded.text,
             language = language,
+            spans = decoded.spans,
+            columns = decoded.columns,
         )
     }
 

--- a/app/src/main/java/io/github/nodyssey/core/report/QualityReport.kt
+++ b/app/src/main/java/io/github/nodyssey/core/report/QualityReport.kt
@@ -1,0 +1,72 @@
+package io.github.nodyssey.core.report
+
+/**
+ * A NodeQuality benchmark report, read back out of the fixed-width text a terminal drew it as.
+ *
+ * The 测评 board runs on xykt's Check.Place scripts, whose output is eighty columns of aligned ASCII
+ * built for a desktop terminal. Eighty columns cannot be shown on a phone: fitting them across
+ * 328dp puts the type below 7sp, and letting them scroll sideways means panning to read one line.
+ * Neither is reading. So the text is taken apart here and rebuilt out of ordinary Compose rows,
+ * which can wrap, at a size a person can actually read.
+ *
+ * This is deliberately a *view* of the report rather than a replacement for it. The scripts are
+ * versioned and their layout moves, so anything not recognised survives as [Block.Note] and the
+ * untouched terminal text stays one tap away — see the fallback in the renderer.
+ */
+data class QualityReport(
+    /** e.g. `硬件质量体检报告`. */
+    val title: String,
+    /** The host the report is about, usually a masked address such as `86.53.*.*`. */
+    val target: String?,
+    val generatedAt: String?,
+    val scriptVersion: String?,
+    val sections: List<Section>,
+    /** The lines below the closing rule: detection counts and the permanent report link. */
+    val footnotes: List<String>,
+) {
+    data class Section(
+        /** The numbering prefix is kept off: `一、` is a position, not part of the name. */
+        val title: String,
+        val blocks: List<Block>,
+    )
+
+    sealed interface Block {
+        /** `标签：值`, with any indented continuation lines that followed it. */
+        data class Field(
+            val label: String,
+            val values: List<String>,
+        ) : Block
+
+        /** A row of `✔`/`✘` capability markers, such as 指令集 or 超开指标. */
+        data class Badges(
+            val label: String,
+            val items: List<Badge>,
+        ) : Block
+
+        /**
+         * A run of rows sharing one header, such as 风险因子's eight databases.
+         *
+         * Kept as a grid rather than flattened into fields because the comparison across columns is
+         * the whole point of these — which database disagrees with the others is the question a
+         * reader has.
+         */
+        data class Table(
+            val columns: List<String>,
+            val rows: List<Row>,
+        ) : Block
+
+        /** Anything the parser did not recognise, preserved verbatim rather than dropped. */
+        data class Note(val text: String) : Block
+    }
+
+    data class Badge(
+        val text: String,
+        val passed: Boolean,
+    )
+
+    data class Row(
+        val label: String,
+        /** One entry per column in the owning table; missing cells are empty strings. */
+        val cells: List<String>,
+    )
+}

--- a/app/src/main/java/io/github/nodyssey/core/report/QualityReportParser.kt
+++ b/app/src/main/java/io/github/nodyssey/core/report/QualityReportParser.kt
@@ -1,0 +1,549 @@
+package io.github.nodyssey.core.report
+
+import io.github.nodyssey.core.TerminalColumns
+import io.github.nodyssey.model.AnsiSpan
+
+/**
+ * Reads a [QualityReport] back out of the fixed-width text a Check.Place script drew.
+ *
+ * The layout is regular enough to take apart: a banner between two rules, numbered sections, and
+ * inside them `标签：值` rows padded into columns. What varies is everything else — the scripts are
+ * versioned, sections come and go with the hardware, and the column counts differ per report — so
+ * every step here degrades rather than fails. An unrecognised line becomes a [QualityReport.Block.Note]
+ * and text that is not a report at all returns null, which is the renderer's signal to keep showing
+ * the terminal block instead.
+ */
+object QualityReportParser {
+
+    /**
+     * The banner and footer rules, each one repeated character.
+     *
+     * Which character depends on the script rather than on the position: HardwareQuality opens with
+     * `++++`, IPQuality with `####`, NetQuality with `****`, and all three close with `====`.
+     */
+    private val RULE = Regex("""^([*+#=])\1{7,}$""")
+
+    /** `一、操作系统信息`. The numeral is a position in the report, not part of the name. */
+    private val SECTION = Regex("""^[一二三四五六七八九十百]+、(.+)$""")
+
+    /**
+     * `Basic System Information:` over `---------`, which is how yabs opens a section.
+     *
+     * NodeQuality's own header block is yabs output, so an older report — or the 基本信息 tab of one
+     * — is this shape rather than the numbered one. The underline is what distinguishes a heading
+     * from an ordinary row that happens to end in a colon.
+     */
+    private val SECTION_UNDERLINE = Regex("""^-{3,}$""")
+
+    private val TITLE = Regex("""^(\S*报告)：(.*)$""")
+    private val META = Regex("""报告时间：(.+?)\s{2,}脚本版本：(\S+)""")
+
+    /** Falls back to naming the report after the project that produced it. */
+    private val PROJECT = Regex("""github\.com/[\w.-]+/([\w.-]+)""")
+
+    /** The xykt scripts write labels with a full-width colon, which values never contain. */
+    private const val COLON = '：'
+
+    /**
+     * yabs writes `Uptime     : 4 days`, padding the label out to a fixed width.
+     *
+     * The colon has to be followed by a space for this to be a label at all — otherwise the `:` in
+     * `https://` would cut every row holding a URL in half.
+     */
+    private val ASCII_LABEL = Regex("""^([^:]{1,40}?)\s*: (.*)$""")
+
+    /** yabs' tables are pipe-delimited, with a row of dashes under the header. */
+    private const val PIPE = '|'
+    private val TABLE_SEPARATOR = Regex("""^[-\s|]+$""")
+
+    /** Connectors in the weighted-score row: `总分 = CPU + 内存 + 硬盘` is arithmetic, not data. */
+    private val CONNECTORS = setOf("=", "+", "-")
+
+    /** The Fio row's own column separator. */
+    private const val COLUMN_BREAK = "||"
+
+    /** xykt marks with `✔`/`✘`; yabs with `✔`/`❌`. */
+    private val PASS_MARKS = charArrayOf('✔', '✅')
+    private val FAIL_MARKS = charArrayOf('✘', '❌')
+    private val MARKS = PASS_MARKS + FAIL_MARKS
+
+    /**
+     * 邮局连通性 writes its verdicts as one unspaced run: `+Gmail+Outlook-QQ+MailRU`.
+     *
+     * It carries the same yes/no meaning as a `✔`/`✘` row and reads as one word without this.
+     */
+    private val SIGNED_RUN = Regex("""^([+-][^+-]+){3,}$""")
+
+    /** ANSI palette indices for the badge backgrounds the scripts use to mean good and bad. */
+    private const val ANSI_RED = 1
+    private const val ANSI_GREEN = 2
+
+    /** A table needs at least this many rows under one header before it is worth calling a table. */
+    private const val MIN_TABLE_ROWS = 2
+
+    /** ...and each of those rows at least this many cells, or it is just a value with spaces in it. */
+    private const val MIN_TABLE_CELLS = 3
+
+    fun parse(
+        code: String,
+        spans: List<AnsiSpan> = emptyList(),
+    ): QualityReport? {
+        val lines = code.lines()
+        val offsets = lineOffsets(lines)
+
+        val rules = lines.indices.filter { RULE.matches(lines[it].trim()) }
+        if (rules.size < 2) return null
+
+        val banner = lines.subList(rules.first() + 1, rules[1])
+        val meta = banner.firstNotNullOfOrNull { META.find(it) }
+        val title = banner.firstNotNullOfOrNull { TITLE.find(it.trim()) }
+        // NodeQuality's own banner names no report — it is the wrapper, and the four reports it runs
+        // are the tabs. Its timestamp and version line is what says this is a report at all, and the
+        // project link is the only name available.
+        val project = banner.firstNotNullOfOrNull { PROJECT.find(it) }?.groupValues?.get(1)
+        if (title == null && (meta == null || project == null)) return null
+
+        // The closing rule is a different character from the banner's, and only present once the
+        // script finished; a truncated report simply has no footnotes.
+        val closing = rules.lastOrNull()?.takeIf { it > rules[1] } ?: lines.size
+
+        return QualityReport(
+            title = title?.groupValues?.get(1) ?: project.orEmpty(),
+            target = title?.groupValues?.get(2)?.trim()?.ifBlank { null },
+            generatedAt = meta?.groupValues?.get(1)?.trim(),
+            scriptVersion = meta?.groupValues?.get(2),
+            sections = sections(lines, offsets, from = rules[1] + 1, until = closing, spans = spans),
+            footnotes =
+            lines
+                .drop(closing + 1)
+                .map { it.trim() }
+                .filter { it.isNotBlank() },
+        )
+    }
+
+    // --- Sections -----------------------------------------------------------
+
+    private fun sections(
+        lines: List<String>,
+        offsets: List<Int>,
+        from: Int,
+        until: Int,
+        spans: List<AnsiSpan>,
+    ): List<QualityReport.Section> {
+        val sections = mutableListOf<QualityReport.Section>()
+        var title: String? = null
+        var rows = mutableListOf<RawRow>()
+
+        fun flush() {
+            val pending = title ?: return
+            sections += QualityReport.Section(pending, blocks(rows, spans))
+            rows = mutableListOf()
+        }
+
+        for (index in from until minOf(until, lines.size)) {
+            val line = lines[index]
+            if (line.isBlank()) continue
+
+            val section = SECTION.find(line.trim())
+            if (section != null) {
+                flush()
+                title = section.groupValues[1].trim()
+                continue
+            }
+            // The yabs shape: a heading is a line with a rule of dashes drawn under it.
+            if (SECTION_UNDERLINE.matches(lines.getOrNull(index + 1)?.trim().orEmpty())) {
+                flush()
+                title = line.trim().removeSuffix(":")
+                continue
+            }
+            if (SECTION_UNDERLINE.matches(line.trim())) continue
+            // Content ahead of the first section header has nowhere to go but its own section.
+            if (title == null) title = ""
+
+            // A pipe-delimited row is indented too — fio centres the rule under its header — and it
+            // belongs to the table rather than to the row above.
+            val indented = line.first().isWhitespace() && !line.contains(PIPE)
+            val previous = rows.lastOrNull()
+            if (indented && previous != null) {
+                // A value too long for one line is continued indented under it, and belongs to the
+                // row above rather than to a row of its own.
+                previous.continuations += line.trim()
+                continue
+            }
+            rows += rawRow(line, offsets[index])
+        }
+        flush()
+        return sections
+    }
+
+    private data class RawRow(
+        val label: String,
+        val line: String,
+        /** Where the value starts within [line]; the label and its colon sit before it. */
+        val valueFrom: Int,
+        /** Offset of [line] within the whole report, so cells can be found in the ANSI spans. */
+        val lineOffset: Int,
+        val continuations: MutableList<String> = mutableListOf(),
+    ) {
+        val value: String get() = line.substring(valueFrom)
+    }
+
+    private fun rawRow(line: String, offset: Int): RawRow {
+        val colon = line.indexOf(COLON)
+        if (colon >= 0) {
+            return RawRow(
+                label = line.take(colon).trim(),
+                line = line,
+                valueFrom = colon + 1,
+                lineOffset = offset,
+            )
+        }
+
+        // A pipe-delimited row is a table row, and its first cell is the label rather than a
+        // heading — leaving it to the ASCII rule below would cut it at a colon inside a cell.
+        if (line.none { it == PIPE }) {
+            ASCII_LABEL.find(line)?.let { match ->
+                return RawRow(
+                    label = match.groupValues[1].trim(),
+                    line = line,
+                    valueFrom = match.groups[2]!!.range.first,
+                    lineOffset = offset,
+                )
+            }
+        }
+
+        // A line with no label at all is kept whole, so it can survive as a note.
+        return RawRow(label = "", line = line, valueFrom = 0, lineOffset = offset)
+    }
+
+    // --- Blocks -------------------------------------------------------------
+
+    private fun blocks(
+        rows: List<RawRow>,
+        spans: List<AnsiSpan>,
+    ): List<QualityReport.Block> {
+        val blocks = mutableListOf<QualityReport.Block>()
+        var index = 0
+
+        while (index < rows.size) {
+            val row = rows[index]
+
+            val piped = pipeTableAt(rows, index)
+            if (piped != null) {
+                blocks += piped.block
+                index = piped.next
+                continue
+            }
+
+            // The dashes under a header, and the empty row fio puts between its two tables, are
+            // drawings that belong to a table already read.
+            if (TABLE_SEPARATOR.matches(row.line)) {
+                index++
+                continue
+            }
+
+            if (row.label.isEmpty()) {
+                // Left padding is kept. A line with no label is one the parser could not take apart,
+                // and for those the terminal's own alignment is the only structure left — NetQuality
+                // draws its latency bars this way.
+                blocks += QualityReport.Block.Note(row.line.trimEnd())
+                index++
+                continue
+            }
+
+            if (row.value.any { it in MARKS }) {
+                blocks += badges(row, spans)
+                index++
+                continue
+            }
+
+            val signed = collapseSpaces(row.value)
+            if (SIGNED_RUN.matches(signed)) {
+                blocks += QualityReport.Block.Badges(label = row.label, items = signedBadges(signed))
+                index++
+                continue
+            }
+
+            val table = tableAt(rows, index)
+            if (table != null) {
+                blocks += table.block
+                index = table.next
+                continue
+            }
+
+            blocks += QualityReport.Block.Field(
+                label = row.label,
+                // Reflowing is the point: the padding held a terminal column that no longer exists.
+                values = (listOf(row.value) + row.continuations).map(::collapseSpaces).filter { it.isNotBlank() },
+            )
+            index++
+        }
+        return blocks
+    }
+
+    private fun badges(row: RawRow, spans: List<AnsiSpan>): QualityReport.Block.Badges {
+        val items =
+            cellsOf(row.line, row.valueFrom).flatMap { it.splitOnMarks() }.map { cell ->
+                val marker = cell.text.firstOrNull()
+                // The glyph says whether the feature is present; the background says whether that is
+                // good news. They disagree on 超开指标, where a working balloon reclaim is a warning.
+                val background = backgroundAt(spans, row.lineOffset + cell.from, row.lineOffset + cell.until)
+                QualityReport.Badge(
+                    text = cell.text.drop(1).trim().trim('/').trim(),
+                    passed =
+                    when (background) {
+                        ANSI_GREEN -> true
+                        ANSI_RED -> false
+                        else -> marker != null && marker in PASS_MARKS
+                    },
+                )
+            }
+        return QualityReport.Block.Badges(label = row.label, items = items.filter { it.text.isNotEmpty() })
+    }
+
+    /**
+     * Cuts a cell at every mark inside it.
+     *
+     * yabs writes two verdicts into one field — `IPv4/IPv6  : ✔ Online / ❌ Offline` — where xykt
+     * would have padded them apart. Splitting at the marks reads both shapes.
+     */
+    private fun Cell.splitOnMarks(): List<Cell> {
+        val cuts = text.indices.filter { text[it] in MARKS }
+        if (cuts.size < 2) return listOf(this)
+        return cuts.mapIndexed { position, start ->
+            val end = cuts.getOrElse(position + 1) { text.length }
+            Cell(
+                text = text.substring(start, end).trimEnd(),
+                from = from + start,
+                until = from + end,
+                columnFrom = columnFrom,
+                columnUntil = columnUntil,
+            )
+        }
+    }
+
+    private fun signedBadges(value: String): List<QualityReport.Badge> =
+        Regex("""[+-][^+-]+""").findAll(value).map { match ->
+            QualityReport.Badge(
+                text = match.value.drop(1).trim(),
+                passed = match.value.first() == '+',
+            )
+        }.toList()
+
+    private fun backgroundAt(spans: List<AnsiSpan>, from: Int, until: Int): Int? =
+        spans.firstOrNull { it.bg != null && it.start < until && it.end > from }?.bg
+
+    // --- Tables -------------------------------------------------------------
+
+    private class Table(val block: QualityReport.Block.Table, val next: Int)
+
+    /**
+     * yabs' own table: pipes for columns and a row of dashes under the header.
+     *
+     * Read before the padded kind because these rows are aligned *and* pipe-separated, and splitting
+     * them on their padding would give a different — wrong — number of columns.
+     */
+    private fun pipeTableAt(rows: List<RawRow>, index: Int): Table? {
+        if (!rows[index].line.contains(PIPE)) return null
+        // The separator is the whole test. xykt writes `3|低风险` and `IOPS||RND4K/Q32` with pipes
+        // too, and neither draws a rule under its header.
+        if (!TABLE_SEPARATOR.matches(rows.getOrNull(index + 1)?.line.orEmpty())) return null
+
+        var end = index + 2
+        while (end < rows.size) {
+            val line = rows[end].line
+            if (!line.contains(PIPE)) break
+            // fio prints two block-size tables into one section, parted by a row of empty cells.
+            // That row ends this table; the next header's own rule opens the following one.
+            if (TABLE_SEPARATOR.matches(line)) break
+            end++
+        }
+        if (end <= index + 2) return null
+
+        val columns = rows[index].line.split(PIPE).map { it.trim() }
+        if (columns.size < 2) return null
+
+        return Table(
+            block =
+            QualityReport.Block.Table(
+                // The first column names the row rather than a column, and becomes the label.
+                columns = columns.drop(1),
+                rows =
+                rows.subList(index + 2, end).map { row ->
+                    val cells = row.line.split(PIPE).map { it.trim() }
+                    QualityReport.Row(label = cells.first(), cells = cells.drop(1))
+                },
+            ),
+            next = end,
+        )
+    }
+
+    /**
+     * Reads [index] as a table header if enough rows beneath it share its shape.
+     *
+     * The header is the row whose cells name the columns — 数据库, 库, 服务商, 项目 — but which of
+     * those it is differs per script, so it is found by shape rather than by name.
+     */
+    private fun tableAt(rows: List<RawRow>, index: Int): Table? {
+        var end = index + 1
+        while (end < rows.size && dataCells(rows[end]).size >= MIN_TABLE_CELLS && !isBadgeRow(rows[end])) end++
+        if (end - (index + 1) < MIN_TABLE_ROWS) return null
+
+        val body = rows.subList(index + 1, end)
+        val widest = body.maxOf { dataCells(it).size }
+        val columns = headerCells(rows[index], widest)
+        if (columns.size < MIN_TABLE_CELLS) return null
+
+        return Table(
+            block =
+            QualityReport.Block.Table(
+                columns = columns.map { tightenCjk(it.text) },
+                rows = body.map { row -> QualityReport.Row(row.label, align(dataCells(row), columns, rows[index])) },
+            ),
+            next = end,
+        )
+    }
+
+    private fun isBadgeRow(row: RawRow): Boolean = row.value.any { it in MARKS }
+
+    private fun dataCells(row: RawRow): List<Cell> =
+        cellsOf(row.line, row.valueFrom)
+            .flatMap { it.splitOnColumnBreak() }
+            .filter { it.text !in CONNECTORS }
+
+    /**
+     * The header's own cells, re-split on single spaces when the padded split came up short.
+     *
+     * 风险因子 separates its eight database names by one space each while its data rows use four, so
+     * the same rule cannot read both; 项目 conversely writes `总 分` with a space inside one cell and
+     * must not be re-split. Which applies is decided by whether the counts already agree.
+     */
+    private fun headerCells(header: RawRow, widest: Int): List<Cell> {
+        val padded = cellsOf(header.line, header.valueFrom).flatMap { it.splitOnColumnBreak() }
+        if (padded.size >= widest) return padded
+
+        val resplit = padded.flatMap { it.splitOnSingleSpaces() }
+        return if (resplit.size == widest) resplit else padded
+    }
+
+    /**
+     * Puts each cell under a column.
+     *
+     * Index order is right whenever the counts agree. When a row is short — 公司类型 has nothing to
+     * say about AbuseIPDB — the gap need not be at the end, so those fall back to the column the
+     * cell physically sits under, which is the alignment the report was written in.
+     */
+    private fun align(
+        cells: List<Cell>,
+        columns: List<Cell>,
+        header: RawRow,
+    ): List<String> {
+        if (cells.size == columns.size) return cells.map { it.text }
+
+        val result = MutableList(columns.size) { "" }
+        cells.forEach { cell ->
+            val column = columns.indices.maxByOrNull { overlap(cell, columns[it], header) } ?: return@forEach
+            if (overlap(cell, columns[column], header) > 0 && result[column].isEmpty()) {
+                result[column] = cell.text
+            }
+        }
+        return result
+    }
+
+    /** Cells and columns only line up in terminal cells, never in characters — CJK is two wide. */
+    private fun overlap(cell: Cell, column: Cell, header: RawRow): Int {
+        val cellFrom = cell.columnFrom
+        val cellUntil = cell.columnUntil
+        val columnFrom = TerminalColumns.columnAt(header.line, column.from)
+        val columnUntil = TerminalColumns.columnAt(header.line, column.until)
+        return (minOf(cellUntil, columnUntil) - maxOf(cellFrom, columnFrom)).coerceAtLeast(0)
+    }
+
+    // --- Cells --------------------------------------------------------------
+
+    private class Cell(
+        val text: String,
+        val from: Int,
+        val until: Int,
+        val columnFrom: Int,
+        val columnUntil: Int,
+    )
+
+    /**
+     * Splits a padded line into cells.
+     *
+     * Two spaces separate columns and one space does not, which is the rule the scripts pad to:
+     * `总 分` and `0.80, 0.36` are single values that happen to contain a space.
+     */
+    private fun cellsOf(line: String, from: Int): List<Cell> {
+        val cells = mutableListOf<Cell>()
+        var index = from
+        while (index < line.length) {
+            while (index < line.length && line[index] == ' ') index++
+            if (index >= line.length) break
+
+            var scan = index
+            var lastInk = index
+            while (scan < line.length) {
+                if (line[scan] == ' ') {
+                    if (scan + 1 >= line.length || line[scan + 1] == ' ') break
+                } else {
+                    lastInk = scan
+                }
+                scan++
+            }
+            val until = lastInk + 1
+            cells += Cell(
+                text = line.substring(index, until),
+                from = index,
+                until = until,
+                columnFrom = TerminalColumns.columnAt(line, index),
+                columnUntil = TerminalColumns.columnAt(line, until),
+            )
+            index = scan
+        }
+        return cells
+    }
+
+    private fun Cell.splitOnColumnBreak(): List<Cell> {
+        if (!text.contains(COLUMN_BREAK)) return listOf(this)
+        // Positions stop being meaningful once a cell is cut up, and only badges need them.
+        return text.split(COLUMN_BREAK).map { part ->
+            Cell(part.trim(), from, until, columnFrom, columnUntil)
+        }.filter { it.text.isNotEmpty() }
+    }
+
+    private fun Cell.splitOnSingleSpaces(): List<Cell> =
+        text.split(' ').filter { it.isNotBlank() }.map { part ->
+            Cell(part, from, until, columnFrom, columnUntil)
+        }
+
+    // --- Text ---------------------------------------------------------------
+
+    private fun collapseSpaces(text: String): String =
+        text
+            .trim()
+            .replace(Regex("""\s{2,}"""), " ")
+            // The GB5 rows draw a bar and mark the result's place on it with a pipe. With the bar's
+            // colours and its backspace gone, a leading pipe is all that is left of the drawing.
+            .removePrefix("|")
+            .trim()
+
+    /**
+     * Closes up the space the scripts letter-space CJK headings with — `总 分`, `内 存`.
+     *
+     * Only between two wide glyphs, which is the idiom; `Netflix Youtube` keeps its space because
+     * neither side of it is CJK.
+     */
+    private fun tightenCjk(text: String): String =
+        Regex("""(?<=[一-鿿]) (?=[一-鿿])""").replace(text, "")
+
+    private fun lineOffsets(lines: List<String>): List<Int> {
+        var offset = 0
+        return lines.map {
+            val start = offset
+            offset += it.length + 1
+            start
+        }
+    }
+}

--- a/app/src/main/java/io/github/nodyssey/model/Models.kt
+++ b/app/src/main/java/io/github/nodyssey/model/Models.kt
@@ -137,6 +137,20 @@ sealed interface RichNode {
     data class CodeBlock(
         val code: String,
         val language: String?,
+        /**
+         * Colour runs recovered from `language-ansi` output, empty for ordinary code.
+         *
+         * Index ranges into [code] rather than a pre-built annotated string, because the palette
+         * these indices resolve against belongs to the renderer, not to the cache.
+         */
+        val spans: List<AnsiSpan> = emptyList(),
+        /**
+         * Width of the longest line in terminal columns, counting CJK and emoji as two.
+         *
+         * A benchmark report is 80 columns of aligned ASCII art that cannot be reflowed, so this is
+         * what decides whether the block can be shown in the thread at all or has to open elsewhere.
+         */
+        val columns: Int = 0,
     ) : RichNode
 
     @Serializable
@@ -144,6 +158,25 @@ sealed interface RichNode {
     data class Quote(
         val children: List<RichNode>,
     ) : RichNode
+
+    /**
+     * NodeSeek's own `nsk-magic-tabs` Markdown extension, which the review board uses to file the
+     * four halves of a NodeQuality report behind one tab each.
+     *
+     * Flattening it — which is what happens when the parser does not recognise the wrapper — puts
+     * all four reports on screen at once, so the group has to survive parsing as a group.
+     */
+    @Serializable
+    @SerialName("tabs")
+    data class Tabs(
+        val tabs: List<Tab>,
+    ) : RichNode {
+        @Serializable
+        data class Tab(
+            val title: String,
+            val children: List<RichNode>,
+        )
+    }
 
     @Serializable
     @SerialName("list")
@@ -163,6 +196,23 @@ sealed interface RichNode {
     @SerialName("hr")
     data object Divider : RichNode
 }
+
+/**
+ * One run of SGR-styled text inside a [RichNode.CodeBlock], as a half-open range into its code.
+ *
+ * [fg] and [bg] are palette indices 0–15 (the eight ANSI colours then their bright variants), not
+ * packed colours: the report's `✔ 解锁` green has to become the *theme's* green, and only the
+ * renderer knows what that is.
+ */
+@Serializable
+data class AnsiSpan(
+    val start: Int,
+    val end: Int,
+    val fg: Int? = null,
+    val bg: Int? = null,
+    val bold: Boolean = false,
+    val underline: Boolean = false,
+)
 
 /** Inline pieces inside a paragraph. */
 @Serializable

--- a/app/src/main/java/io/github/nodyssey/ui/account/ProfileFieldsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/account/ProfileFieldsScreen.kt
@@ -15,6 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -39,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,7 +50,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -296,22 +299,25 @@ private fun MarkdownField(
     label: String,
     minLines: Int,
 ) {
-    // Held here rather than in the ViewModel: the selection is a property of this text field, and the
-    // formatting buttons are the only thing that reads it.
-    var fieldValue by remember { mutableStateOf(TextFieldValue(value)) }
-    if (fieldValue.text != value) {
-        fieldValue = fieldValue.copy(text = value)
+    // Scoped to the field, not to the ViewModel: unlike the post composer, nothing here edits the
+    // text behind the user's back, so there is no caret to protect from a background write — and a
+    // `TextFieldState` parked in a ViewModel observes the global snapshot for as long as it lives.
+    val fieldState = rememberTextFieldState()
+    // The saved signature arrives from the network after this field is already on screen. Seeding is
+    // one-way and one-time; from then on the field is the writer and the ViewModel the reader, which
+    // is what the old `if (fieldValue.text != value)` assignment during composition got wrong.
+    LaunchedEffect(value) {
+        if (value.isNotEmpty() && fieldState.text.isEmpty()) fieldState.setTextAndPlaceCursorAtEnd(value)
+    }
+    LaunchedEffect(fieldState) {
+        snapshotFlow { fieldState.text.toString() }.collect(onValueChange)
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
         OutlinedTextField(
-            value = fieldValue,
-            onValueChange = {
-                fieldValue = it
-                onValueChange(it.text)
-            },
+            state = fieldState,
             label = { Text(label) },
-            minLines = minLines,
+            lineLimits = TextFieldLineLimits.MultiLine(minHeightInLines = minLines),
             shape = AccountFieldShape,
             textStyle = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.fillMaxWidth(),
@@ -324,10 +330,7 @@ private fun MarkdownField(
                 SignatureFormat.entries.forEach { format ->
                     val description = stringResource(format.descriptionRes)
                     IconButton(
-                        onClick = {
-                            fieldValue = fieldValue.applyMarkdown(format.insertion)
-                            onValueChange(fieldValue.text)
-                        },
+                        onClick = { fieldState.edit { applyMarkdown(format.insertion) } },
                         modifier = Modifier.semantics { contentDescription = description },
                     ) {
                         Text(format.glyph, style = MaterialTheme.typography.labelLarge)

--- a/app/src/main/java/io/github/nodyssey/ui/account/SecurityScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/account/SecurityScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.TextObfuscationMode
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -25,8 +27,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SecureTextField
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -39,12 +41,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -82,17 +84,14 @@ fun SecurityRoute(
 
     SecurityScreen(
         state = state,
+        currentPasswordState = viewModel.currentPasswordState,
+        newPasswordState = viewModel.newPasswordState,
+        confirmPasswordState = viewModel.confirmPasswordState,
+        twoFactorPasswordState = viewModel.twoFactorPasswordState,
         snackbarHostState = snackbarHostState,
         onBack = onBack,
-        onCurrentPasswordChange = viewModel::updateCurrentPassword,
-        onNewPasswordChange = viewModel::updateNewPassword,
-        onRepeatPasswordChange = viewModel::updateConfirmPassword,
-        onToggleCurrentVisible = viewModel::toggleCurrentVisible,
-        onToggleNewVisible = viewModel::toggleNewVisible,
-        onToggleConfirmVisible = viewModel::toggleConfirmVisible,
         onRequestPasswordChange = viewModel::requestPasswordChange,
         onRequestTwoFactor = viewModel::requestTwoFactorEnrolment,
-        onTwoFactorPasswordChange = viewModel::updateTwoFactorPassword,
         onDismissConfirmation = viewModel::dismissConfirmation,
         onConfirmPasswordChange = viewModel::confirmPasswordChange,
         onConfirmTwoFactor = viewModel::confirmTwoFactorEnrolment,
@@ -111,17 +110,14 @@ fun SecurityRoute(
 @Composable
 fun SecurityScreen(
     state: SecurityUiState,
+    currentPasswordState: TextFieldState,
+    newPasswordState: TextFieldState,
+    confirmPasswordState: TextFieldState,
+    twoFactorPasswordState: TextFieldState,
     snackbarHostState: SnackbarHostState,
     onBack: () -> Unit,
-    onCurrentPasswordChange: (String) -> Unit,
-    onNewPasswordChange: (String) -> Unit,
-    onRepeatPasswordChange: (String) -> Unit,
-    onToggleCurrentVisible: () -> Unit,
-    onToggleNewVisible: () -> Unit,
-    onToggleConfirmVisible: () -> Unit,
     onRequestPasswordChange: () -> Unit,
     onRequestTwoFactor: () -> Unit,
-    onTwoFactorPasswordChange: (String) -> Unit,
     onDismissConfirmation: () -> Unit,
     onConfirmPasswordChange: () -> Unit,
     onConfirmTwoFactor: () -> Unit,
@@ -160,20 +156,16 @@ fun SecurityScreen(
             AccountSectionLabel(stringResource(R.string.account_change_password))
 
             PasswordField(
-                value = state.currentPassword,
-                onValueChange = onCurrentPasswordChange,
+                fieldState = currentPasswordState,
                 label = stringResource(R.string.account_password_current),
-                visible = state.currentVisible,
-                onToggleVisible = onToggleCurrentVisible,
+                contentType = ContentType.Password,
             )
 
             Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
                 PasswordField(
-                    value = state.newPassword,
-                    onValueChange = onNewPasswordChange,
+                    fieldState = newPasswordState,
                     label = stringResource(R.string.account_password_new),
-                    visible = state.newVisible,
-                    onToggleVisible = onToggleNewVisible,
+                    contentType = ContentType.NewPassword,
                     isError = state.isTooShort,
                     supportingText =
                     if (state.isTooShort) {
@@ -186,12 +178,10 @@ fun SecurityScreen(
             }
 
             PasswordField(
-                value = state.confirmPassword,
-                onValueChange = onRepeatPasswordChange,
+                fieldState = confirmPasswordState,
                 label = stringResource(R.string.account_password_confirm),
                 placeholder = stringResource(R.string.account_password_confirm_hint),
-                visible = state.confirmVisible,
-                onToggleVisible = onToggleConfirmVisible,
+                contentType = ContentType.NewPassword,
                 isError = state.isMismatched,
                 supportingText =
                 if (state.isMismatched) stringResource(R.string.account_password_mismatch) else null,
@@ -231,8 +221,8 @@ fun SecurityScreen(
 
         SecurityConfirmation.TwoFactor ->
             TwoFactorDialog(
-                password = state.twoFactorPassword,
-                onPasswordChange = onTwoFactorPasswordChange,
+                passwordState = twoFactorPasswordState,
+                canConfirm = state.twoFactorPassword.isNotEmpty(),
                 onConfirm = onConfirmTwoFactor,
                 onDismiss = onDismissConfirmation,
             )
@@ -254,8 +244,8 @@ fun SecurityScreen(
  */
 @Composable
 private fun TwoFactorDialog(
-    password: String,
-    onPasswordChange: (String) -> Unit,
+    passwordState: TextFieldState,
+    canConfirm: Boolean,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -269,20 +259,20 @@ private fun TwoFactorDialog(
                     stringResource(R.string.account_confirm_2fa_body),
                     style = MaterialTheme.typography.bodyMedium,
                 )
-                OutlinedTextField(
-                    value = password,
-                    onValueChange = onPasswordChange,
+                SecureTextField(
+                    state = passwordState,
                     label = { Text(stringResource(R.string.account_password_current)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    visualTransformation = PasswordVisualTransformation(),
+                    textObfuscationMode = TextObfuscationMode.RevealLastTyped,
                     shape = AccountFieldShape,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .semantics { contentType = ContentType.Password },
                 )
             }
         },
         confirmButton = {
-            TextButton(onClick = onConfirm, enabled = password.isNotEmpty()) {
+            TextButton(onClick = onConfirm, enabled = canConfirm) {
                 Text(stringResource(R.string.account_confirm_2fa_action))
             }
         },
@@ -293,45 +283,36 @@ private fun TwoFactorDialog(
     )
 }
 
+/**
+ * One password box.
+ *
+ * `SecureTextField` rather than an `OutlinedTextField` carrying a `PasswordVisualTransformation`:
+ * it brings the password keyboard, blocks the field from being copied out, and — the reason the
+ * hand-rolled eye button is gone — obscures with [TextObfuscationMode.RevealLastTyped], which shows
+ * the character just typed and hides it again. That is what the eye was for, without a toggle to
+ * leave switched on and without three booleans in the ViewModel to remember which fields are open.
+ */
 @Composable
 private fun PasswordField(
-    value: String,
-    onValueChange: (String) -> Unit,
+    fieldState: TextFieldState,
     label: String,
-    visible: Boolean,
-    onToggleVisible: () -> Unit,
+    contentType: ContentType,
     placeholder: String? = null,
     isError: Boolean = false,
     supportingText: String? = null,
 ) {
-    OutlinedTextField(
-        value = value,
-        onValueChange = onValueChange,
+    SecureTextField(
+        state = fieldState,
         label = { Text(label) },
         placeholder = placeholder?.let { { Text(it) } },
-        singleLine = true,
         isError = isError,
         supportingText = supportingText?.let { { Text(it) } },
-        // `PasswordVisualTransformation` only masks what is drawn. Without the password keyboard type
-        // a third-party IME — which on this forum's audience is essentially everyone — keeps
-        // autocorrecting and learning, so a new password can end up in the IME's personal dictionary
-        // and be suggested elsewhere. That would undo the point of this screen.
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-        visualTransformation =
-        if (visible) VisualTransformation.None else PasswordVisualTransformation(),
+        textObfuscationMode = TextObfuscationMode.RevealLastTyped,
         shape = AccountFieldShape,
-        trailingIcon = {
-            IconButton(onClick = onToggleVisible) {
-                Icon(
-                    imageVector = if (visible) NodysseyIcons.VisibilityOff else NodysseyIcons.Visibility,
-                    contentDescription =
-                    stringResource(
-                        if (visible) R.string.account_password_hide else R.string.account_password_show,
-                    ),
-                )
-            }
-        },
-        modifier = Modifier.fillMaxWidth(),
+        // Naming the field's content type is what lets a password manager recognise this as a change-
+        // password form: `Password` for the credential it already holds, `NewPassword` for the two it
+        // should offer to generate and then save. Without it the manager sees three anonymous boxes.
+        modifier = Modifier.fillMaxWidth().semantics { this.contentType = contentType },
     )
 }
 
@@ -458,17 +439,14 @@ private fun SecurityPreview() {
                 newPassword = "Correct-Horse-9",
                 confirmPassword = "Correct-Horse-9",
             ),
+            currentPasswordState = rememberTextFieldState("hunter2hunter2"),
+            newPasswordState = rememberTextFieldState("Correct-Horse-9"),
+            confirmPasswordState = rememberTextFieldState("Correct-Horse-9"),
+            twoFactorPasswordState = rememberTextFieldState(),
             snackbarHostState = remember { SnackbarHostState() },
             onBack = {},
-            onCurrentPasswordChange = {},
-            onNewPasswordChange = {},
-            onRepeatPasswordChange = {},
-            onToggleCurrentVisible = {},
-            onToggleNewVisible = {},
-            onToggleConfirmVisible = {},
             onRequestPasswordChange = {},
             onRequestTwoFactor = {},
-            onTwoFactorPasswordChange = {},
             onDismissConfirmation = {},
             onConfirmPasswordChange = {},
             onConfirmTwoFactor = {},

--- a/app/src/main/java/io/github/nodyssey/ui/account/SecurityViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/account/SecurityViewModel.kt
@@ -1,5 +1,8 @@
 package io.github.nodyssey.ui.account
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -13,6 +16,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -28,9 +33,26 @@ class SecurityViewModel(
     private val _uiState = MutableStateFlow(SecurityUiState())
     val uiState: StateFlow<SecurityUiState> = _uiState.asStateFlow()
 
+    /**
+     * The four password boxes' own state.
+     *
+     * `SecureTextField` needs a `TextFieldState`, and holding them here keeps clearing-on-success a
+     * one-liner. [uiState] mirrors the text so the validation below — too short, mismatched, ready —
+     * stays where the rest of the screen's rules live.
+     */
+    val currentPasswordState = TextFieldState()
+    val newPasswordState = TextFieldState()
+    val confirmPasswordState = TextFieldState()
+    val twoFactorPasswordState = TextFieldState()
+
     private var submitJob: Job? = null
 
     init {
+        mirror(currentPasswordState) { state, value -> state.copy(currentPassword = value) }
+        mirror(newPasswordState) { state, value -> state.copy(newPassword = value) }
+        mirror(confirmPasswordState) { state, value -> state.copy(confirmPassword = value) }
+        mirror(twoFactorPasswordState) { state, value -> state.copy(twoFactorPassword = value) }
+
         viewModelScope.launch {
             runCatchingExceptCancellation { account.twoFactor() }
                 .onSuccess { two ->
@@ -46,39 +68,35 @@ class SecurityViewModel(
         }
     }
 
-    fun updateCurrentPassword(value: String) = _uiState.update { it.copy(currentPassword = value) }
-
-    fun updateNewPassword(value: String) = _uiState.update { it.copy(newPassword = value) }
-
-    fun updateConfirmPassword(value: String) = _uiState.update { it.copy(confirmPassword = value) }
-
-    fun toggleCurrentVisible() = _uiState.update { it.copy(currentVisible = !it.currentVisible) }
-
-    fun toggleNewVisible() = _uiState.update { it.copy(newVisible = !it.newVisible) }
-
-    fun toggleConfirmVisible() = _uiState.update { it.copy(confirmVisible = !it.confirmVisible) }
-
     fun requestPasswordChange() = _uiState.update { it.copy(confirming = SecurityConfirmation.Password) }
 
     fun requestTwoFactorEnrolment() = _uiState.update { it.copy(confirming = SecurityConfirmation.TwoFactor) }
 
-    fun updateTwoFactorPassword(value: String) = _uiState.update { it.copy(twoFactorPassword = value) }
-
     /** Leaving the dialog abandons the password it collected rather than parking it in state. */
-    fun dismissConfirmation() = _uiState.update { it.copy(confirming = null, twoFactorPassword = "") }
+    fun dismissConfirmation() {
+        twoFactorPasswordState.clearText()
+        _uiState.update { it.copy(confirming = null, twoFactorPassword = "") }
+    }
 
     fun confirmPasswordChange() {
         if (submitJob?.isActive == true) return
         val state = _uiState.value
         if (!state.canSubmitPassword) return
+        // Read straight from the fields rather than from the mirrored copy: the mirror is a frame
+        // behind by construction, and what gets sent to the server must be exactly what is on screen.
+        val currentPassword = currentPasswordState.text.toString()
+        val newPassword = newPasswordState.text.toString()
         submitJob =
             viewModelScope.launch {
                 _uiState.update { it.copy(confirming = null, isSubmitting = true, message = null) }
                 runCatchingExceptCancellation {
-                    account.changePassword(state.currentPassword, state.newPassword)
+                    account.changePassword(currentPassword, newPassword)
                 }.onSuccess {
                     // The fields are cleared on success and only on success: a failed attempt that
                     // wipes what the user typed makes them re-enter three passwords to retry.
+                    currentPasswordState.clearText()
+                    newPasswordState.clearText()
+                    confirmPasswordState.clearText()
                     _uiState.update {
                         it.copy(
                             isSubmitting = false,
@@ -101,10 +119,11 @@ class SecurityViewModel(
 
     fun confirmTwoFactorEnrolment() {
         if (submitJob?.isActive == true) return
-        val password = _uiState.value.twoFactorPassword
+        val password = twoFactorPasswordState.text.toString()
         if (password.isEmpty()) return
         submitJob =
             viewModelScope.launch {
+                twoFactorPasswordState.clearText()
                 _uiState.update {
                     it.copy(confirming = null, twoFactorPassword = "", isSubmitting = true, message = null)
                 }
@@ -137,6 +156,16 @@ class SecurityViewModel(
 
     fun consumeMessage() = _uiState.update { it.copy(message = null) }
 
+    /** Keeps [uiState]'s copy of one field in step with the box the user is typing into. */
+    private fun mirror(
+        field: TextFieldState,
+        write: (SecurityUiState, String) -> SecurityUiState,
+    ) {
+        snapshotFlow { field.text.toString() }
+            .onEach { value -> _uiState.update { state -> write(state, value) } }
+            .launchIn(viewModelScope)
+    }
+
     companion object {
         fun factory(container: AppContainer): ViewModelProvider.Factory =
             viewModelFactory {
@@ -155,9 +184,6 @@ data class SecurityUiState(
     val currentPassword: String = "",
     val newPassword: String = "",
     val confirmPassword: String = "",
-    val currentVisible: Boolean = false,
-    val newVisible: Boolean = false,
-    val confirmVisible: Boolean = false,
     val confirming: SecurityConfirmation? = null,
     /**
      * Collected inside the 2FA dialog, not on the form above it: enrolment is its own endpoint and

--- a/app/src/main/java/io/github/nodyssey/ui/assets/AssetsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/assets/AssetsScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -29,6 +28,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -414,29 +415,27 @@ private fun DailyQuota.progress(): Float? {
     return (current.toFloat() / cap).coerceIn(0f, 1f)
 }
 
-/** A determinate bar when the number is known, an empty track when it is not. Never a guessed fill. */
+/**
+ * A determinate bar when the number is known, an empty track when it is not. Never a guessed fill.
+ *
+ * The gap and the stop indicator Material draws by default are turned off: at 4.dp these bars sit
+ * directly under a quota row and read as one continuous track, and a dot at the far right would look
+ * like a value the site never published.
+ */
 @Composable
 private fun ProgressTrack(
     progress: Float?,
     height: Dp,
 ) {
-    Box(
-        Modifier
-            .fillMaxWidth()
-            .height(height)
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-    ) {
-        if (progress != null && progress > 0f) {
-            Box(
-                Modifier
-                    .fillMaxWidth(progress)
-                    .height(height)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary),
-            )
-        }
-    }
+    LinearProgressIndicator(
+        progress = { progress ?: 0f },
+        color = MaterialTheme.colorScheme.primary,
+        trackColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        strokeCap = StrokeCap.Round,
+        gapSize = 0.dp,
+        drawStopIndicator = {},
+        modifier = Modifier.fillMaxWidth().height(height),
+    )
 }
 
 @Composable

--- a/app/src/main/java/io/github/nodyssey/ui/common/AttendanceBoardDialog.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/AttendanceBoardDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -63,8 +64,10 @@ fun AttendanceBoardDialog(
 
                 else ->
                     LazyColumn(Modifier.height(BOARD_LIST_HEIGHT)) {
-                        items(count = entries.size, key = { it }) { index ->
-                            val entry = entries[index]
+                        // No `key`: the board is a one-shot snapshot that never reorders or grows,
+                        // and names are not guaranteed unique — a duplicate key would crash for the
+                        // sake of an identity Lazy already gets from the index.
+                        itemsIndexed(entries) { index, entry ->
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/app/src/main/java/io/github/nodyssey/ui/common/MarkdownFormatting.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/MarkdownFormatting.kt
@@ -1,7 +1,12 @@
 package io.github.nodyssey.ui.common
 
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.delete
+import androidx.compose.foundation.text.input.insert
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
+import java.text.BreakIterator
 
 /**
  * One Markdown formatting action, described rather than implemented.
@@ -17,39 +22,152 @@ internal data class MarkdownInsertion(
     /** Inserted when nothing is selected, so the result is never a pair of bare delimiters. */
     val placeholder: String,
     /**
-     * Where the caret lands inside [suffix] once text was selected.
+     * Where the caret lands inside [suffix].
      *
-     * Usually the end of the insertion, which is `suffix.length`. Link and image are the exceptions:
-     * they point at the URL slot, because with the text already written that is the only thing left
-     * to type.
+     * Usually the end of the insertion, which is `suffix.length`. Link is the exception: it points
+     * at the URL slot, because with the text already written that is the only thing left to type.
      */
     val caretInSuffix: Int = suffix.length,
+    val caret: MarkdownCaret = MarkdownCaret.AFTER_INSERTION,
 )
 
 /**
- * Applies [insertion] to the current selection and places the caret where typing continues.
+ * Where an insertion leaves the caret.
  *
- * With nothing selected the caret goes just after the prefix, so the placeholder is sitting right
- * there to be typed over. With a selection it goes to [MarkdownInsertion.caretInSuffix].
+ * The two editors answer this differently and always have: the post composer selects what it just
+ * wrapped, the signature editor places a caret. Unifying the *arithmetic* is the point of this file;
+ * unifying the *behaviour* would be a silent UX change, so the difference is named here instead.
  */
-internal fun TextFieldValue.applyMarkdown(insertion: MarkdownInsertion): TextFieldValue {
-    val start = selection.min.coerceIn(0, text.length)
-    val end = selection.max.coerceIn(0, text.length)
-    val selected = text.substring(start, end)
+internal enum class MarkdownCaret {
+    /** Selects the wrapped content, so the next keystroke replaces it. The post composer's choice. */
+    SELECT_CONTENT,
+
+    /** Just past the prefix when nothing was selected, at [MarkdownInsertion.caretInSuffix] otherwise. */
+    AFTER_INSERTION,
+
+    /** Always at [MarkdownInsertion.caretInSuffix], selection or not. Used by the composer's link. */
+    IN_SUFFIX,
+}
+
+/**
+ * Applies [insertion] to the current selection and leaves the caret where typing continues.
+ *
+ * Operates on a [TextFieldBuffer] — the buffer handed to `TextFieldState.edit {}` — rather than
+ * rebuilding an immutable value. `replace` carries the selection across the edit on its own, so the
+ * only offsets computed here are the ones that deliberately move the caret somewhere else.
+ */
+internal fun TextFieldBuffer.applyMarkdown(insertion: MarkdownInsertion) {
+    val start = selection.min
+    val end = selection.max
+    val selected = asCharSequence().substring(start, end)
 
     val body = selected.ifEmpty { insertion.placeholder }
-    val replacement = insertion.prefix + body + insertion.suffix
-    val caretOffset =
-        if (selected.isEmpty()) {
-            insertion.prefix.length
-        } else {
-            insertion.prefix.length + selected.length + insertion.caretInSuffix
-        }
+    replace(start, end, insertion.prefix + body + insertion.suffix)
 
-    val updated = text.replaceRange(start, end, replacement)
-    return TextFieldValue(updated, TextRange((start + caretOffset).coerceIn(0, updated.length)))
+    val bodyStart = start + insertion.prefix.length
+    val bodyEnd = bodyStart + body.length
+    when (insertion.caret) {
+        MarkdownCaret.SELECT_CONTENT -> selection = TextRange(bodyStart, bodyEnd)
+
+        MarkdownCaret.IN_SUFFIX -> placeCursorBeforeCharAt(bodyEnd + insertion.caretInSuffix)
+
+        MarkdownCaret.AFTER_INSERTION ->
+            if (selected.isEmpty()) {
+                placeCursorBeforeCharAt(bodyStart)
+            } else {
+                placeCursorBeforeCharAt(bodyEnd + insertion.caretInSuffix)
+            }
+    }
+}
+
+/**
+ * Toggles a line prefix (`## `, `> `, `- `) at the start of the caret's line.
+ *
+ * Toggling rather than inserting is what makes tapping the same key twice undo it instead of
+ * stacking `>> `.
+ */
+internal fun TextFieldBuffer.toggleLinePrefix(prefix: String) {
+    val caret = selection.min
+    val text = asCharSequence()
+    val lineStart = text.lastIndexOf('\n', (caret - 1).coerceAtLeast(0))
+        .let { if (it < 0 || text.isEmpty()) 0 else it + 1 }
+    val hasPrefix = text.startsWith(prefix, lineStart)
+    if (hasPrefix) {
+        delete(lineStart, lineStart + prefix.length)
+    } else {
+        insert(lineStart, prefix)
+    }
+}
+
+/** Drops [text] in at the caret, replacing the selection. Used by the emoji panel. */
+internal fun TextFieldBuffer.insertText(text: String) {
+    replace(selection.min, selection.max, text)
+}
+
+/**
+ * Deletes one character before the caret — the emoji panel's own backspace key.
+ *
+ * Steps back one grapheme cluster, not one code point: the panel's own ❤️ is base + variation
+ * selector, and a code-point step would strip the selector and leave a black text-style heart.
+ */
+internal fun TextFieldBuffer.deleteBackwards() {
+    val start = selection.min
+    val end = selection.max
+    if (start != end) {
+        delete(start, end)
+        return
+    }
+    if (start == 0) return
+    val iterator = BreakIterator.getCharacterInstance()
+    iterator.setText(asCharSequence().toString())
+    val previous = iterator.preceding(start).let { if (it == BreakIterator.DONE) 0 else it }
+    delete(previous, start)
+}
+
+/**
+ * Appends an uploaded image on a line of its own.
+ *
+ * Not inserted at the caret: uploads finish while typing continues, and dropping `![…](…)` into the
+ * middle of the sentence being written is both surprising and hard to undo. A block image also has
+ * to start its own line to render as one. Appending through the buffer is what keeps the caret where
+ * the user left it — the previous version rewrote the whole body and shoved the caret to the end.
+ */
+internal fun TextFieldBuffer.appendBlock(block: String) {
+    val body = asCharSequence()
+    val separator = when {
+        body.isBlank() -> ""
+        body.endsWith("\n\n") -> ""
+        body.endsWith("\n") -> "\n"
+        else -> "\n\n"
+    }
+    replace(length, length, separator + block)
+}
+
+/** Removes an attachment's Markdown again when its cell is dismissed. */
+internal fun TextFieldBuffer.removeBlock(block: String) {
+    if (block.isEmpty()) return
+    val body = asCharSequence().toString()
+    // Longest separator first, so removing "\n\n![…]" does not leave a stray blank line behind.
+    val index = listOf("\n\n$block", "\n$block", block)
+        .firstNotNullOfOrNull { candidate ->
+            body.indexOf(candidate).takeIf { it >= 0 }?.let { it to candidate.length }
+        } ?: return
+    delete(index.first, index.first + index.second)
 }
 
 /** The URL slot in `](https://)`, i.e. just past the `](`. Shared by the link and image actions. */
 internal const val MARKDOWN_LINK_SUFFIX = "](https://)"
 internal const val MARKDOWN_LINK_CARET = 2
+
+/**
+ * Edits a field from outside the composition — an upload landing, a draft being restored.
+ *
+ * The extra `sendApplyNotifications` is the whole difference from a plain `edit`. Snapshot writes
+ * only reach observers such as the ViewModels' `snapshotFlow` mirrors once notifications are
+ * dispatched, which a running frame does for free; a background coroutine gets no such frame, so
+ * without this an image could land in the body and the draft would still autosave the text as it was.
+ */
+internal fun TextFieldState.editFromViewModel(block: TextFieldBuffer.() -> Unit) {
+    edit(block)
+    Snapshot.sendApplyNotifications()
+}

--- a/app/src/main/java/io/github/nodyssey/ui/common/SpendConfirmDialog.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/SpendConfirmDialog.kt
@@ -59,7 +59,6 @@ fun SpendConfirmDialog(
     AlertDialog(
         onDismissRequest = onDismiss,
         modifier = modifier,
-        shape = RoundedCornerShape(28.dp),
         icon = { Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary) },
         title = { Text(title, style = MaterialTheme.typography.headlineSmall) },
         text = {

--- a/app/src/main/java/io/github/nodyssey/ui/composer/MarkdownEditing.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/MarkdownEditing.kt
@@ -1,7 +1,12 @@
 package io.github.nodyssey.ui.composer
 
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import io.github.nodyssey.ui.common.MARKDOWN_LINK_CARET
+import io.github.nodyssey.ui.common.MARKDOWN_LINK_SUFFIX
+import io.github.nodyssey.ui.common.MarkdownCaret
+import io.github.nodyssey.ui.common.MarkdownInsertion
+import io.github.nodyssey.ui.common.applyMarkdown
+import io.github.nodyssey.ui.common.toggleLinePrefix
 
 /**
  * Everything the editor toolbar can do.
@@ -20,106 +25,62 @@ val EditorAction.isTextTransform: Boolean
 /**
  * Applies one toolbar action to the current selection.
  *
- * Two shapes, both operating on [TextFieldValue] rather than a plain string so the caret lands
- * somewhere useful afterwards — an editor that formats correctly but drops the caret at the end of
- * the document makes people stop using the toolbar:
+ * Two shapes, both leaving the caret somewhere useful — an editor that formats correctly but drops
+ * the caret at the end of the document makes people stop using the toolbar:
  *
  * - **Wrapping** (bold, inline code, links) surrounds the selection, or inserts a placeholder and
  *   selects it so the next keystroke replaces it.
  * - **Line prefixes** (heading, quote, list) toggle at the start of the caret's line, so tapping
  *   the same key twice undoes it instead of stacking `>> `.
+ *
+ * The mechanics live in `ui/common`, shared with the signature editor; this file only says which
+ * insertion each key stands for.
  */
-fun applyMarkdown(
-    value: TextFieldValue,
-    action: EditorAction,
-): TextFieldValue = when (action) {
-    EditorAction.BOLD -> value.wrap("**", "**", "加粗文字")
-    EditorAction.CODE -> value.wrap("`", "`", "code")
-    EditorAction.LINK -> value.link()
-    EditorAction.MENTION -> value.insert("@")
-    EditorAction.HEADING -> value.togglePrefix("## ")
-    EditorAction.QUOTE -> value.togglePrefix("> ")
-    EditorAction.LIST -> value.togglePrefix("- ")
-    EditorAction.IMAGE, EditorAction.EMOJI, EditorAction.PREVIEW -> value
+internal fun TextFieldBuffer.applyMarkdown(action: EditorAction) {
+    when (action) {
+        EditorAction.BOLD -> applyMarkdown(BOLD)
+        EditorAction.CODE -> applyMarkdown(CODE)
+        EditorAction.LINK -> applyMarkdown(LINK)
+        EditorAction.MENTION -> applyMarkdown(MENTION)
+        EditorAction.HEADING -> toggleLinePrefix("## ")
+        EditorAction.QUOTE -> toggleLinePrefix("> ")
+        EditorAction.LIST -> toggleLinePrefix("- ")
+        EditorAction.IMAGE, EditorAction.EMOJI, EditorAction.PREVIEW -> Unit
+    }
 }
 
-/** Drops [text] in at the caret, replacing the selection. Used by the emoji panel. */
-fun insertText(
-    value: TextFieldValue,
-    text: String,
-): TextFieldValue = value.insert(text)
+private val BOLD =
+    MarkdownInsertion(
+        prefix = "**",
+        suffix = "**",
+        placeholder = "加粗文字",
+        caret = MarkdownCaret.SELECT_CONTENT,
+    )
+
+private val CODE =
+    MarkdownInsertion(
+        prefix = "`",
+        suffix = "`",
+        placeholder = "code",
+        caret = MarkdownCaret.SELECT_CONTENT,
+    )
 
 /**
- * Appends an uploaded image on a line of its own.
+ * The caret goes into the empty address, never onto the label.
  *
- * Not inserted at the caret: uploads finish while typing continues, and dropping `![…](…)` into the
- * middle of the sentence being written is both surprising and hard to undo. A block image also has
- * to start its own line to render as one.
+ * Unlike the signature editor's link, which stops just past `](`: here the scheme is already typed,
+ * so landing after it is one fewer thing to do.
  */
-fun appendBlock(
-    body: String,
-    block: String,
-): String = when {
-    body.isBlank() -> block
-    body.endsWith("\n\n") -> body + block
-    body.endsWith("\n") -> body + "\n" + block
-    else -> body + "\n\n" + block
-}
+private val LINK =
+    MarkdownInsertion(
+        prefix = "[",
+        suffix = MARKDOWN_LINK_SUFFIX,
+        placeholder = "链接文字",
+        caretInSuffix = MARKDOWN_LINK_CARET + URL_SCHEME.length,
+        caret = MarkdownCaret.IN_SUFFIX,
+    )
 
-/** Removes an attachment's Markdown again when its cell is dismissed. */
-fun removeBlock(
-    body: String,
-    block: String,
-): String = body
-    .replace("\n\n$block", "")
-    .replace("\n$block", "")
-    .replace(block, "")
-
-private fun TextFieldValue.wrap(
-    prefix: String,
-    suffix: String,
-    placeholder: String,
-): TextFieldValue {
-    val start = selection.min.coerceIn(0, text.length)
-    val end = selection.max.coerceIn(0, text.length)
-    val selected = text.substring(start, end)
-    val content = selected.ifEmpty { placeholder }
-    val replaced = text.replaceRange(start, end, prefix + content + suffix)
-    val contentStart = start + prefix.length
-    return TextFieldValue(replaced, TextRange(contentStart, contentStart + content.length))
-}
-
-private fun TextFieldValue.link(): TextFieldValue {
-    val start = selection.min.coerceIn(0, text.length)
-    val end = selection.max.coerceIn(0, text.length)
-    val label = text.substring(start, end).ifEmpty { "链接文字" }
-    val replaced = text.replaceRange(start, end, "[$label](https://)")
-    // Caret inside the empty URL: the label is the easy part, the address is what needs typing.
-    val cursor = start + label.length + 3 + URL_SCHEME.length
-    return TextFieldValue(replaced, TextRange(cursor.coerceIn(0, replaced.length)))
-}
-
-private fun TextFieldValue.insert(insertion: String): TextFieldValue {
-    val start = selection.min.coerceIn(0, text.length)
-    val end = selection.max.coerceIn(0, text.length)
-    val replaced = text.replaceRange(start, end, insertion)
-    val cursor = (start + insertion.length).coerceIn(0, replaced.length)
-    return TextFieldValue(replaced, TextRange(cursor))
-}
-
-private fun TextFieldValue.togglePrefix(prefix: String): TextFieldValue {
-    val caret = selection.min.coerceIn(0, text.length)
-    val lineStart = text.lastIndexOf('\n', (caret - 1).coerceAtLeast(0))
-        .let { if (it < 0 || text.isEmpty()) 0 else it + 1 }
-    val hasPrefix = text.startsWith(prefix, lineStart)
-    val replaced = if (hasPrefix) {
-        text.removeRange(lineStart, lineStart + prefix.length)
-    } else {
-        text.replaceRange(lineStart, lineStart, prefix)
-    }
-    val shift = if (hasPrefix) -prefix.length else prefix.length
-    val cursor = (caret + shift).coerceIn(lineStart.coerceAtMost(replaced.length), replaced.length)
-    return TextFieldValue(replaced, TextRange(cursor))
-}
+/** A bare `@` with no placeholder: the name follows immediately, typed by hand. */
+private val MENTION = MarkdownInsertion(prefix = "@", placeholder = "")
 
 private const val URL_SCHEME = "https://"

--- a/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerScreen.kt
@@ -19,6 +19,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -61,9 +65,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -75,10 +77,11 @@ import io.github.nodyssey.data.composer.PostDraft
 import io.github.nodyssey.data.composer.PostPermission
 import io.github.nodyssey.data.composer.UploadFailure
 import io.github.nodyssey.ui.common.NodysseyIcons
+import io.github.nodyssey.ui.common.deleteBackwards
+import io.github.nodyssey.ui.common.insertText
 import io.github.nodyssey.ui.theme.PostBody
 import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.readableWidth
-import java.text.BreakIterator
 import java.text.DateFormat
 import java.util.Date
 
@@ -117,10 +120,10 @@ fun PostComposerRoute(
 
     PostComposerScreen(
         state = state,
+        titleState = viewModel.titleState,
+        bodyState = viewModel.bodyState,
         snackbarHostState = snackbarHostState,
         onClose = onClose,
-        onTitleChange = viewModel::updateTitle,
-        onBodyChange = viewModel::updateBody,
         onBoardSelect = viewModel::selectBoard,
         onPermissionSelect = viewModel::selectPermission,
         onViewModeChange = viewModel::setViewMode,
@@ -197,10 +200,10 @@ private fun UploadErrorSnackbar(
 @Composable
 fun PostComposerScreen(
     state: PostComposerUiState,
+    titleState: TextFieldState,
+    bodyState: TextFieldState,
     snackbarHostState: SnackbarHostState,
     onClose: () -> Unit,
-    onTitleChange: (String) -> Unit,
-    onBodyChange: (String) -> Unit,
     onBoardSelect: (Board) -> Unit,
     onPermissionSelect: (PostPermission) -> Unit,
     onViewModeChange: (ComposerViewMode) -> Unit,
@@ -237,8 +240,8 @@ fun PostComposerScreen(
         } else {
             EditorContent(
                 state = state,
-                onTitleChange = onTitleChange,
-                onBodyChange = onBodyChange,
+                titleState = titleState,
+                bodyState = bodyState,
                 onBoardSelect = onBoardSelect,
                 onPermissionSelect = onPermissionSelect,
                 onViewModeChange = onViewModeChange,
@@ -333,8 +336,8 @@ private fun PublishButton(
 @Composable
 private fun EditorContent(
     state: PostComposerUiState,
-    onTitleChange: (String) -> Unit,
-    onBodyChange: (String) -> Unit,
+    titleState: TextFieldState,
+    bodyState: TextFieldState,
     onBoardSelect: (Board) -> Unit,
     onPermissionSelect: (PostPermission) -> Unit,
     onViewModeChange: (ComposerViewMode) -> Unit,
@@ -343,31 +346,18 @@ private fun EditorContent(
     onRetryAttachment: (ImageAttachment) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var bodyValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
-        mutableStateOf(TextFieldValue(state.body, TextRange(state.body.length)))
-    }
     var emojiOpen by rememberSaveable { mutableStateOf(false) }
     // Held here, not in the panel: the panel leaves the composition whenever it closes.
     var recentEmoji by rememberSaveable { mutableStateOf(listOf<String>()) }
     val focusRequester = remember { FocusRequester() }
     val keyboard = LocalSoftwareKeyboardController.current
-    LaunchedEffect(state.body) {
-        if (state.body != bodyValue.text) {
-            bodyValue = TextFieldValue(state.body, TextRange(state.body.length))
-        }
-    }
-    fun edit(next: TextFieldValue) {
-        bodyValue = next
-        onBodyChange(next.text)
-    }
 
     Column(modifier = modifier.fillMaxSize().imePadding()) {
         ComposerOptions(state = state, onBoardSelect = onBoardSelect, onPermissionSelect = onPermissionSelect)
-        TitleField(title = state.title, onTitleChange = onTitleChange)
+        TitleField(titleState = titleState, length = state.title.length)
         BodyArea(
             state = state,
-            bodyValue = bodyValue,
-            onEdit = ::edit,
+            bodyState = bodyState,
             focusRequester = focusRequester,
             modifier = Modifier.weight(1f),
         )
@@ -390,7 +380,7 @@ private fun EditorContent(
 
                     else -> {
                         emojiOpen = false
-                        edit(applyMarkdown(bodyValue, action))
+                        bodyState.edit { applyMarkdown(action) }
                         focusRequester.requestFocus()
                     }
                 }
@@ -406,8 +396,8 @@ private fun EditorContent(
         )
         if (emojiOpen) {
             EmojiPanel(
-                onInsert = { text -> edit(insertText(bodyValue, text)) },
-                onBackspace = { edit(bodyValue.deleteBackwards()) },
+                onInsert = { text -> bodyState.edit { insertText(text) } },
+                onBackspace = { bodyState.edit { deleteBackwards() } },
                 recent = recentEmoji,
                 onRecentChange = { recentEmoji = it },
             )
@@ -418,19 +408,18 @@ private fun EditorContent(
 @Composable
 private fun BodyArea(
     state: PostComposerUiState,
-    bodyValue: TextFieldValue,
-    onEdit: (TextFieldValue) -> Unit,
+    bodyState: TextFieldState,
     focusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
     if (state.viewMode != ComposerViewMode.COMPARE) {
-        BodyField(bodyValue, onEdit, focusRequester, modifier)
+        BodyField(bodyState, focusRequester, modifier)
         return
     }
     // 对照: the site puts the two side by side, which needs a width a phone does not have. Stacked
     // keeps the pairing — edit above, result below — without shrinking either to an unreadable column.
     Column(modifier = modifier) {
-        BodyField(bodyValue, onEdit, focusRequester, Modifier.weight(1f))
+        BodyField(bodyState, focusRequester, Modifier.weight(1f))
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         MarkdownPreviewBody(
             markdown = state.body,
@@ -445,23 +434,22 @@ private fun BodyArea(
 
 @Composable
 private fun BodyField(
-    bodyValue: TextFieldValue,
-    onEdit: (TextFieldValue) -> Unit,
+    bodyState: TextFieldState,
     focusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
     BasicTextField(
-        value = bodyValue,
-        onValueChange = onEdit,
+        state = bodyState,
         textStyle = PostBody.copy(color = MaterialTheme.colorScheme.onSurface),
         cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        lineLimits = TextFieldLineLimits.MultiLine(),
         modifier = modifier
             .readableWidth()
             .focusRequester(focusRequester)
             .padding(horizontal = Spacing.lg, vertical = Spacing.md),
-        decorationBox = { inner ->
+        decorator = { inner ->
             Box(Modifier.fillMaxSize()) {
-                if (bodyValue.text.isEmpty()) {
+                if (bodyState.text.isEmpty()) {
                     Text(
                         text = stringResource(R.string.composer_body_hint),
                         style = PostBody,
@@ -476,13 +464,15 @@ private fun BodyField(
 
 @Composable
 private fun TitleField(
-    title: String,
-    onTitleChange: (String) -> Unit,
+    titleState: TextFieldState,
+    length: Int,
 ) {
     BasicTextField(
-        value = title,
-        onValueChange = onTitleChange,
-        singleLine = true,
+        state = titleState,
+        lineLimits = TextFieldLineLimits.SingleLine,
+        // Enforced at the input layer rather than trimmed afterwards: truncating in the ViewModel
+        // cut composing text out from under the IME, which made the field stutter mid-word.
+        inputTransformation = InputTransformation.maxLength(PostComposerViewModel.MAX_TITLE_LENGTH),
         textStyle = MaterialTheme.typography.titleMedium.copy(
             fontSize = 19.sp,
             lineHeight = 26.sp,
@@ -491,11 +481,11 @@ private fun TitleField(
         ),
         cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
         modifier = Modifier.readableWidth().padding(horizontal = Spacing.lg),
-        decorationBox = { inner ->
+        decorator = { inner ->
             Column {
                 Row(verticalAlignment = Alignment.Bottom) {
                     Box(Modifier.weight(1f).padding(bottom = Spacing.sm)) {
-                        if (title.isEmpty()) {
+                        if (length == 0) {
                             Text(
                                 text = stringResource(R.string.composer_title_hint),
                                 style = MaterialTheme.typography.titleMedium.copy(fontSize = 19.sp),
@@ -507,7 +497,7 @@ private fun TitleField(
                     Text(
                         text = stringResource(
                             R.string.composer_title_count,
-                            title.length,
+                            length,
                             PostComposerViewModel.MAX_TITLE_LENGTH,
                         ),
                         style = MaterialTheme.typography.labelSmall,
@@ -735,22 +725,6 @@ private val ComposerViewMode.labelRes: Int
         ComposerViewMode.PREVIEW -> R.string.composer_view_preview
         ComposerViewMode.COMPARE -> R.string.composer_view_compare
     }
-
-/** Deletes one character before the caret — the emoji panel's own backspace key. */
-internal fun TextFieldValue.deleteBackwards(): TextFieldValue {
-    val start = selection.min.coerceIn(0, text.length)
-    val end = selection.max.coerceIn(0, text.length)
-    if (start != end) {
-        return TextFieldValue(text.removeRange(start, end), TextRange(start))
-    }
-    if (start == 0) return this
-    // Step back one grapheme cluster, not one code point: the panel's own ❤️ is base + variation
-    // selector, and a code-point step would strip the selector and leave a black text-style heart.
-    val iterator = BreakIterator.getCharacterInstance()
-    iterator.setText(text)
-    val previous = iterator.preceding(start).let { if (it == BreakIterator.DONE) 0 else it }
-    return TextFieldValue(text.removeRange(previous, start), TextRange(previous))
-}
 
 private fun countImages(markdown: String): Int = IMAGE_MARKDOWN.findAll(markdown).count()
 

--- a/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerViewModel.kt
@@ -1,5 +1,8 @@
 package io.github.nodyssey.ui.composer
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.placeCursorAtEnd
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -23,6 +26,9 @@ import io.github.nodyssey.data.composer.UploadFailure
 import io.github.nodyssey.data.composer.UploadStatus
 import io.github.nodyssey.data.session.SessionState
 import io.github.nodyssey.di.AppContainer
+import io.github.nodyssey.ui.common.appendBlock
+import io.github.nodyssey.ui.common.editFromViewModel
+import io.github.nodyssey.ui.common.removeBlock
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -46,6 +52,17 @@ class PostComposerViewModel(
     private val _uiState = MutableStateFlow(PostComposerUiState())
     val uiState: StateFlow<PostComposerUiState> = _uiState.asStateFlow()
 
+    /**
+     * The editor's own text and selection, owned here so an upload landing mid-sentence can splice
+     * its Markdown in without disturbing the caret.
+     *
+     * [uiState] still carries `title`/`body` as plain strings — publish validation, the preview and
+     * the draft all read them — but it mirrors these rather than competing with them. That is the
+     * whole point: one writer, one direction.
+     */
+    val titleState = TextFieldState()
+    val bodyState = TextFieldState()
+
     private val uploads = ImageUploadQueue(viewModelScope, uploader)
 
     private var saveJob: Job? = null
@@ -66,12 +83,20 @@ class PostComposerViewModel(
             .onEach { attachments -> _uiState.update { it.copy(attachments = attachments) } }
             .launchIn(viewModelScope)
         // An upload lands while typing continues, so its Markdown goes to the end of the body
-        // rather than wherever the caret happens to be sitting.
+        // rather than wherever the caret happens to be sitting — and, because this edits the buffer
+        // instead of replacing the whole string, the caret stays wherever the user left it.
         uploads.uploaded
             .onEach { attachment ->
                 val markdown = attachment.markdown ?: return@onEach
-                mutate { it.copy(body = appendBlock(it.body, markdown)) }
+                bodyState.editFromViewModel { appendBlock(markdown) }
             }.launchIn(viewModelScope)
+
+        snapshotFlow { titleState.text.toString() }
+            .onEach { title -> if (title != _uiState.value.title) mutate { it.copy(title = title) } }
+            .launchIn(viewModelScope)
+        snapshotFlow { bodyState.text.toString() }
+            .onEach { body -> if (body != _uiState.value.body) mutate { it.copy(body = body) } }
+            .launchIn(viewModelScope)
 
         viewModelScope.launch {
             val draft = repository.draft.first()
@@ -88,10 +113,6 @@ class PostComposerViewModel(
         }
     }
 
-    fun updateTitle(title: String) = mutate { it.copy(title = title.take(MAX_TITLE_LENGTH)) }
-
-    fun updateBody(body: String) = mutate { it.copy(body = body) }
-
     fun selectBoard(board: Board) = mutate { it.copy(boardSlug = board.slug, boardTitle = board.title) }
 
     fun selectPermission(permission: PostPermission) = mutate { it.copy(permission = permission) }
@@ -103,6 +124,14 @@ class PostComposerViewModel(
 
     fun continueDraft() {
         val draft = _uiState.value.pendingDraft ?: return
+        titleState.editFromViewModel {
+            replace(0, length, draft.title)
+            placeCursorAtEnd()
+        }
+        bodyState.editFromViewModel {
+            replace(0, length, draft.body)
+            placeCursorAtEnd()
+        }
         _uiState.update {
             it.copy(
                 title = draft.title,
@@ -134,7 +163,7 @@ class PostComposerViewModel(
     fun removeAttachment(attachment: ImageAttachment) {
         val removed = uploads.remove(attachment.id) ?: return
         val markdown = removed.markdown ?: return
-        mutate { it.copy(body = removeBlock(it.body, markdown)) }
+        bodyState.editFromViewModel { removeBlock(markdown) }
     }
 
     // --- Publishing ---------------------------------------------------------
@@ -147,8 +176,10 @@ class PostComposerViewModel(
             runCatchingExceptCancellation {
                 repository.publish(
                     PostSubmission(
-                        title = state.title,
-                        body = state.body,
+                        // Straight from the fields, not from the mirrored copy: the mirror runs a
+                        // frame behind, and what is published must be exactly what is on screen.
+                        title = titleState.text.toString(),
+                        body = bodyState.text.toString(),
                         boardSlug = requireNotNull(state.boardSlug),
                         permission = state.permission,
                     ),

--- a/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposer.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposer.kt
@@ -27,6 +27,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -62,7 +64,6 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -72,6 +73,8 @@ import io.github.nodyssey.data.composer.ImageAttachment
 import io.github.nodyssey.data.composer.PickedImage
 import io.github.nodyssey.data.composer.UploadFailure
 import io.github.nodyssey.ui.common.NodysseyIcons
+import io.github.nodyssey.ui.common.deleteBackwards
+import io.github.nodyssey.ui.common.insertText
 import io.github.nodyssey.ui.theme.CommentBody
 import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.readableWidth
@@ -90,7 +93,7 @@ import java.util.Date
 fun ReplyComposerHost(
     state: ReplyComposerUiState,
     onDismiss: () -> Unit,
-    onBodyChange: (String) -> Unit,
+    bodyState: TextFieldState,
     onClearQuote: () -> Unit,
     onPreviewChange: (Boolean) -> Unit,
     onPickImages: (List<PickedImage>) -> Unit,
@@ -137,7 +140,7 @@ fun ReplyComposerHost(
         ReplyEditorSheet(
             state = state,
             onDismiss = onDismiss,
-            onBodyChange = onBodyChange,
+            bodyState = bodyState,
             onClearQuote = onClearQuote,
             onPreview = { onPreviewChange(true) },
             onPickImages = launchPicker,
@@ -157,7 +160,7 @@ fun ReplyComposerHost(
 private fun ReplyEditorSheet(
     state: ReplyComposerUiState,
     onDismiss: () -> Unit,
-    onBodyChange: (String) -> Unit,
+    bodyState: TextFieldState,
     onClearQuote: () -> Unit,
     onPreview: () -> Unit,
     onPickImages: () -> Unit,
@@ -169,20 +172,8 @@ private fun ReplyEditorSheet(
     recentEmoji: List<String>,
     onRecentEmojiChange: (List<String>) -> Unit,
 ) {
-    var bodyValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
-        mutableStateOf(TextFieldValue(state.body, TextRange(state.body.length)))
-    }
     var emojiOpen by rememberSaveable { mutableStateOf(false) }
     val keyboard = LocalSoftwareKeyboardController.current
-    LaunchedEffect(state.body) {
-        if (state.body != bodyValue.text) {
-            bodyValue = TextFieldValue(state.body, TextRange(state.body.length))
-        }
-    }
-    fun edit(next: TextFieldValue) {
-        bodyValue = next
-        onBodyChange(next.text)
-    }
 
     ModalBottomSheet(
         // Guarded like the close button and the BackHandler: while a publish is in flight, a swipe
@@ -233,8 +224,8 @@ private fun ReplyEditorSheet(
                 )
             }
             BasicTextField(
-                value = bodyValue,
-                onValueChange = ::edit,
+                state = bodyState,
+                lineLimits = TextFieldLineLimits.MultiLine(),
                 textStyle = CommentBody.copy(
                     fontSize = 16.sp,
                     lineHeight = 26.sp,
@@ -245,11 +236,11 @@ private fun ReplyEditorSheet(
                     .readableWidth()
                     .heightIn(min = MIN_EDITOR_HEIGHT, max = MAX_EDITOR_HEIGHT)
                     .padding(horizontal = Spacing.xl, vertical = Spacing.sm),
-                decorationBox = { inner ->
+                decorator = { inner ->
                     // Fills the width it was given: `readableWidth` centres what it wraps, so a
                     // decoration that measures to its content would centre a half-typed reply.
                     Box(Modifier.fillMaxWidth()) {
-                        if (bodyValue.text.isEmpty()) {
+                        if (bodyState.text.isEmpty()) {
                             Text(
                                 text = stringResource(R.string.post_reply_editor_hint),
                                 style = CommentBody.copy(fontSize = 16.sp, lineHeight = 26.sp),
@@ -296,7 +287,7 @@ private fun ReplyEditorSheet(
 
                         else -> {
                             emojiOpen = false
-                            edit(applyMarkdown(bodyValue, action))
+                            bodyState.edit { applyMarkdown(action) }
                         }
                     }
                 },
@@ -310,8 +301,8 @@ private fun ReplyEditorSheet(
             )
             if (emojiOpen) {
                 EmojiPanel(
-                    onInsert = { text -> edit(insertText(bodyValue, text)) },
-                    onBackspace = { edit(bodyValue.deleteBackwards()) },
+                    onInsert = { text -> bodyState.edit { insertText(text) } },
+                    onBackspace = { bodyState.edit { deleteBackwards() } },
                     recent = recentEmoji,
                     onRecentChange = onRecentEmojiChange,
                 )

--- a/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposerViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposerViewModel.kt
@@ -1,5 +1,8 @@
 package io.github.nodyssey.ui.composer
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.placeCursorAtEnd
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -20,6 +23,9 @@ import io.github.nodyssey.data.composer.PickedImage
 import io.github.nodyssey.data.composer.UploadFailure
 import io.github.nodyssey.data.composer.UploadStatus
 import io.github.nodyssey.di.AppContainer
+import io.github.nodyssey.ui.common.appendBlock
+import io.github.nodyssey.ui.common.editFromViewModel
+import io.github.nodyssey.ui.common.removeBlock
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,6 +62,9 @@ class ReplyComposerViewModel(
     private val _uiState = MutableStateFlow(ReplyComposerUiState(postId = postId))
     val uiState: StateFlow<ReplyComposerUiState> = _uiState.asStateFlow()
 
+    /** The sheet's text and selection. See `PostComposerViewModel.bodyState` for why it lives here. */
+    val bodyState = TextFieldState()
+
     private val uploads = ImageUploadQueue(viewModelScope, uploader)
 
     private var saveJob: Job? = null
@@ -68,8 +77,11 @@ class ReplyComposerViewModel(
         uploads.uploaded
             .onEach { attachment ->
                 val markdown = attachment.markdown ?: return@onEach
-                mutate { it.copy(body = appendBlock(it.body, markdown)) }
+                bodyState.editFromViewModel { appendBlock(markdown) }
             }.launchIn(viewModelScope)
+        snapshotFlow { bodyState.text.toString() }
+            .onEach { body -> if (body != _uiState.value.body) mutate { it.copy(body = body) } }
+            .launchIn(viewModelScope)
     }
 
     /**
@@ -83,6 +95,10 @@ class ReplyComposerViewModel(
             val stored = repository.draft(postId).first()
             _uiState.update { current ->
                 val restored = if (current.body.isBlank() && stored != null) {
+                    bodyState.editFromViewModel {
+                        replace(0, length, stored.body)
+                        placeCursorAtEnd()
+                    }
                     current.copy(
                         body = stored.body,
                         savedAtMillis = stored.savedAtMillis.takeIf { it > 0 },
@@ -100,8 +116,6 @@ class ReplyComposerViewModel(
         _uiState.update { it.copy(visible = false, previewing = false) }
     }
 
-    fun updateBody(body: String) = mutate { it.copy(body = body) }
-
     fun clearQuote() = mutate { it.copy(quote = null) }
 
     fun setPreviewing(previewing: Boolean) {
@@ -117,7 +131,7 @@ class ReplyComposerViewModel(
     fun removeAttachment(attachment: ImageAttachment) {
         val removed = uploads.remove(attachment.id) ?: return
         val markdown = removed.markdown ?: return
-        mutate { it.copy(body = removeBlock(it.body, markdown)) }
+        bodyState.editFromViewModel { removeBlock(markdown) }
     }
 
     fun publish(onPublished: (Int?) -> Unit) {

--- a/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadScreen.kt
@@ -29,9 +29,11 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -458,30 +460,20 @@ private fun MessageInputBar(
             ),
             modifier = Modifier.weight(1f),
         )
-        Box(
-            modifier =
-            Modifier
-                .minimumInteractiveComponentSize()
-                .size(44.dp)
-                .clip(RoundedCornerShape(14.dp))
-                .background(
-                    if (canSend) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.surfaceContainerHighest
-                    },
-                ).clickable(enabled = canSend, onClick = onSend),
-            contentAlignment = Alignment.Center,
+        FilledIconButton(
+            onClick = onSend,
+            enabled = canSend,
+            shape = RoundedCornerShape(14.dp),
+            colors =
+            IconButtonDefaults.filledIconButtonColors(
+                disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
+            modifier = Modifier.size(44.dp),
         ) {
             Icon(
                 NodysseyIcons.Send,
                 contentDescription = stringResource(R.string.message_send),
-                tint =
-                if (canSend) {
-                    MaterialTheme.colorScheme.onPrimary
-                } else {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                },
                 modifier = Modifier.size(20.dp),
             )
         }

--- a/app/src/main/java/io/github/nodyssey/ui/notifications/ConversationList.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/notifications/ConversationList.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.Badge
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -222,18 +223,13 @@ private fun ConversationRow(
                     modifier = Modifier.weight(1f),
                 )
                 if (isUnread) {
-                    Box(
-                        Modifier
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.primary)
-                            .padding(horizontal = 5.dp, vertical = 1.dp),
+                    // `primary`, not Badge's default `error`: an unread message is a thing to read,
+                    // not a thing that went wrong.
+                    Badge(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
                     ) {
-                        Text(
-                            text = conversation.unreadCount.coerceAtMost(MAX_UNREAD).toString(),
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
+                        Text(conversation.unreadCount.coerceAtMost(MAX_UNREAD).toString())
                     }
                 }
             }

--- a/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -25,11 +24,11 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.ThumbUp
@@ -47,6 +46,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
@@ -155,7 +155,7 @@ fun PostDetailRoute(
     ReplyComposerHost(
         state = replyState,
         onDismiss = replyViewModel::close,
-        onBodyChange = replyViewModel::updateBody,
+        bodyState = replyViewModel.bodyState,
         onClearQuote = replyViewModel::clearQuote,
         onPreviewChange = replyViewModel::setPreviewing,
         onPickImages = replyViewModel::addImages,
@@ -428,43 +428,27 @@ private fun DetailFloatingToolbarContent(
     onNext: () -> Unit,
     onPageClick: () -> Unit,
 ) {
-    val previousPageDescription = stringResource(R.string.post_previous_page)
-    val nextPageDescription = stringResource(R.string.post_next_page)
     Row(
         modifier = Modifier.height(48.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
     ) {
-        IconButton(
-            onClick = onPrevious,
-            enabled = page > 1,
-            modifier =
-            Modifier.semantics {
-                contentDescription = previousPageDescription
-            },
-        ) {
-            Text(
-                "‹",
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+        IconButton(onClick = onPrevious, enabled = page > 1) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = stringResource(R.string.post_previous_page),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
         TextButton(onClick = onPageClick, contentPadding = PaddingValues(horizontal = Spacing.sm)) {
             Text(stringResource(R.string.post_page_of, page, totalPages))
             Icon(Icons.Default.KeyboardArrowDown, contentDescription = null)
         }
-        IconButton(
-            onClick = onNext,
-            enabled = page < totalPages,
-            modifier =
-            Modifier.semantics {
-                contentDescription = nextPageDescription
-            },
-        ) {
-            Text(
-                "›",
-                style = MaterialTheme.typography.headlineSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+        IconButton(onClick = onNext, enabled = page < totalPages) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = stringResource(R.string.post_next_page),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -499,7 +483,7 @@ private fun PageJumpSheet(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 style = MaterialTheme.typography.bodySmall,
             )
-            androidx.compose.material3.OutlinedTextField(
+            OutlinedTextField(
                 value = input,
                 onValueChange = { input = it.filter { character -> character.isDigit() } },
                 label = { Text(stringResource(R.string.post_page_input, totalPages)) },
@@ -675,7 +659,6 @@ private fun ThreadList(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 /**
  * Full-width opening punctuation draws its ink in the right half of the em box, so a title like
  * 「【出】92折出SG落地机」 starts a good half character right of everything under it. That gap was
@@ -692,6 +675,7 @@ private fun TextStyle.hangLeadingPunctuation(text: String): TextStyle =
         this
     }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ThreadHeader(
     title: String,

--- a/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -48,7 +49,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetValue
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -74,7 +74,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -674,6 +676,22 @@ private fun ThreadList(
 }
 
 @OptIn(ExperimentalLayoutApi::class)
+/**
+ * Full-width opening punctuation draws its ink in the right half of the em box, so a title like
+ * 「【出】92折出SG落地机」 starts a good half character right of everything under it. That gap was
+ * invisible while the opening post sat in its own container — the title and the container were on
+ * different left edges anyway — and became the most obvious misalignment on the screen once they
+ * shared one. Hanging the first line out by half an em puts the bracket's ink back on the margin.
+ */
+private val HANGING_PUNCTUATION = setOf('【', '「', '『', '《', '〈', '（', '〔', '“', '‘')
+
+private fun TextStyle.hangLeadingPunctuation(text: String): TextStyle =
+    if (text.firstOrNull() in HANGING_PUNCTUATION) {
+        copy(textIndent = TextIndent(firstLine = fontSize * -0.5f))
+    } else {
+        this
+    }
+
 @Composable
 private fun ThreadHeader(
     title: String,
@@ -689,7 +707,7 @@ private fun ThreadHeader(
     ) {
         Text(
             text = title,
-            style = PostTitle,
+            style = PostTitle.hangLeadingPunctuation(title),
             color = MaterialTheme.colorScheme.onSurface,
         )
         FlowRow(
@@ -704,6 +722,13 @@ private fun ThreadHeader(
     }
 }
 
+/**
+ * The opening post, laid out flat like every other floor.
+ *
+ * It used to sit in a rounded container, which cost two levels of horizontal inset and boxed in the
+ * long bodies this forum is full of. The larger avatar, the bodyLarge text and the comments header
+ * below already mark it as the opening post, so the container was only spending width.
+ */
 @Composable
 private fun OriginalPost(
     body: PostContent,
@@ -713,81 +738,80 @@ private fun OriginalPost(
     onChickenClick: () -> Unit,
     onAuthorClick: (Long) -> Unit,
 ) {
-    Surface(
-        modifier = Modifier.padding(horizontal = Spacing.lg),
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-        shape = RoundedCornerShape(24.dp),
+    Column(
+        modifier = Modifier.padding(start = Spacing.lg, end = Spacing.lg, bottom = 12.dp),
     ) {
-        Column(
-            modifier = Modifier.padding(start = Spacing.lg, end = Spacing.lg, top = Spacing.lg, bottom = 12.dp),
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         ) {
+            // The identity block opens the author's space; the floor label stays outside it.
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                modifier = Modifier
+                    .weight(1f)
+                    .authorClickable(body.authorUid, onAuthorClick),
             ) {
-                // The identity block opens the author's space; the floor label stays outside it.
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    modifier = Modifier
-                        .weight(1f)
-                        .authorClickable(body.authorUid, onAuthorClick),
-                ) {
-                    UserAvatar(
-                        url = body.avatarUrl,
-                        name = body.authorName,
-                        size = Sizes.avatarOriginalPost,
-                    )
-                    Column(Modifier.weight(1f)) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        ) {
-                            Text(
-                                text = body.authorName,
-                                style = MaterialTheme.typography.titleSmall,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f, fill = false),
-                            )
-                            FloorBadges(body)
-                        }
-                        FloorTimeLine(body)
+                UserAvatar(
+                    url = body.avatarUrl,
+                    name = body.authorName,
+                    size = Sizes.avatarOriginalPost,
+                )
+                Column(Modifier.weight(1f)) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        Text(
+                            text = body.authorName,
+                            style = MaterialTheme.typography.titleSmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
+                        )
+                        FloorBadges(body)
                     }
+                    FloorTimeLine(body)
                 }
-                body.floor?.let { FloorLabel(it) }
             }
-
-            if (body.nodes.isEmpty()) {
-                Text(
-                    text = stringResource(R.string.post_body_empty),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = Spacing.md),
-                )
-            } else {
-                RichContent(
-                    nodes = body.nodes,
-                    onLinkClick = onOpenBrowser,
-                    onImageClick = onImageClick,
-                    onQuoteRefClick = { onJumpToFloor(it.floor) },
-                    textStyle = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(top = Spacing.md),
-                )
-            }
-            UserSignature(
-                nodes = body.signatureNodes,
-                onOpenBrowser = onOpenBrowser,
-                onImageClick = onImageClick,
-                onJumpToFloor = onJumpToFloor,
-            )
-            ReactionRow(onChickenClick = onChickenClick)
+            body.floor?.let { FloorLabel(it) }
         }
+
+        if (body.nodes.isEmpty()) {
+            Text(
+                text = stringResource(R.string.post_body_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = Spacing.md),
+            )
+        } else {
+            RichContent(
+                nodes = body.nodes,
+                onLinkClick = onOpenBrowser,
+                onImageClick = onImageClick,
+                onQuoteRefClick = { onJumpToFloor(it.floor) },
+                textStyle = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = Spacing.md),
+            )
+        }
+        UserSignature(
+            nodes = body.signatureNodes,
+            onOpenBrowser = onOpenBrowser,
+            onImageClick = onImageClick,
+            onJumpToFloor = onJumpToFloor,
+        )
+        ReactionRow(onChickenClick = onChickenClick)
     }
 }
 
 @Composable
 private fun CommentsHeader(count: Int) {
+    // Without the opening post's container, this line is what separates it from the replies.
+    HorizontalDivider(
+        color = MaterialTheme.colorScheme.outlineVariant,
+        modifier = Modifier.padding(horizontal = Spacing.lg),
+    )
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -932,6 +956,9 @@ private fun UserSignature(
 private fun Modifier.authorClickable(uid: Long?, onAuthorClick: (Long) -> Unit): Modifier =
     if (uid == null) this else clickable { onAuthorClick(uid) }
 
+/** `ButtonDefaults.TextButtonContentPadding`'s horizontal inset. */
+private val TEXT_BUTTON_CONTENT_INSET = 12.dp
+
 @Composable
 private fun ReactionRow(
     onChickenClick: () -> Unit,
@@ -939,7 +966,13 @@ private fun ReactionRow(
     onReply: (() -> Unit)? = null,
 ) {
     Row(
-        modifier = modifier.fillMaxWidth().padding(top = Spacing.sm),
+        // Every reaction is a TextButton, which keeps 12dp of content padding inside its own bounds.
+        // Laid out honestly the last icon stops 12dp short of the margin the floor label and the
+        // body text sit on; shifting the row out by exactly that much lines the ink up instead.
+        modifier = modifier
+            .fillMaxWidth()
+            .offset(x = TEXT_BUTTON_CONTENT_INSET)
+            .padding(top = Spacing.sm),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
@@ -74,6 +74,7 @@ import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
 import io.github.nodyssey.R
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.net.NodeSeekError
@@ -244,7 +245,7 @@ fun PostListScreen(
                             ) {
                                 items(
                                     count = posts.itemCount,
-                                    key = { index -> posts.peek(index)?.summary?.postId ?: index },
+                                    key = posts.itemKey { it.summary.postId },
                                 ) { index ->
                                     val post = posts[index]
                                     if (post != null) {

--- a/app/src/main/java/io/github/nodyssey/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/profile/ProfileScreen.kt
@@ -157,11 +157,7 @@ fun ProfileScreen(
                 .padding(padding)
                 .fillMaxSize()
                 .readableWidth(),
-            contentPadding =
-            androidx.compose.foundation.layout.PaddingValues(
-                horizontal = Spacing.lg,
-                vertical = Spacing.lg,
-            ),
+            contentPadding = PaddingValues(horizontal = Spacing.lg, vertical = Spacing.lg),
             verticalArrangement = Arrangement.spacedBy(Spacing.lg),
         ) {
             item(key = "profile-header") {

--- a/app/src/main/java/io/github/nodyssey/ui/richtext/ReportCard.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/richtext/ReportCard.kt
@@ -1,0 +1,400 @@
+package io.github.nodyssey.ui.richtext
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.nodyssey.R
+import io.github.nodyssey.core.report.QualityReport
+import io.github.nodyssey.ui.theme.CodeStyle
+import io.github.nodyssey.ui.theme.LocalNodysseyExtraColors
+import io.github.nodyssey.ui.theme.Sizes
+import io.github.nodyssey.ui.theme.Spacing
+import io.github.nodyssey.ui.theme.TABULAR_FIGURES
+
+/**
+ * A NodeQuality benchmark report, rebuilt out of ordinary rows instead of the terminal art it
+ * arrived as.
+ *
+ * The report is eighty columns wide and cannot become narrower without becoming unreadable: fitting
+ * eighty columns across a phone puts the type near 7sp. So the layout is not reproduced at all. What
+ * the padding encoded — this is a label, that is its value, these five belong to one comparison — is
+ * recovered by [io.github.nodyssey.core.report.QualityReportParser] and drawn again at 14sp, where a
+ * value that no longer fits wraps instead of scrolling off the side.
+ *
+ * The scripts are versioned and their layout moves, so [onShowSource] stays available on every card:
+ * whatever this misreads, the original is one tap away and is still the thing that was posted.
+ */
+@Composable
+fun ReportCard(
+    report: QualityReport,
+    onShowSource: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by rememberSaveable(report.title, report.target) { mutableStateOf(true) }
+
+    Column(
+        modifier =
+        modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(MaterialTheme.colorScheme.surfaceContainerLow),
+    ) {
+        ReportHeader(
+            report = report,
+            expanded = expanded,
+            onToggle = { expanded = !expanded },
+        )
+
+        AnimatedVisibility(visible = expanded) {
+            Column {
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Column(
+                    modifier = Modifier.padding(
+                        start = Spacing.md,
+                        end = Spacing.md,
+                        top = Spacing.md,
+                        bottom = Spacing.sm,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.lg),
+                ) {
+                    report.sections.forEach { ReportSection(it) }
+                    if (report.footnotes.isNotEmpty()) Footnotes(report.footnotes)
+                }
+                SourceAction(onShowSource)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReportHeader(
+    report: QualityReport,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .defaultMinSize(minHeight = Sizes.minTouchTarget)
+            .padding(start = Spacing.md, end = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f).padding(vertical = Spacing.sm)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = report.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                report.target?.let { target ->
+                    Text(
+                        text = target,
+                        style = MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = Spacing.sm),
+                    )
+                }
+            }
+            // The timestamp is the one piece of provenance that matters: a benchmark from six months
+            // ago describes a machine that has since been resold.
+            listOfNotNull(report.generatedAt, report.scriptVersion)
+                .takeIf { it.isNotEmpty() }
+                ?.let { meta ->
+                    Text(
+                        text = meta.joinToString(" · "),
+                        style = MaterialTheme.typography.labelSmall.copy(fontFeatureSettings = TABULAR_FIGURES),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+        }
+        Box(
+            modifier = Modifier.size(Sizes.minTouchTarget),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowDown,
+                contentDescription =
+                stringResource(if (expanded) R.string.action_collapse else R.string.action_expand),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .size(20.dp)
+                    .rotate(if (expanded) 180f else 0f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReportSection(section: QualityReport.Section) {
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        if (section.title.isNotBlank()) {
+            Text(
+                text = section.title,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        section.blocks.forEach { block ->
+            when (block) {
+                is QualityReport.Block.Field -> FieldRow(block)
+                is QualityReport.Block.Badges -> BadgeRow(block)
+                is QualityReport.Block.Table -> ReportTable(block)
+                is QualityReport.Block.Note -> NoteLine(block)
+            }
+        }
+    }
+}
+
+/**
+ * A line the parser could not take apart, kept exactly as the terminal drew it.
+ *
+ * Monospace and scrolling rather than wrapping, because whatever structure such a line still has is
+ * in its spacing — NetQuality's latency bars are drawn out of block characters, and reflowing them
+ * into the body face turns a chart into noise. This is the seam where the card degrades, and it
+ * degrades into the original rather than into a mess.
+ */
+@Composable
+private fun NoteLine(note: QualityReport.Block.Note) {
+    Text(
+        text = note.text,
+        style = CodeStyle,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        softWrap = false,
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+    )
+}
+
+/**
+ * `标签  值`, with the label in a column of its own.
+ *
+ * A fixed label column rather than an inline `标签：值` run so that a reader scanning for one fact
+ * has a single left edge to run their eye down. It is a minimum rather than a fixed width: a long
+ * label takes the room it needs and the value wraps under it.
+ */
+@Composable
+private fun FieldRow(field: QualityReport.Block.Field) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = field.label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .widthIn(min = LABEL_WIDTH)
+                .padding(end = Spacing.sm),
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            field.values.forEach { value ->
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun BadgeRow(badges: QualityReport.Block.Badges) {
+    val extra = LocalNodysseyExtraColors.current
+
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = badges.label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .widthIn(min = LABEL_WIDTH)
+                .padding(end = Spacing.sm),
+        )
+        FlowRow(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            badges.items.forEach { badge ->
+                Text(
+                    text = badge.text,
+                    style = MaterialTheme.typography.labelMedium,
+                    color =
+                    if (badge.passed) extra.onSuccessContainer else MaterialTheme.colorScheme.onErrorContainer,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(
+                            if (badge.passed) {
+                                extra.successContainer
+                            } else {
+                                MaterialTheme.colorScheme.errorContainer
+                            },
+                        ).padding(horizontal = 7.dp, vertical = 3.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A comparison grid, with its row labels held still while the cells scroll.
+ *
+ * 风险因子 asks eight databases the same seven questions, and the answer only means something next
+ * to the question — so the label column cannot be allowed to scroll away from the cells the way it
+ * would in a plain horizontally-scrolled table.
+ */
+@Composable
+private fun ReportTable(table: QualityReport.Block.Table) {
+    if (table.rows.isEmpty()) return
+    val cells = rememberScrollState()
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.surfaceContainer),
+    ) {
+        Column {
+            HeaderCell(text = "", width = LABEL_WIDTH)
+            table.rows.forEach { row ->
+                Text(
+                    text = row.label,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    modifier = Modifier
+                        .width(LABEL_WIDTH)
+                        .padding(horizontal = Spacing.sm, vertical = 5.dp),
+                )
+            }
+        }
+        Column(modifier = Modifier.horizontalScroll(cells)) {
+            Row { table.columns.forEach { HeaderCell(it) } }
+            table.rows.forEach { row ->
+                Row {
+                    // Padded to the header's length: a row that is short is short at a known column,
+                    // and a blank there is the finding.
+                    List(table.columns.size) { row.cells.getOrElse(it) { "" } }.forEach { cell ->
+                        Text(
+                            text = cell,
+                            style = MaterialTheme.typography.bodySmall.copy(fontFeatureSettings = TABULAR_FIGURES),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            modifier = Modifier
+                                .width(CELL_WIDTH)
+                                .padding(horizontal = Spacing.sm, vertical = 5.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderCell(
+    text: String,
+    width: Dp = CELL_WIDTH,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.SemiBold,
+        maxLines = 1,
+        modifier = Modifier
+            .width(width)
+            .padding(horizontal = Spacing.sm, vertical = 6.dp),
+    )
+}
+
+@Composable
+private fun Footnotes(footnotes: List<String>) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        footnotes.forEach { note ->
+            Text(
+                text = note,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SourceAction(onShowSource: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onShowSource)
+            .defaultMinSize(minHeight = Sizes.minTouchTarget)
+            .padding(horizontal = Spacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Text(
+            text = stringResource(R.string.report_show_source),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+/** Wide enough for `操作系统/内核`, which is the longest label the scripts use. */
+private val LABEL_WIDTH = 92.dp
+
+/** Wide enough for `IP2Location` at 13sp, which is the longest column name. */
+private val CELL_WIDTH = 88.dp
+
+internal val ReportTerminalGround = Color(0xFF282C34)
+
+internal val ReportTerminalInk = Color(0xFFD7DAE0)
+
+internal val ReportTerminalStyle =
+    androidx.compose.ui.text.TextStyle(
+        fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+        fontSize = 12.sp,
+        lineHeight = 18.sp,
+    )

--- a/app/src/main/java/io/github/nodyssey/ui/richtext/ReportSourceDialog.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/richtext/ReportSourceDialog.kt
@@ -1,0 +1,180 @@
+package io.github.nodyssey.ui.richtext
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChanged
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import io.github.nodyssey.R
+import io.github.nodyssey.ui.common.NodysseyIcons
+import io.github.nodyssey.ui.common.rememberClipboardCopy
+import io.github.nodyssey.ui.theme.Spacing
+
+/**
+ * The report exactly as it was posted, on a terminal ground, pinchable.
+ *
+ * This is the escape hatch behind every [ReportCard]: the scripts are versioned and the card is an
+ * interpretation, so whatever it gets wrong has to be checkable against the original. It is also the
+ * only place the eighty-column layout is honoured, which is why it is full screen and why the type
+ * starts at whatever size makes the widest line fit rather than at a fixed one.
+ *
+ * The ground stays dark in both themes. The reports colour their verdicts by background — a green
+ * `解锁`, a red `机房` — and those stop meaning anything on a light surface.
+ *
+ * A dialog rather than a navigation destination: the report is several kilobytes of text, and a
+ * back-stack entry is serialised into the saved instance state.
+ */
+@Composable
+fun ReportSourceDialog(
+    title: String,
+    source: String,
+    columns: Int,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        var zoom by remember(source) { mutableFloatStateOf(1f) }
+        val copy = rememberClipboardCopy()
+        val confirmation = stringResource(R.string.post_code_copied)
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(ReportTerminalGround),
+        ) {
+            Column(Modifier.systemBarsPadding()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = Spacing.lg, end = Spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = ReportTerminalInk,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = { copy("report", source, confirmation) }) {
+                        Icon(
+                            imageVector = NodysseyIcons.ContentCopy,
+                            contentDescription = stringResource(R.string.action_copy),
+                            tint = ReportTerminalInk,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(R.string.action_close),
+                            tint = ReportTerminalInk,
+                        )
+                    }
+                }
+
+                BoxWithFit(columns = columns, zoom = zoom, onZoom = { zoom = it }) { fontScale ->
+                    Text(
+                        text = source,
+                        style = ReportTerminalStyle.copy(
+                            fontSize = ReportTerminalStyle.fontSize * fontScale,
+                            lineHeight = ReportTerminalStyle.lineHeight * fontScale,
+                        ),
+                        color = ReportTerminalInk,
+                        softWrap = false,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Scrolls both ways and starts at the scale that makes [columns] fit across the screen.
+ *
+ * The zoom changes the *type size* rather than transforming a layer, because the content has to stay
+ * scrollable to its new edges — a scaled layer keeps the size it was laid out at, so half the report
+ * would end up somewhere the scroll could not reach.
+ *
+ * Only a second finger drives it. A one-finger drag has to stay with the scroll containers, or the
+ * report becomes unscrollable the moment it is readable.
+ */
+@Composable
+private fun BoxWithFit(
+    columns: Int,
+    zoom: Float,
+    onZoom: (Float) -> Unit,
+    content: @Composable (Float) -> Unit,
+) {
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false)
+                    do {
+                        val event = awaitPointerEvent()
+                        if (event.changes.count { it.pressed } > 1) {
+                            onZoom((zoom * event.calculateZoom()).coerceIn(MIN_ZOOM, MAX_ZOOM))
+                            event.changes.forEach { if (it.positionChanged()) it.consume() }
+                        }
+                    } while (event.changes.any { it.pressed })
+                }
+            },
+    ) {
+        val available = maxWidth - Spacing.lg * 2
+        // The advance of a monospace glyph is about six tenths of its size, so this is the size at
+        // which the widest line just fits. It is deliberately allowed to be tiny: the whole report
+        // at a glance is what the fit is for, and reading it is what the pinch is for.
+        val fitted = remember(available, columns) {
+            if (columns <= 0) 1f else (available.value / columns / MONOSPACE_ADVANCE / BASE_SIZE).coerceIn(MIN_FIT, 1f)
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .horizontalScroll(rememberScrollState())
+                .padding(Spacing.lg),
+        ) {
+            content(fitted * zoom)
+        }
+    }
+}
+
+private const val MONOSPACE_ADVANCE = 0.6f
+private const val BASE_SIZE = 12f
+private const val MIN_FIT = 0.4f
+private const val MIN_ZOOM = 0.5f
+private const val MAX_ZOOM = 6f

--- a/app/src/main/java/io/github/nodyssey/ui/richtext/RichContent.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/richtext/RichContent.kt
@@ -25,6 +25,8 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SecondaryScrollableTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,6 +34,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,6 +61,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -67,6 +71,7 @@ import coil3.request.ImageRequest
 import io.github.nodyssey.R
 import io.github.nodyssey.core.image.ImagesDeferredException
 import io.github.nodyssey.core.image.allowMeteredImage
+import io.github.nodyssey.core.report.QualityReportParser
 import io.github.nodyssey.model.InlineNode
 import io.github.nodyssey.model.InlineStyle
 import io.github.nodyssey.model.RichNode
@@ -147,7 +152,7 @@ private fun RichBlock(
 
         is RichNode.BlockImage -> BlockImage(node = node, onImageClick = onImageClick)
 
-        is RichNode.CodeBlock -> CodeBlock(node)
+        is RichNode.CodeBlock -> CodeOrReport(node)
 
         is RichNode.Quote ->
             Row(modifier = Modifier.fillMaxWidth()) {
@@ -210,11 +215,87 @@ private fun RichBlock(
 
         is RichNode.Table -> DataTable(node, textStyle)
 
+        is RichNode.Tabs ->
+            TabGroup(
+                node = node,
+                onLinkClick = onLinkClick,
+                onImageClick = onImageClick,
+                onQuoteRefClick = onQuoteRefClick,
+                textStyle = textStyle,
+            )
+
         RichNode.Divider ->
             HorizontalDivider(
                 color = MaterialTheme.colorScheme.outlineVariant,
                 modifier = Modifier.padding(horizontal = Spacing.xl, vertical = Spacing.xs),
             )
+    }
+}
+
+/**
+ * NodeSeek's own tab group, which on the review board holds the four halves of a benchmark report.
+ *
+ * Showing one tab at a time is the whole point of the node: a NodeQuality post carries four reports
+ * of a couple of hundred lines each, and the site files them behind tabs for the same reason. The
+ * strip scrolls rather than wrapping or squeezing — four labels do not fit across 360dp.
+ */
+@Composable
+private fun TabGroup(
+    node: RichNode.Tabs,
+    onLinkClick: (String) -> Unit,
+    onImageClick: (String) -> Unit,
+    onQuoteRefClick: (InlineNode.QuoteRef) -> Unit,
+    textStyle: TextStyle,
+) {
+    if (node.tabs.isEmpty()) return
+
+    var selected by rememberSaveable { mutableIntStateOf(0) }
+    // Re-parsing a thread can change the tab count, and the saved index outlives the old node.
+    val index = selected.coerceIn(0, node.tabs.lastIndex)
+
+    Column(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .background(MaterialTheme.colorScheme.surfaceContainerLow),
+    ) {
+        SecondaryScrollableTabRow(
+            selectedTabIndex = index,
+            containerColor = Color.Transparent,
+            edgePadding = Spacing.sm,
+            divider = {},
+        ) {
+            node.tabs.forEachIndexed { position, tab ->
+                Tab(
+                    selected = position == index,
+                    onClick = { selected = position },
+                    text = {
+                        Text(
+                            text = tab.title,
+                            style = MaterialTheme.typography.labelLarge,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                )
+            }
+        }
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        Column(
+            modifier = Modifier.padding(Spacing.md),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            node.tabs[index].children.forEach { child ->
+                RichBlock(
+                    node = child,
+                    onLinkClick = onLinkClick,
+                    onImageClick = onImageClick,
+                    onQuoteRefClick = onQuoteRefClick,
+                    textStyle = textStyle,
+                )
+            }
+        }
     }
 }
 
@@ -386,6 +467,36 @@ private fun InlineImageError(onRetry: () -> Unit) {
 private enum class InlineImagePhase { Loading, Success, Deferred, Error }
 
 private val INLINE_IMAGE_LOADING_HEIGHT = 132.dp
+
+/**
+ * Draws a benchmark report as a report and everything else as code.
+ *
+ * The test is whether [QualityReportParser] can make sense of the text, not what language the site
+ * tagged it with: `language-ansi` is also how an unrelated coloured terminal paste arrives, and that
+ * is not a report. Parsing is cheap next to the layout it feeds and is remembered on the node, so a
+ * scroll past a thread of them does not repeat it.
+ */
+@Composable
+private fun CodeOrReport(node: RichNode.CodeBlock) {
+    val report = remember(node) { QualityReportParser.parse(node.code, node.spans) }
+    if (report == null) {
+        CodeBlock(node)
+        return
+    }
+
+    var showingSource by rememberSaveable(node.code) { mutableStateOf(false) }
+
+    ReportCard(report = report, onShowSource = { showingSource = true })
+
+    if (showingSource) {
+        ReportSourceDialog(
+            title = report.title,
+            source = node.code,
+            columns = node.columns,
+            onDismiss = { showingSource = false },
+        )
+    }
+}
 
 @Composable
 private fun CodeBlock(node: RichNode.CodeBlock) {

--- a/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Search
@@ -61,6 +62,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
 import io.github.nodyssey.R
 import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.data.Board
@@ -357,7 +359,7 @@ private fun PostResults(
     LazyColumn {
         items(
             count = posts.itemCount,
-            key = { index -> posts.peek(index)?.summary?.postId ?: index },
+            key = posts.itemKey { it.summary.postId },
         ) { index ->
             posts[index]?.let { post ->
                 PostRow(post = post, onClick = { onPostClick(post.summary.postId) })
@@ -505,7 +507,12 @@ private fun UserResults(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                Text("›", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
             }
         }
     }

--- a/app/src/main/java/io/github/nodyssey/ui/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/settings/NotificationSettingsScreen.kt
@@ -21,10 +21,12 @@ import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -86,11 +88,13 @@ fun NotificationSettingsScreen(
     modifier: Modifier = Modifier,
 ) {
     val enabled = settings.notificationsEnabled
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             MediumTopAppBar(
                 title = { Text(stringResource(R.string.notify_settings_title)) },
+                scrollBehavior = scrollBehavior,
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/app/src/main/java/io/github/nodyssey/ui/settings/OpenSourceLicensesScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/settings/OpenSourceLicensesScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import io.github.nodyssey.R
@@ -32,11 +34,13 @@ fun OpenSourceLicensesScreen(
     onOpenUri: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             LargeTopAppBar(
                 title = { Text(stringResource(R.string.settings_licenses)) },
+                scrollBehavior = scrollBehavior,
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/app/src/main/java/io/github/nodyssey/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/settings/SettingsScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -25,12 +25,14 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -85,11 +87,13 @@ fun SettingsScreen(
     var bodyFontSize by remember(state.settings.fontScale) {
         mutableFloatStateOf(fontScaleToBodySize(state.settings.fontScale))
     }
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             MediumTopAppBar(
                 title = { Text(stringResource(R.string.settings_title)) },
+                scrollBehavior = scrollBehavior,
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -178,7 +182,7 @@ fun SettingsScreen(
                     leading = { Icon(Icons.Default.Delete, contentDescription = null) },
                     trailing = {
                         if (state.isClearingCache) {
-                            CircularProgressIndicator(Modifier.width(22.dp))
+                            CircularProgressIndicator(Modifier.size(22.dp))
                         }
                     },
                 )

--- a/app/src/main/java/io/github/nodyssey/ui/theme/Color.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/theme/Color.kt
@@ -174,29 +174,39 @@ internal val NodysseyDarkColorScheme =
     )
 
 /**
- * The one tonal pair Material 3 has no role for.
+ * The tonal pairs Material 3 has no role for.
  *
  * Board tags are grouped into four colour families (see `BoardTag`), and the fourth — the boards
  * that carry a warning ("曝光", "内版") — needs a warm amber that is neither `error` nor any of the
  * three brand tones. Keeping it in a [staticCompositionLocalOf] rather than a top-level `val` is
  * what lets it flip with the theme like every other token.
+ *
+ * `success` joins it for the benchmark reports: those mark a check as passed or failed, and Material
+ * gives a role to only half of that pair. Green rather than a brand tone because the reports are
+ * read as a verdict — `error` opposite `primary` would read as "bad" opposite "branded".
  */
 @Immutable
 data class NodysseyExtraColors(
     val warningContainer: Color,
     val onWarningContainer: Color,
+    val successContainer: Color,
+    val onSuccessContainer: Color,
 )
 
 internal val LightExtraColors =
     NodysseyExtraColors(
         warningContainer = Color(0xFFF7E3A6),
         onWarningContainer = Color(0xFF4E3D00),
+        successContainer = Color(0xFFBFE9C8),
+        onSuccessContainer = Color(0xFF0A2E15),
     )
 
 internal val DarkExtraColors =
     NodysseyExtraColors(
         warningContainer = Color(0xFF4E4426),
         onWarningContainer = Color(0xFFF7E3A6),
+        successContainer = Color(0xFF244A2F),
+        onSuccessContainer = Color(0xFFBFE9C8),
     )
 
 val LocalNodysseyExtraColors = staticCompositionLocalOf { LightExtraColors }

--- a/app/src/main/java/io/github/nodyssey/ui/theme/Shape.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/theme/Shape.kt
@@ -4,7 +4,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes
 import androidx.compose.ui.unit.dp
 
-/** The Material 3 shape scale, at the radii the design doc specifies. */
+/**
+ * The Material 3 shape scale, at the radii the design doc specifies.
+ *
+ * The four in-between slots — `largeIncreased` (20.dp) and friends — are left at their Material
+ * defaults, which already match the design doc; read them as `MaterialTheme.shapes.largeIncreased`
+ * rather than declaring a parallel constant.
+ */
 val NodysseyShapes =
     Shapes(
         extraSmall = RoundedCornerShape(4.dp),
@@ -13,9 +19,6 @@ val NodysseyShapes =
         large = RoundedCornerShape(16.dp),
         extraLarge = RoundedCornerShape(28.dp),
     )
-
-/** Between `large` and `extraLarge`; Material 3 has the token but not yet a stable `Shapes` slot. */
-val ShapeLargeIncreased = RoundedCornerShape(20.dp)
 
 /**
  * The status-screen shape family.

--- a/app/src/main/java/io/github/nodyssey/ui/tools/CommunityToolsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/tools/CommunityToolsScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -54,11 +56,13 @@ fun CommunityToolsScreen(
     onAboutCommunity: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             LargeTopAppBar(
                 title = { Text(stringResource(R.string.tools_title)) },
+                scrollBehavior = scrollBehavior,
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(

--- a/app/src/main/java/io/github/nodyssey/ui/tools/LuckyScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/tools/LuckyScreen.kt
@@ -31,7 +31,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimeInput
 import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimePickerDialog
+import androidx.compose.material3.TimePickerDialogDefaults
+import androidx.compose.material3.TimePickerDisplayMode
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
@@ -365,10 +369,31 @@ private fun DrawTimePicker(
             initialMinute = current.minute,
             is24Hour = true,
         )
-    AlertDialog(
+    // The mode toggle is the reason this is `TimePickerDialog` and not an `AlertDialog` holding a
+    // `TimePicker`: dragging a dial to 23:59 is slow, and typing the time was simply unreachable.
+    var displayMode by remember { mutableStateOf(TimePickerDisplayMode.Picker) }
+    TimePickerDialog(
         onDismissRequest = onDismiss,
-        title = { Text(stringResource(R.string.lucky_pick_time)) },
-        text = { TimePicker(state = pickerState) },
+        title = {
+            Text(
+                text = stringResource(R.string.lucky_pick_time),
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.padding(bottom = 20.dp),
+            )
+        },
+        modeToggleButton = {
+            TimePickerDialogDefaults.DisplayModeToggle(
+                onDisplayModeChange = {
+                    displayMode =
+                        if (displayMode == TimePickerDisplayMode.Picker) {
+                            TimePickerDisplayMode.Input
+                        } else {
+                            TimePickerDisplayMode.Picker
+                        }
+                },
+                displayMode = displayMode,
+            )
+        },
         confirmButton = {
             TextButton(onClick = { onPicked(combineTime(millis, pickerState.hour, pickerState.minute)) }) {
                 Text(stringResource(R.string.action_done))
@@ -377,7 +402,13 @@ private fun DrawTimePicker(
         dismissButton = {
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
         },
-    )
+    ) {
+        if (displayMode == TimePickerDisplayMode.Input) {
+            TimeInput(state = pickerState)
+        } else {
+            TimePicker(state = pickerState)
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,9 @@
     <!-- Actions -->
     <string name="action_back">返回</string>
     <string name="action_close">关闭</string>
+    <string name="action_expand">展开</string>
+    <string name="action_collapse">收起</string>
+    <string name="report_show_source">查看原始报告</string>
     <string name="action_retry">重试</string>
     <string name="action_refresh">刷新</string>
     <string name="search_load_more_failed">加载更多失败</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -365,8 +365,6 @@
     <string name="account_password_new">新密码</string>
     <string name="account_password_confirm">确认新密码</string>
     <string name="account_password_confirm_hint">再输入一次新密码</string>
-    <string name="account_password_show">显示密码</string>
-    <string name="account_password_hide">隐藏密码</string>
     <string name="account_password_update">更新密码</string>
     <string name="account_password_mismatch">两次输入的新密码不一致</string>
     <string name="account_password_too_short">新密码至少 %1$d 位</string>

--- a/app/src/test/java/io/github/nodyssey/core/html/AnsiParserTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/html/AnsiParserTest.kt
@@ -1,0 +1,102 @@
+package io.github.nodyssey.core.html
+
+import org.jsoup.Jsoup
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnsiParserTest {
+
+    private fun code(html: String) = requireNotNull(Jsoup.parse("<pre><code>$html</code></pre>").selectFirst("code"))
+
+    private fun decode(html: String) = AnsiParser.decode(AnsiParser.sourceOf(code(html)))
+
+    /**
+     * The bug this class exists for: the escapes are empty elements, so reading the code element as
+     * text loses them and leaves their parameters behind as visible `[36m`.
+     */
+    @Test
+    fun `rebuilds the escape characters that jsoup text would drop`() {
+        val html = """<span data-ansicode="27"></span>[36m容器/虚拟化：<span data-ansicode="27"></span>[0m"""
+
+        // The old reading, kept so that a regression back to `wholeText()` fails here.
+        assertEquals("[36m容器/虚拟化：[0m", code(html).wholeText())
+
+        assertEquals("容器/虚拟化：", decode(html).text)
+    }
+
+    @Test
+    fun `keeps the colour of the run the escape opened`() {
+        val html = """<span data-ansicode="27"></span>[36m架构：<span data-ansicode="27"></span>[32mx86_64<span data-ansicode="27"></span>[0m"""
+
+        val decoded = decode(html)
+
+        assertEquals("架构：x86_64", decoded.text)
+        assertEquals(2, decoded.spans.size)
+        val label = decoded.spans[0]
+        assertEquals(0 to 3, label.start to label.end)
+        assertEquals(6, label.fg)
+        val value = decoded.spans[1]
+        assertEquals("x86_64", decoded.text.substring(value.start, value.end))
+        assertEquals(2, value.fg)
+    }
+
+    @Test
+    fun `carries background and bold, which is how the reports draw their badges`() {
+        val decoded =
+            decode(
+                """<span data-ansicode="27"></span>[41m<span data-ansicode="27"></span>[1m ✘ VT-x <span data-ansicode="27"></span>[0m""",
+            )
+
+        // The badge's own trailing space goes with the block's trailing whitespace; mid-line, which
+        // is where the reports actually put these, it survives.
+        assertEquals(" ✘ VT-x", decoded.text)
+        val span = decoded.spans.single()
+        assertEquals(1, span.bg)
+        assertTrue(span.bold)
+    }
+
+    @Test
+    fun `a reset closes every attribute at once`() {
+        val html = """<span data-ansicode="27"></span>[1m<span data-ansicode="27"></span>[4mbold<span data-ansicode="27"></span>[0mplain"""
+
+        val decoded = decode(html)
+
+        assertEquals("boldplain", decoded.text)
+        val span = decoded.spans.single()
+        assertEquals("bold", decoded.text.substring(span.start, span.end))
+        assertTrue(span.bold)
+        assertTrue(span.underline)
+    }
+
+    /** The reports use backspace to overstrike their bar graphs; a text layout cannot honour it. */
+    @Test
+    fun `drops control characters that are not newline or tab`() {
+        val html = """945<span data-ansicode="8"></span><span data-ansicode="13"></span>|"""
+
+        assertEquals("945|", decode(html).text)
+    }
+
+    @Test
+    fun `counts CJK and emoji as two columns`() {
+        // 80 ASCII columns is the report's own rule width.
+        assertEquals(80, AnsiParser.decode("+".repeat(80)).columns)
+        assertEquals(10, AnsiParser.decode("容器虚拟化").columns)
+        assertEquals(2, AnsiParser.decode("💻").columns)
+        // The widest line wins, not the last one.
+        assertEquals(6, AnsiParser.decode("ab\n容器虚\nc").columns)
+    }
+
+    @Test
+    fun `leaves ordinary code alone`() {
+        val decoded = AnsiParser.decode("curl -sL https://run.nodequality.com | bash\n\tindented")
+
+        assertEquals("curl -sL https://run.nodequality.com | bash\n\tindented", decoded.text)
+        assertTrue(decoded.spans.isEmpty())
+    }
+
+    @Test
+    fun `a truncated escape takes its parameters with it`() {
+        assertEquals("done", AnsiParser.decode("done\u001B[36").text)
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/core/html/MagicTabsParserTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/html/MagicTabsParserTest.kt
@@ -1,0 +1,135 @@
+package io.github.nodyssey.core.html
+
+import io.github.nodyssey.model.RichNode
+import org.jsoup.Jsoup
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The review board's benchmark posts, which are the densest markup NodeSeek produces.
+ *
+ * Shape taken verbatim from post 845099: four sibling title/body pairs, two of them holding an
+ * `language-ansi` report and two holding a screenshot.
+ */
+class MagicTabsParserTest {
+
+    private fun parse(html: String) = RichContentParser.parse(Jsoup.parse("<article>$html</article>").selectFirst("article"))
+
+    private val report =
+        """
+        <div class="nsk-magic-tabs"><div class="nsk-magic-tab-title">💻基本信息</div>
+        <div class="nsk-magic-tab-body"><pre><code class="language-ansi">++++++++
+<span data-ansicode="27"></span>[36m容器/虚拟化：<span data-ansicode="27"></span>[32mKVM 虚拟机<span data-ansicode="27"></span>[0m
+</code></pre>
+        </div><div class="nsk-magic-tab-title">🎬IP质量</div>
+        <div class="nsk-magic-tab-body"><pre><code class="language-ansi">########
+<span data-ansicode="27"></span>[36m自治系统号：<span data-ansicode="27"></span>[32mAS3257<span data-ansicode="27"></span>[0m
+</code></pre>
+        </div><div class="nsk-magic-tab-title">🌐网络质量</div>
+        <div class="nsk-magic-tab-body"><p><img src="https://i.111666.best/image/n1Uzbj2KRJVCSvST2nR6Zc.webp" alt="image"></p>
+        </div></div>
+        """.trimIndent()
+
+    @Test
+    fun `keeps the tab group together instead of flattening it into one paragraph`() {
+        val nodes = parse(report)
+
+        val tabs = nodes.filterIsInstance<RichNode.Tabs>().single()
+        assertEquals(listOf("💻基本信息", "🎬IP质量", "🌐网络质量"), tabs.tabs.map { it.title })
+    }
+
+    /**
+     * The regression that made a report unreadable: with the wrapper unrecognised the reports became
+     * `InlineNode.Text(code = true)` inside a single paragraph, so they rendered at body size and
+     * wrapped. Nothing may survive at the top level except the group.
+     */
+    @Test
+    fun `the reports are code blocks, not inline code in a body paragraph`() {
+        val nodes = parse(report)
+
+        assertEquals(1, nodes.size)
+        val bodies = nodes.filterIsInstance<RichNode.Tabs>().single().tabs.map { it.children }
+
+        val hardware = bodies[0].single() as RichNode.CodeBlock
+        assertEquals("ansi", hardware.language)
+        assertTrue(hardware.code.startsWith("++++++++"))
+
+        val ip = bodies[1].single() as RichNode.CodeBlock
+        assertTrue(ip.code.contains("AS3257"))
+    }
+
+    @Test
+    fun `strips the escape sequences that used to show up as literal bracket codes`() {
+        val hardware =
+            parse(report)
+                .filterIsInstance<RichNode.Tabs>()
+                .single()
+                .tabs[0]
+                .children
+                .single() as RichNode.CodeBlock
+
+        assertTrue("escape leaked: ${hardware.code}", !hardware.code.contains("[36m"))
+        assertTrue(hardware.code.contains("容器/虚拟化：KVM 虚拟机"))
+        assertEquals(2, hardware.spans.size)
+    }
+
+    /** A screenshot tab has to stay inside its tab rather than floating up to the post body. */
+    @Test
+    fun `an image tab keeps its image`() {
+        val networkTab =
+            parse(report).filterIsInstance<RichNode.Tabs>().single().tabs[2]
+
+        val image = networkTab.children.single() as RichNode.BlockImage
+        assertEquals("https://i.111666.best/image/n1Uzbj2KRJVCSvST2nR6Zc.webp", image.url)
+    }
+
+    @Test
+    fun `measures the report in terminal columns`() {
+        val hardware =
+            parse(report)
+                .filterIsInstance<RichNode.Tabs>()
+                .single()
+                .tabs[0]
+                .children
+                .single() as RichNode.CodeBlock
+
+        // "容器/虚拟化：KVM 虚拟机" — nine wide glyphs (the full-width colon counts) at two cells
+        // each, plus five narrow ones. The 8-column rule line above it does not win.
+        assertEquals(23, hardware.columns)
+    }
+
+    @Test
+    fun `content before the first title is kept ahead of the group`() {
+        val nodes =
+            parse(
+                """
+                <div class="nsk-magic-tabs"><p>报告如下</p><div class="nsk-magic-tab-title">💻基本信息</div>
+                <div class="nsk-magic-tab-body"><p>正文</p></div></div>
+                """.trimIndent(),
+            )
+
+        assertEquals(2, nodes.size)
+        assertTrue(nodes[0] is RichNode.Paragraph)
+        assertTrue(nodes[1] is RichNode.Tabs)
+    }
+
+    /** If the site renames its classes, losing the post entirely is worse than losing the tabs. */
+    @Test
+    fun `a group with no recognisable titles falls back to plain blocks`() {
+        val nodes = parse("""<div class="nsk-magic-tabs"><p>只有正文</p></div>""")
+
+        assertTrue(nodes.none { it is RichNode.Tabs })
+        assertEquals(1, nodes.filterIsInstance<RichNode.Paragraph>().size)
+    }
+
+    @Test
+    fun `ordinary code blocks are unaffected`() {
+        val nodes = parse("<pre><code class=\"language-bash\">curl -sL https://run.nodequality.com | bash</code></pre>")
+
+        val code = nodes.single() as RichNode.CodeBlock
+        assertEquals("bash", code.language)
+        assertEquals("curl -sL https://run.nodequality.com | bash", code.code)
+        assertTrue(code.spans.isEmpty())
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/core/report/QualityReportParserTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/report/QualityReportParserTest.kt
@@ -1,0 +1,275 @@
+package io.github.nodyssey.core.report
+
+import io.github.nodyssey.core.html.AnsiParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Driven by the two reports from post 845099, captured verbatim after ANSI decoding.
+ *
+ * They are the real thing rather than a reduction because every hard case here — a row that is short
+ * one cell, a header padded differently from its own body, arithmetic connectors mixed in with data
+ * — is something the scripts do that nobody would think to invent.
+ */
+class QualityReportParserTest {
+
+    private fun load(name: String): String =
+        checkNotNull(javaClass.classLoader?.getResourceAsStream("fixtures/reports/$name"))
+            .bufferedReader()
+            .readText()
+
+    private val hardware = checkNotNull(QualityReportParser.parse(load("hardware-quality.txt")))
+    private val ip = checkNotNull(QualityReportParser.parse(load("ip-quality.txt")))
+
+    private fun QualityReport.section(title: String) =
+        checkNotNull(sections.firstOrNull { it.title == title }) { "no section $title in ${sections.map { it.title }}" }
+
+    private fun QualityReport.Section.field(label: String) =
+        checkNotNull(blocks.filterIsInstance<QualityReport.Block.Field>().firstOrNull { it.label == label })
+
+    private fun QualityReport.Section.table() =
+        checkNotNull(blocks.filterIsInstance<QualityReport.Block.Table>().firstOrNull())
+
+    private fun QualityReport.Section.badges(label: String) =
+        checkNotNull(blocks.filterIsInstance<QualityReport.Block.Badges>().firstOrNull { it.label == label })
+
+    // --- Banner -------------------------------------------------------------
+
+    @Test
+    fun `reads the banner`() {
+        assertEquals("硬件质量体检报告", hardware.title)
+        assertEquals("86.53.*.*", hardware.target)
+        assertEquals("2026-07-28 12:14:43 CST", hardware.generatedAt)
+        assertEquals("v2026-05-21", hardware.scriptVersion)
+
+        assertEquals("IP质量体检报告", ip.title)
+        assertEquals("v2026-03-29", ip.scriptVersion)
+    }
+
+    @Test
+    fun `keeps the closing notes`() {
+        assertEquals(2, hardware.footnotes.size)
+        assertTrue(hardware.footnotes.last().contains("https://Report.Check.Place/hardware/YKCFLFS1L.svg"))
+    }
+
+    @Test
+    fun `drops the numbering from section titles`() {
+        assertEquals(
+            listOf("操作系统信息", "主板信息", "CPU测评", "内存测评", "硬盘测评", "HQ硬件加权评分"),
+            hardware.sections.map { it.title },
+        )
+    }
+
+    // --- Fields -------------------------------------------------------------
+
+    @Test
+    fun `reflows the padding the terminal needed`() {
+        assertEquals(
+            listOf("Debian GNU/Linux 12 (bookworm) 5.10.0-14-cloud-amd64"),
+            hardware.section("操作系统信息").field("操作系统/内核").values,
+        )
+        assertEquals(
+            listOf("读取 43989.9 MB/s 写入 19808.9 MB/s 延迟 169 ns"),
+            hardware.section("内存测评").field("Sysbench").values,
+        )
+    }
+
+    /** A value too long for eighty columns is continued indented, and is not a row of its own. */
+    @Test
+    fun `folds continuation lines into the row above`() {
+        assertEquals(
+            listOf(
+                "Intel 82371SB PIIX3 ISA [Natoma/Triton II]",
+                "Intel 440FX - 82441FX PMC [Natoma]",
+            ),
+            hardware.section("主板信息").field("芯片组").values,
+        )
+        assertEquals(2, hardware.section("CPU测评").field("CPU").values.size)
+    }
+
+    /** With the bar's colours and its backspace gone, a leading pipe is all that is left of it. */
+    @Test
+    fun `strips what is left of the bar charts`() {
+        assertEquals(listOf("945"), hardware.section("CPU测评").field("GB5单核").values)
+        assertEquals(listOf("低风险"), ip.section("风险评分").field("DB-IP").values)
+    }
+
+    // --- Tables -------------------------------------------------------------
+
+    @Test
+    fun `reads a table whose header is padded differently from its body`() {
+        // 风险因子 separates its eight names by one space; its rows use four.
+        val table = ip.section("风险因子").table()
+
+        assertEquals(
+            listOf("IP2Location", "ipapi", "ipregistry", "IPQS", "Scamalytics", "ipdata", "IPinfo", "DB-IP"),
+            table.columns,
+        )
+        assertEquals(7, table.rows.size)
+        assertEquals("服务器", table.rows[4].label)
+        assertEquals(listOf("是", "是", "是", "无", "否", "否", "否", "无"), table.rows[4].cells)
+    }
+
+    /**
+     * 公司类型 has nothing to say about AbuseIPDB, so it is one cell short.
+     *
+     * Index order would still be right here because the gap is at the end, but the parser does not
+     * get to assume that — the cells are placed under the column they physically sit beneath.
+     */
+    @Test
+    fun `places a short row under the columns it lines up with`() {
+        val table = ip.section("IP类型属性").table()
+
+        assertEquals(listOf("IPinfo", "ipregistry", "ipapi", "IP2Location", "AbuseIPDB"), table.columns)
+        assertEquals(listOf("家宽", "家宽", "家宽", "机房", "家宽"), table.rows[0].cells)
+        assertEquals(listOf("家宽", "机房", "家宽", "机房", ""), table.rows[1].cells)
+    }
+
+    @Test
+    fun `splits the fio row on its own column separator`() {
+        val table = hardware.section("硬盘测评").table()
+
+        assertEquals(
+            listOf("RND4K/Q1", "IOPS", "RND4K/Q32", "IOPS", "SEQ1M/Q1", "IOPS", "SEQ1M/Q8", "IOPS"),
+            table.columns,
+        )
+        assertEquals(listOf("37.9MB/s", "9.7k", "222MB/s", "57k", "2719MB/s", "2.7k", "5270MB/s", "5.3k"), table.rows[0].cells)
+    }
+
+    @Test
+    fun `treats the score row's arithmetic as arithmetic`() {
+        val table = hardware.section("HQ硬件加权评分").table()
+
+        // `总 分` is letter-spaced for the terminal, and `= + +` joins the parts of a sum.
+        assertEquals(listOf("总分", "CPU", "GPU", "内存", "硬盘"), table.columns)
+        assertEquals(listOf("42832", "21839", "N/A", "18168", "2825"), table.rows[0].cells)
+        assertEquals(listOf("13.9%", "19.8%", "N/A", "15.7%", "10.7%"), table.rows[1].cells)
+    }
+
+    /** A single spaced-out row is a value, not a one-row table. */
+    @Test
+    fun `does not mistake a lone spaced row for a table`() {
+        val risk = ip.section("风险评分")
+
+        assertTrue(risk.blocks.none { it is QualityReport.Block.Table })
+        assertEquals(listOf("极低 低 中等 高 极高"), risk.field("风险等级").values)
+    }
+
+    // --- Badges -------------------------------------------------------------
+
+    @Test
+    fun `reads the capability markers`() {
+        val items = hardware.section("CPU测评").badges("指令集").items
+
+        assertEquals(listOf("VT-x/AMD-V", "AES-NI", "AVX2", "BMI1/2", "EPT/NPT"), items.map { it.text })
+    }
+
+    @Test
+    fun `turns the mail run into separate verdicts`() {
+        val items = ip.section("邮局连通性及黑名单检测").badges("通信").items
+
+        assertEquals(12, items.size)
+        assertEquals("Gmail", items[0].text)
+        assertTrue(items[0].passed)
+        assertEquals("QQ", items[4].text)
+        assertTrue(!items[4].passed)
+    }
+
+    /**
+     * The glyph and the colour disagree on 超开指标, and the colour is the one that means anything.
+     *
+     * A working balloon reclaim is written `✔ 气球回收` on a red ground because it means the host is
+     * overselling memory. Reading the tick as good would tell the reader the opposite of the truth.
+     */
+    @Test
+    fun `takes good and bad from the colour, not from the tick`() {
+        val decoded =
+            AnsiParser.decode(
+                listOf(
+                    "++++++++",
+                    "        硬件质量体检报告：1.2.3.4",
+                    "        报告时间：2026-07-28 12:14:43 CST  脚本版本：v2026-05-21",
+                    "++++++++",
+                    "五、内存测评",
+                    "超开指标：\u001B[41m ✔ 气球回收 \u001B[0m   \u001B[42m ✘ KSM 复用 \u001B[0m",
+                    "========",
+                ).joinToString("\n"),
+            )
+
+        val report = checkNotNull(QualityReportParser.parse(decoded.text, decoded.spans))
+        val items = report.section("内存测评").badges("超开指标").items
+
+        assertEquals(listOf("气球回收", "KSM 复用"), items.map { it.text })
+        assertTrue("a red ✔ is not good news", !items[0].passed)
+        assertTrue("a green ✘ is good news", items[1].passed)
+    }
+
+    @Test
+    fun `falls back to the tick when there is no colour`() {
+        val items = hardware.section("内存测评").badges("超开指标").items
+
+        assertTrue(items[0].passed)
+        assertTrue(!items[1].passed)
+    }
+
+    // --- Rejection ----------------------------------------------------------
+
+    /**
+     * NetQuality rules with `*`, and is usually posted as the script's SVG rather than as text — so
+     * this covers the case where someone pastes it instead.
+     *
+     * Its latency bars are drawn with block characters and no label, which is what [Block.Note] is
+     * for: the alignment is the only structure they have left, so the spacing is kept.
+     */
+    @Test
+    fun `reads a report ruled with asterisks`() {
+        val report =
+            checkNotNull(
+                QualityReportParser.parse(
+                    listOf(
+                        "*".repeat(72),
+                        "        网络质量体检报告：182.16.*.*",
+                        "        报告时间：2026-07-26 21:00:00 CST  脚本版本：v2026-01-25",
+                        "*".repeat(72),
+                        "一、BGP信息（BGP.TOOLS & HE.NET）",
+                        "注册信息：            APNIC, AS45753 Netsec Limited, Prefix/24",
+                        "四、三网TCP大包延迟",
+                        "津    156    156    154 冀      0    181    161",
+                        "=".repeat(72),
+                        "今日网络检测量：1490",
+                    ).joinToString("\n"),
+                ),
+            )
+
+        assertEquals("网络质量体检报告", report.title)
+        assertEquals("v2026-01-25", report.scriptVersion)
+        assertEquals(
+            listOf("APNIC, AS45753 Netsec Limited, Prefix/24"),
+            report.section("BGP信息（BGP.TOOLS & HE.NET）").field("注册信息").values,
+        )
+
+        val bars = report.section("三网TCP大包延迟").blocks.single() as QualityReport.Block.Note
+        assertEquals("津    156    156    154 冀      0    181    161", bars.text)
+    }
+
+    @Test
+    fun `returns null for text that is not a report`() {
+        assertNull(QualityReportParser.parse("curl -sL https://run.nodequality.com | bash"))
+        // Rules alone are not enough; something between them has to name a report.
+        assertNull(QualityReportParser.parse("++++++++\nhello\n++++++++"))
+    }
+
+    @Test
+    fun `survives a report that stops halfway`() {
+        val truncated = load("hardware-quality.txt").substringBefore("五、内存测评")
+
+        val report = QualityReportParser.parse(truncated)
+
+        assertNotNull(report)
+        assertEquals("硬件质量体检报告", report?.title)
+        assertTrue(report?.footnotes.isNullOrEmpty())
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/core/report/YabsReportParserTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/report/YabsReportParserTest.kt
@@ -1,0 +1,124 @@
+package io.github.nodyssey.core.report
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The other report family: NodeQuality's own header block, which is yabs output.
+ *
+ * Shapes taken from `part/header.sh` and `part/yabs.sh` in LloydAsp/NodeQuality — a banner with no
+ * report name in it, headings underlined with dashes, `Label     : value` on a half-width colon, and
+ * pipe-delimited tables with a dashed separator row.
+ */
+class YabsReportParserTest {
+
+    private val report =
+        checkNotNull(
+            QualityReportParser.parse(
+                checkNotNull(javaClass.classLoader?.getResourceAsStream("fixtures/reports/nodequality-yabs.txt"))
+                    .bufferedReader()
+                    .readText(),
+            ),
+        )
+
+    private fun section(title: String) =
+        checkNotNull(report.sections.firstOrNull { it.title == title }) {
+            "no section $title in ${report.sections.map { it.title }}"
+        }
+
+    private fun QualityReport.Section.field(label: String) =
+        checkNotNull(blocks.filterIsInstance<QualityReport.Block.Field>().firstOrNull { it.label == label })
+
+    /** This banner names no report, so the project that produced it is the only name available. */
+    @Test
+    fun `names the report after the project when the banner does not`() {
+        assertEquals("NodeQuality", report.title)
+        assertEquals(null, report.target)
+        assertEquals("2025-03-24 10:39:57 CST", report.generatedAt)
+        assertEquals("v0.0.1", report.scriptVersion)
+    }
+
+    @Test
+    fun `takes a heading from the dashes drawn under it`() {
+        assertEquals(
+            listOf(
+                "Basic System Information",
+                "IPv4 Network Information",
+                "fio Disk Speed Tests (Mixed R/W 50/50) (Partition -)",
+                "iperf3 Network Speed Tests (IPv4)",
+            ),
+            report.sections.map { it.title },
+        )
+    }
+
+    @Test
+    fun `reads a label written with a half-width colon`() {
+        assertEquals(listOf("Intel Xeon Processor (SierraForest)"), section("Basic System Information").field("Processor").values)
+        assertEquals(listOf("2 @ 2699.998 MHz"), section("Basic System Information").field("CPU cores").values)
+    }
+
+    /** A colon inside a value must not be mistaken for the label's own. */
+    @Test
+    fun `does not cut a value at a colon of its own`() {
+        assertEquals(listOf("AS25820 IT7 Networks Inc"), section("IPv4 Network Information").field("ASN").values)
+    }
+
+    @Test
+    fun `reads the cross mark yabs uses`() {
+        val basics = section("Basic System Information")
+        val aes = basics.blocks.filterIsInstance<QualityReport.Block.Badges>().first { it.label == "AES-NI" }
+
+        assertEquals(listOf("Enabled"), aes.items.map { it.text })
+        assertTrue(aes.items.single().passed)
+
+        val virt = basics.blocks.filterIsInstance<QualityReport.Block.Badges>().first { it.label == "VM-x/AMD-V" }
+        assertTrue(!virt.items.single().passed)
+    }
+
+    /** yabs writes two verdicts into one field where xykt would have padded them apart. */
+    @Test
+    fun `splits a field holding two verdicts`() {
+        val stack =
+            section("Basic System Information")
+                .blocks
+                .filterIsInstance<QualityReport.Block.Badges>()
+                .first { it.label == "IPv4/IPv6" }
+
+        assertEquals(listOf("Online", "Offline"), stack.items.map { it.text })
+        assertEquals(listOf(true, false), stack.items.map { it.passed })
+    }
+
+    @Test
+    fun `reads a pipe-delimited table`() {
+        val table = section("iperf3 Network Speed Tests (IPv4)").blocks.filterIsInstance<QualityReport.Block.Table>().single()
+
+        assertEquals(listOf("Location (Link)", "Send Speed", "Recv Speed", "Ping"), table.columns)
+        assertEquals(6, table.rows.size)
+        assertEquals("Clouvider", table.rows.first().label)
+        assertEquals(listOf("London, UK (10G)", "872 Mbits/sec", "920 Mbits/sec", "186 ms"), table.rows.first().cells)
+    }
+
+    /**
+     * fio prints two block-size tables into one section, parted by a row of empty cells.
+     *
+     * Both have to survive as tables of their own, or the second one's numbers end up filed under
+     * the first one's block sizes.
+     */
+    @Test
+    fun `reads both of the tables fio puts in one section`() {
+        val tables = section("fio Disk Speed Tests (Mixed R/W 50/50) (Partition -)")
+            .blocks
+            .filterIsInstance<QualityReport.Block.Table>()
+
+        assertEquals(2, tables.size)
+        assertEquals(listOf("Read", "Write", "Total"), tables[0].rows.map { it.label })
+        assertEquals(listOf("Read", "Write", "Total"), tables[1].rows.map { it.label })
+        assertTrue(tables[0].columns.first().startsWith("4k"))
+        assertTrue(tables[1].columns.first().startsWith("512k"))
+
+        // Nothing drawn survives as a row of its own.
+        val labels = tables.flatMap { it.rows }.map { it.label }
+        assertTrue("separator survived: $labels", labels.none { it.isEmpty() || it.all { c -> c == '-' } })
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/ui/ViewModelTracking.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/ViewModelTracking.kt
@@ -1,0 +1,50 @@
+package io.github.nodyssey.ui
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.advanceUntilIdle
+
+/**
+ * Keeps every ViewModel a test builds, so they can all be shut down together afterwards.
+ *
+ * `onCleared` is protected, so nothing outside the class can retire a ViewModel — which was
+ * harmless while their only state was a `MutableStateFlow`. It stopped being harmless once they
+ * started mirroring `TextFieldState`s: `snapshotFlow` registers an observer on the *global*
+ * snapshot, so a ViewModel left running outlives its test and keeps watching writes made by every
+ * test that follows it in the same JVM. That is what turned the Compose screen tests flaky.
+ */
+internal class ViewModels {
+    private val tracked = mutableListOf<ViewModel>()
+
+    fun <T : ViewModel> track(viewModel: T): T = viewModel.also { tracked += it }
+
+    /**
+     * Call from `@After`, before `Dispatchers.resetMain()`.
+     *
+     * Cancelling is only half of it: a cancelled `snapshotFlow` collector unregisters its observer
+     * from its own `finally`, which never runs unless something dispatches the coroutine one last
+     * time. Hence the scheduler — without draining it the observers survive the test that made them.
+     */
+    fun clear(scheduler: TestCoroutineScheduler) {
+        tracked.forEach { it.viewModelScope.cancel() }
+        tracked.clear()
+        scheduler.advanceUntilIdle()
+    }
+}
+
+/**
+ * Types [text] into a field the way a keyboard would, from a test with no composition running.
+ *
+ * The `sendApplyNotifications` is the part that is easy to forget: the ViewModels observe their
+ * fields with `snapshotFlow`, and outside a Compose frame nothing pumps the snapshot system, so a
+ * write lands in the state but no collector ever hears about it.
+ */
+internal fun TextFieldState.typeText(text: String) {
+    setTextAndPlaceCursorAtEnd(text)
+    Snapshot.sendApplyNotifications()
+}

--- a/app/src/test/java/io/github/nodyssey/ui/account/SecurityScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/account/SecurityScreenTest.kt
@@ -1,5 +1,6 @@
 package io.github.nodyssey.ui.account
 
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsEnabled
@@ -47,17 +48,14 @@ class SecurityScreenTest {
             NodysseyTheme {
                 SecurityScreen(
                     state = state,
+                    currentPasswordState = rememberTextFieldState(state.currentPassword),
+                    newPasswordState = rememberTextFieldState(state.newPassword),
+                    confirmPasswordState = rememberTextFieldState(state.confirmPassword),
+                    twoFactorPasswordState = rememberTextFieldState(),
                     snackbarHostState = remember { SnackbarHostState() },
                     onBack = {},
-                    onCurrentPasswordChange = {},
-                    onNewPasswordChange = {},
-                    onRepeatPasswordChange = {},
-                    onToggleCurrentVisible = {},
-                    onToggleNewVisible = {},
-                    onToggleConfirmVisible = {},
                     onRequestPasswordChange = onRequestPasswordChange,
                     onRequestTwoFactor = {},
-                    onTwoFactorPasswordChange = {},
                     onDismissConfirmation = onDismissConfirmation,
                     onConfirmPasswordChange = onConfirmPasswordChange,
                     onConfirmTwoFactor = {},

--- a/app/src/test/java/io/github/nodyssey/ui/account/SecurityViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/account/SecurityViewModelTest.kt
@@ -1,11 +1,15 @@
 package io.github.nodyssey.ui.account
 
 import io.github.nodyssey.data.account.TwoFactorState
+import io.github.nodyssey.ui.ViewModels
+import io.github.nodyssey.ui.typeText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -28,20 +32,30 @@ class SecurityViewModelTest {
     fun setUp() = Dispatchers.setMain(dispatcher)
 
     @After
-    fun tearDown() = Dispatchers.resetMain()
+    fun tearDown() {
+        viewModels.clear(dispatcher.scheduler)
+        Dispatchers.resetMain()
+    }
 
-    private fun readyViewModel(repository: FakeAccountSettingsRepository): SecurityViewModel {
-        val vm = SecurityViewModel(repository)
-        vm.updateCurrentPassword("old-password")
-        vm.updateNewPassword("Correct-Horse-9")
-        vm.updateConfirmPassword("Correct-Horse-9")
+    private val viewModels = ViewModels()
+
+    private fun viewModel(repository: FakeAccountSettingsRepository) =
+        viewModels.track(SecurityViewModel(repository))
+
+    private fun TestScope.readyViewModel(repository: FakeAccountSettingsRepository): SecurityViewModel {
+        val vm = viewModel(repository)
+        vm.currentPasswordState.typeText("old-password")
+        vm.newPasswordState.typeText("Correct-Horse-9")
+        vm.confirmPasswordState.typeText("Correct-Horse-9")
+        runCurrent()
+        advanceUntilIdle()
         return vm
     }
 
     @Test
     fun `reads the two-factor state on open`() =
         runTest(dispatcher) {
-            val vm = SecurityViewModel(FakeAccountSettingsRepository(twoFactor = TwoFactorState(true)))
+            val vm = viewModel(FakeAccountSettingsRepository(twoFactor = TwoFactorState(true)))
             advanceUntilIdle()
 
             assertFalse(vm.uiState.value.isLoading)
@@ -112,12 +126,14 @@ class SecurityViewModelTest {
     fun `an incomplete or mismatched form cannot be submitted`() =
         runTest(dispatcher) {
             val repository = FakeAccountSettingsRepository()
-            val vm = SecurityViewModel(repository)
+            val vm = viewModel(repository)
             advanceUntilIdle()
 
-            vm.updateCurrentPassword("old-password")
-            vm.updateNewPassword("Correct-Horse-9")
-            vm.updateConfirmPassword("Correct-Horse-8")
+            vm.currentPasswordState.typeText("old-password")
+            vm.newPasswordState.typeText("Correct-Horse-9")
+            vm.confirmPasswordState.typeText("Correct-Horse-8")
+            runCurrent()
+            advanceUntilIdle()
             assertTrue(vm.uiState.value.isMismatched)
             assertFalse(vm.uiState.value.canSubmitPassword)
 
@@ -130,12 +146,14 @@ class SecurityViewModelTest {
     fun `a too-short password cannot be submitted`() =
         runTest(dispatcher) {
             val repository = FakeAccountSettingsRepository()
-            val vm = SecurityViewModel(repository)
+            val vm = viewModel(repository)
             advanceUntilIdle()
 
-            vm.updateCurrentPassword("old-password")
-            vm.updateNewPassword("short")
-            vm.updateConfirmPassword("short")
+            vm.currentPasswordState.typeText("old-password")
+            vm.newPasswordState.typeText("short")
+            vm.confirmPasswordState.typeText("short")
+            runCurrent()
+            advanceUntilIdle()
 
             assertTrue(vm.uiState.value.isTooShort)
             vm.confirmPasswordChange()
@@ -147,7 +165,7 @@ class SecurityViewModelTest {
     fun `two-factor enrolment also waits for its confirmation, then hands out the uri`() =
         runTest(dispatcher) {
             val repository = FakeAccountSettingsRepository()
-            val vm = SecurityViewModel(repository)
+            val vm = viewModel(repository)
             advanceUntilIdle()
 
             vm.requestTwoFactorEnrolment()
@@ -156,7 +174,9 @@ class SecurityViewModelTest {
             assertFalse(repository.calls.contains("beginTwoFactorEnrolment"))
 
             // The site's enrolment endpoint takes the account password, so the dialog collects one.
-            vm.updateTwoFactorPassword("hunter2!")
+            vm.twoFactorPasswordState.typeText("hunter2!")
+            runCurrent()
+            advanceUntilIdle()
             vm.confirmTwoFactorEnrolment()
             advanceUntilIdle()
 
@@ -173,7 +193,7 @@ class SecurityViewModelTest {
     fun `enrolment without a password never reaches the site`() =
         runTest(dispatcher) {
             val repository = FakeAccountSettingsRepository()
-            val vm = SecurityViewModel(repository)
+            val vm = viewModel(repository)
             advanceUntilIdle()
 
             vm.requestTwoFactorEnrolment()
@@ -188,9 +208,11 @@ class SecurityViewModelTest {
     @Test
     fun `the enrolment uri is consumed after being handed over`() =
         runTest(dispatcher) {
-            val vm = SecurityViewModel(FakeAccountSettingsRepository())
+            val vm = viewModel(FakeAccountSettingsRepository())
             advanceUntilIdle()
-            vm.updateTwoFactorPassword("hunter2!")
+            vm.twoFactorPasswordState.typeText("hunter2!")
+            runCurrent()
+            advanceUntilIdle()
             vm.confirmTwoFactorEnrolment()
             advanceUntilIdle()
 
@@ -202,7 +224,7 @@ class SecurityViewModelTest {
     @Test
     fun `a missing authenticator app is reported rather than swallowed`() =
         runTest(dispatcher) {
-            val vm = SecurityViewModel(FakeAccountSettingsRepository())
+            val vm = viewModel(FakeAccountSettingsRepository())
             advanceUntilIdle()
 
             vm.reportMissingAuthenticatorApp()

--- a/app/src/test/java/io/github/nodyssey/ui/common/MarkdownFormattingTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/common/MarkdownFormattingTest.kt
@@ -1,7 +1,7 @@
 package io.github.nodyssey.ui.common
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -21,67 +21,81 @@ class MarkdownFormattingTest {
         )
 
     private fun field(text: String, selection: IntRange? = null) =
-        TextFieldValue(
-            text = text,
-            selection =
+        TextFieldState(
+            initialText = text,
+            initialSelection =
             selection?.let { TextRange(it.first, it.last) } ?: TextRange(text.length),
         )
 
     @Test
     fun `with nothing selected the placeholder is inserted and the caret sits on it`() {
-        val result = field("").applyMarkdown(bold)
+        val state = field("")
 
-        assertEquals("**加粗文字**", result.text)
+        state.edit { applyMarkdown(bold) }
+
+        assertEquals("**加粗文字**", state.text.toString())
         // Just past the opening delimiter, so typing replaces the placeholder in place.
-        assertEquals(TextRange(2), result.selection)
+        assertEquals(TextRange(2), state.selection)
     }
 
     @Test
     fun `a selection is wrapped and the caret goes to the end`() {
-        val result = field("出杭州轻量", selection = 0..5).applyMarkdown(bold)
+        val state = field("出杭州轻量", selection = 0..5)
 
-        assertEquals("**出杭州轻量**", result.text)
-        assertEquals(TextRange("**出杭州轻量**".length), result.selection)
+        state.edit { applyMarkdown(bold) }
+
+        assertEquals("**出杭州轻量**", state.text.toString())
+        assertEquals(TextRange("**出杭州轻量**".length), state.selection)
     }
 
     @Test
     fun `a prefix-only action needs no suffix`() {
-        val result = field("关于我", selection = 0..3).applyMarkdown(heading)
+        val state = field("关于我", selection = 0..3)
 
-        assertEquals("## 关于我", result.text)
-        assertEquals(TextRange("## 关于我".length), result.selection)
+        state.edit { applyMarkdown(heading) }
+
+        assertEquals("## 关于我", state.text.toString())
+        assertEquals(TextRange("## 关于我".length), state.selection)
     }
 
     /** Link is the exception: with the text written, the URL is the only thing left to type. */
     @Test
     fun `link puts the caret in the url slot rather than at the end`() {
-        val result = field("星辰担保", selection = 0..4).applyMarkdown(link)
+        val state = field("星辰担保", selection = 0..4)
 
-        assertEquals("[星辰担保](https://)", result.text)
-        assertEquals(TextRange("[星辰担保](".length), result.selection)
+        state.edit { applyMarkdown(link) }
+
+        assertEquals("[星辰担保](https://)", state.text.toString())
+        assertEquals(TextRange("[星辰担保](".length), state.selection)
     }
 
     @Test
     fun `an empty link selection puts the caret on the link text`() {
-        val result = field("").applyMarkdown(link)
+        val state = field("")
 
-        assertEquals("[链接文字](https://)", result.text)
-        assertEquals(TextRange(1), result.selection)
+        state.edit { applyMarkdown(link) }
+
+        assertEquals("[链接文字](https://)", state.text.toString())
+        assertEquals(TextRange(1), state.selection)
     }
 
     @Test
     fun `formatting applies in the middle of existing text`() {
-        val result = field("交易走星辰担保，勿私", selection = 3..7).applyMarkdown(bold)
+        val state = field("交易走星辰担保，勿私", selection = 3..7)
 
-        assertEquals("交易走**星辰担保**，勿私", result.text)
-        assertEquals(TextRange("交易走**星辰担保**".length), result.selection)
+        state.edit { applyMarkdown(bold) }
+
+        assertEquals("交易走**星辰担保**，勿私", state.text.toString())
+        assertEquals(TextRange("交易走**星辰担保**".length), state.selection)
     }
 
+    /** The buffer clamps a selection to the text on construction; formatting must survive that. */
     @Test
     fun `an out-of-range selection is clamped rather than crashing`() {
-        val result =
-            TextFieldValue("短", selection = TextRange(0, 99)).applyMarkdown(bold)
+        val state = TextFieldState(initialText = "短", initialSelection = TextRange(0, 99))
 
-        assertEquals("**短**", result.text)
+        state.edit { applyMarkdown(bold) }
+
+        assertEquals("**短**", state.text.toString())
     }
 }

--- a/app/src/test/java/io/github/nodyssey/ui/composer/MarkdownEditingTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/MarkdownEditingTest.kt
@@ -1,87 +1,126 @@
 package io.github.nodyssey.ui.composer
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
+import io.github.nodyssey.ui.common.appendBlock
+import io.github.nodyssey.ui.common.deleteBackwards
+import io.github.nodyssey.ui.common.removeBlock
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /** The toolbar's text transforms, including where the caret lands afterwards. */
 class MarkdownEditingTest {
+    private fun field(text: String, selection: TextRange) =
+        TextFieldState(initialText = text, initialSelection = selection)
+
     @Test
     fun `bold wraps the selection and keeps it selected`() {
-        val value = TextFieldValue("规则改名费用", TextRange(2, 4))
+        val state = field("规则改名费用", TextRange(2, 4))
 
-        val result = applyMarkdown(value, EditorAction.BOLD)
+        state.edit { applyMarkdown(EditorAction.BOLD) }
 
-        assertEquals("规则**改名**费用", result.text)
-        assertEquals(TextRange(4, 6), result.selection)
+        assertEquals("规则**改名**费用", state.text.toString())
+        assertEquals(TextRange(4, 6), state.selection)
     }
 
     @Test
     fun `bold on an empty selection inserts a placeholder that the next keystroke replaces`() {
-        val result = applyMarkdown(TextFieldValue("", TextRange(0)), EditorAction.BOLD)
+        val state = field("", TextRange(0))
 
-        assertEquals("**加粗文字**", result.text)
-        assertEquals(TextRange(2, 6), result.selection)
+        state.edit { applyMarkdown(EditorAction.BOLD) }
+
+        assertEquals("**加粗文字**", state.text.toString())
+        assertEquals(TextRange(2, 6), state.selection)
     }
 
     @Test
     fun `a link puts the caret in the empty address, not on the label`() {
-        val result = applyMarkdown(TextFieldValue("看这个", TextRange(0, 3)), EditorAction.LINK)
+        val state = field("看这个", TextRange(0, 3))
 
-        assertEquals("[看这个](https://)", result.text)
-        assertEquals(TextRange("[看这个](https://".length), result.selection)
+        state.edit { applyMarkdown(EditorAction.LINK) }
+
+        assertEquals("[看这个](https://)", state.text.toString())
+        assertEquals(TextRange("[看这个](https://".length), state.selection)
+    }
+
+    /** Unlike the signature editor's link, which stops before the scheme. Both are deliberate. */
+    @Test
+    fun `an empty link selection still lands in the address`() {
+        val state = field("", TextRange(0))
+
+        state.edit { applyMarkdown(EditorAction.LINK) }
+
+        assertEquals("[链接文字](https://)", state.text.toString())
+        assertEquals(TextRange("[链接文字](https://".length), state.selection)
     }
 
     @Test
     fun `line prefixes toggle rather than stacking`() {
-        val quoted = applyMarkdown(TextFieldValue("第二行", TextRange(1)), EditorAction.QUOTE)
-        assertEquals("> 第二行", quoted.text)
+        val state = field("第二行", TextRange(1))
 
-        val unquoted = applyMarkdown(quoted, EditorAction.QUOTE)
-        assertEquals("第二行", unquoted.text)
+        state.edit { applyMarkdown(EditorAction.QUOTE) }
+        assertEquals("> 第二行", state.text.toString())
+
+        state.edit { applyMarkdown(EditorAction.QUOTE) }
+        assertEquals("第二行", state.text.toString())
     }
 
     @Test
     fun `a line prefix applies to the caret's own line`() {
-        val value = TextFieldValue("第一行\n第二行", TextRange(5))
+        val state = field("第一行\n第二行", TextRange(5))
 
-        val result = applyMarkdown(value, EditorAction.LIST)
+        state.edit { applyMarkdown(EditorAction.LIST) }
 
-        assertEquals("第一行\n- 第二行", result.text)
+        assertEquals("第一行\n- 第二行", state.text.toString())
     }
 
     @Test
     fun `an appended image starts its own block, and removing it leaves the body as it was`() {
         val image = "![a.png](https://cdn.nodeimage.com/i/a.webp)"
+        val state = field("正文", TextRange(2))
 
-        val withImage = appendBlock("正文", image)
+        state.edit { appendBlock(image) }
+        assertEquals("正文\n\n$image", state.text.toString())
 
-        assertEquals("正文\n\n$image", withImage)
-        assertEquals("正文", removeBlock(withImage, image))
+        state.edit { removeBlock(image) }
+        assertEquals("正文", state.text.toString())
     }
 
     @Test
     fun `appending to an empty body does not open with blank lines`() {
-        assertEquals("![a](u)", appendBlock("", "![a](u)"))
+        val state = field("", TextRange(0))
+
+        state.edit { appendBlock("![a](u)") }
+
+        assertEquals("![a](u)", state.text.toString())
+    }
+
+    /** The bug this migration fixed: an upload landing mid-sentence used to yank the caret away. */
+    @Test
+    fun `appending an image leaves the caret where the user was typing`() {
+        val state = field("正在写的一句话", TextRange(3))
+
+        state.edit { appendBlock("![a](u)") }
+
+        assertEquals(TextRange(3), state.selection)
     }
 
     @Test
     fun `backspace removes a whole emoji rather than half of it`() {
-        val value = TextFieldValue("赞一个🎉", TextRange("赞一个🎉".length))
+        val state = field("赞一个🎉", TextRange("赞一个🎉".length))
 
-        val result = value.deleteBackwards()
+        state.edit { deleteBackwards() }
 
-        assertEquals("赞一个", result.text)
+        assertEquals("赞一个", state.text.toString())
     }
 
     @Test
     fun `backspace removes a variation-selector emoji in one tap`() {
         // ❤️ is U+2764 + U+FE0F; a code-point step would leave the black text-style heart behind.
-        val value = TextFieldValue("好❤️", TextRange("好❤️".length))
+        val state = field("好❤️", TextRange("好❤️".length))
 
-        val result = value.deleteBackwards()
+        state.edit { deleteBackwards() }
 
-        assertEquals("好", result.text)
+        assertEquals("好", state.text.toString())
     }
 }

--- a/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerScreenTest.kt
@@ -1,5 +1,6 @@
 package io.github.nodyssey.ui.composer
 
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -34,10 +35,10 @@ class PostComposerScreenTest {
             NodysseyTheme {
                 PostComposerScreen(
                     state = state,
+                    titleState = rememberTextFieldState(state.title),
+                    bodyState = rememberTextFieldState(state.body),
                     snackbarHostState = SnackbarHostState(),
                     onClose = {},
-                    onTitleChange = {},
-                    onBodyChange = {},
                     onBoardSelect = {},
                     onPermissionSelect = {},
                     onViewModeChange = { viewMode = it },

--- a/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerViewModelTest.kt
@@ -12,6 +12,8 @@ import io.github.nodyssey.data.composer.PostDraft
 import io.github.nodyssey.data.composer.PostSubmission
 import io.github.nodyssey.data.composer.UploadStatus
 import io.github.nodyssey.data.session.SessionState
+import io.github.nodyssey.ui.ViewModels
+import io.github.nodyssey.ui.typeText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +22,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -38,6 +41,7 @@ class PostComposerViewModelTest {
     private val boards = MutableStateFlow(listOf(Board("tech", "技术", null)))
     private val uploader = FakeImageUploader()
     private val session = MutableStateFlow(SessionState(isSignedIn = true))
+    private val viewModels = ViewModels()
 
     @Before
     fun setUp() {
@@ -46,10 +50,12 @@ class PostComposerViewModelTest {
 
     @After
     fun tearDown() {
+        viewModels.clear(dispatcher.scheduler)
         Dispatchers.resetMain()
     }
 
-    private fun viewModel() = PostComposerViewModel(repository, boards, session, clock, uploader)
+    private fun viewModel() =
+        viewModels.track(PostComposerViewModel(repository, boards, session, clock, uploader))
 
     @Test
     fun `offers a saved draft and restores every field`() = runTest(dispatcher) {
@@ -78,8 +84,9 @@ class PostComposerViewModelTest {
         val viewModel = viewModel()
         advanceUntilIdle()
 
-        viewModel.updateTitle("新标题")
-        viewModel.updateBody("正文")
+        viewModel.titleState.typeText("新标题")
+        viewModel.bodyState.typeText("正文")
+        runCurrent()
         advanceTimeBy(749)
         assertNull(repository.savedDraft)
 
@@ -95,13 +102,15 @@ class PostComposerViewModelTest {
     fun `clearing the editor deletes the stored draft instead of resurrecting it`() = runTest(dispatcher) {
         val viewModel = viewModel()
         advanceUntilIdle()
-        viewModel.updateTitle("标题")
-        viewModel.updateBody("正文")
+        viewModel.titleState.typeText("标题")
+        viewModel.bodyState.typeText("正文")
+        runCurrent()
         advanceUntilIdle()
         assertEquals("标题", repository.savedDraft?.title)
 
-        viewModel.updateTitle("")
-        viewModel.updateBody("")
+        viewModel.titleState.typeText("")
+        viewModel.bodyState.typeText("")
+        runCurrent()
         advanceUntilIdle()
 
         assertEquals(1, repository.deleteCount)
@@ -113,8 +122,10 @@ class PostComposerViewModelTest {
         repository.publishError = NodeSeekException(NodeSeekError.Network)
         val viewModel = viewModel()
         advanceUntilIdle()
-        viewModel.updateTitle("标题")
-        viewModel.updateBody("正文")
+        viewModel.titleState.typeText("标题")
+        viewModel.bodyState.typeText("正文")
+        runCurrent()
+        advanceUntilIdle()
         viewModel.selectBoard(boards.value.single())
 
         viewModel.publish { error("must not publish") }
@@ -130,8 +141,10 @@ class PostComposerViewModelTest {
     fun `successful retry clears the draft and returns the post id`() = runTest(dispatcher) {
         val viewModel = viewModel()
         advanceUntilIdle()
-        viewModel.updateTitle("标题")
-        viewModel.updateBody("正文")
+        viewModel.titleState.typeText("标题")
+        viewModel.bodyState.typeText("正文")
+        runCurrent()
+        advanceUntilIdle()
         viewModel.selectBoard(boards.value.single())
         var publishedId: Long? = null
 
@@ -148,8 +161,10 @@ class PostComposerViewModelTest {
         repository.publishedId = null
         val viewModel = viewModel()
         advanceUntilIdle()
-        viewModel.updateTitle("标题")
-        viewModel.updateBody("正文")
+        viewModel.titleState.typeText("标题")
+        viewModel.bodyState.typeText("正文")
+        runCurrent()
+        advanceUntilIdle()
         viewModel.selectBoard(boards.value.single())
         var callbackInvoked = false
 
@@ -165,7 +180,9 @@ class PostComposerViewModelTest {
     fun `an uploaded image is appended to the body and removed with its cell`() = runTest(dispatcher) {
         val viewModel = viewModel()
         advanceUntilIdle()
-        viewModel.updateBody("正文")
+        viewModel.bodyState.typeText("正文")
+        runCurrent()
+        advanceUntilIdle()
 
         viewModel.addImages(listOf(PickedImage("content://pick/1", "screenshot.png")))
         advanceUntilIdle()
@@ -186,8 +203,10 @@ class PostComposerViewModelTest {
         uploader.failures = 1
         val viewModel = viewModel()
         advanceUntilIdle()
-        viewModel.updateTitle("标题")
-        viewModel.updateBody("正文")
+        viewModel.titleState.typeText("标题")
+        viewModel.bodyState.typeText("正文")
+        runCurrent()
+        advanceUntilIdle()
         viewModel.selectBoard(boards.value.single())
 
         viewModel.addImages(listOf(PickedImage("content://pick/1", "a.png")))

--- a/app/src/test/java/io/github/nodyssey/ui/composer/ReplyComposerViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/ReplyComposerViewModelTest.kt
@@ -8,6 +8,8 @@ import io.github.nodyssey.data.composer.CommentDraft
 import io.github.nodyssey.data.composer.CommentSubmission
 import io.github.nodyssey.data.composer.ImageAttachment
 import io.github.nodyssey.data.composer.ImageUploader
+import io.github.nodyssey.ui.ViewModels
+import io.github.nodyssey.ui.typeText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -15,6 +17,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -39,18 +42,22 @@ class ReplyComposerViewModelTest {
 
     @After
     fun tearDown() {
+        viewModels.clear(dispatcher.scheduler)
         Dispatchers.resetMain()
     }
 
+    private val viewModels = ViewModels()
+
     private fun viewModel(postId: Long = 1L) =
-        ReplyComposerViewModel(postId, repository, clock, uploader)
+        viewModels.track(ReplyComposerViewModel(postId, repository, clock, uploader))
 
     @Test
     fun `closing the sheet keeps the reply, and reopening restores the stored draft`() = runTest(dispatcher) {
         val viewModel = viewModel()
         viewModel.open()
         advanceUntilIdle()
-        viewModel.updateBody("写到一半")
+        viewModel.bodyState.typeText("写到一半")
+        runCurrent()
         advanceUntilIdle()
 
         assertEquals("写到一半", repository.saved[1L]?.body)
@@ -72,7 +79,8 @@ class ReplyComposerViewModelTest {
         val first = viewModel(postId = 1L)
         first.open()
         advanceUntilIdle()
-        first.updateBody("第一帖")
+        first.bodyState.typeText("第一帖")
+        runCurrent()
         advanceUntilIdle()
 
         val second = viewModel(postId = 2L)
@@ -100,7 +108,8 @@ class ReplyComposerViewModelTest {
             ),
         )
         advanceUntilIdle()
-        viewModel.updateBody("赞成用星辰兑换改名")
+        viewModel.bodyState.typeText("赞成用星辰兑换改名")
+        runCurrent()
         advanceUntilIdle()
 
         viewModel.publish {}
@@ -123,7 +132,8 @@ class ReplyComposerViewModelTest {
         val viewModel = viewModel(postId = 7L)
         viewModel.open(ReplyQuote(floor = 3, author = "nssk", excerpt = "占位"))
         advanceUntilIdle()
-        viewModel.updateBody("好")
+        viewModel.bodyState.typeText("好")
+        runCurrent()
         advanceUntilIdle()
 
         viewModel.publish {}
@@ -153,7 +163,8 @@ class ReplyComposerViewModelTest {
         val viewModel = viewModel()
         viewModel.open()
         advanceUntilIdle()
-        viewModel.updateBody("这条要留住")
+        viewModel.bodyState.typeText("这条要留住")
+        runCurrent()
         advanceUntilIdle()
 
         viewModel.publish { error("must not report success") }
@@ -183,11 +194,13 @@ class ReplyComposerViewModelTest {
         val viewModel = viewModel()
         viewModel.open()
         advanceUntilIdle()
-        viewModel.updateBody("先写点")
+        viewModel.bodyState.typeText("先写点")
+        runCurrent()
         advanceUntilIdle()
         assertEquals("先写点", repository.saved[1L]?.body)
 
-        viewModel.updateBody("")
+        viewModel.bodyState.typeText("")
+        runCurrent()
         advanceUntilIdle()
 
         assertNull(repository.saved[1L])

--- a/app/src/test/java/io/github/nodyssey/ui/richtext/ReportCardTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/richtext/ReportCardTest.kt
@@ -1,0 +1,120 @@
+package io.github.nodyssey.ui.richtext
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import io.github.nodyssey.core.html.AnsiParser
+import io.github.nodyssey.core.report.QualityReportParser
+import io.github.nodyssey.model.RichNode
+import io.github.nodyssey.ui.theme.NodysseyTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * What the report looks like once it is on screen rather than in a data class.
+ *
+ * The parser's own tests cover the reading; these cover the decision the renderer makes — that a
+ * benchmark report becomes a card and anything else stays a code block — and that the way back to
+ * the original is actually reachable.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp-xhdpi")
+class ReportCardTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun report(): String =
+        checkNotNull(javaClass.classLoader?.getResourceAsStream("fixtures/reports/hardware-quality.txt"))
+            .bufferedReader()
+            .readText()
+
+    private fun showCodeBlock(code: String, language: String? = "ansi") {
+        val decoded = AnsiParser.decode(code)
+        compose.setContent {
+            NodysseyTheme {
+                // The card is taller than a phone, which is the whole problem it exists for. Without
+                // a scroller the assertions below the fold would fail on layout rather than content.
+                Column(Modifier.verticalScroll(rememberScrollState())) {
+                    RichContent(
+                        nodes = listOf(
+                            RichNode.CodeBlock(
+                                code = decoded.text,
+                                language = language,
+                                spans = decoded.spans,
+                                columns = decoded.columns,
+                            ),
+                        ),
+                        onLinkClick = {},
+                        onImageClick = {},
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a benchmark report is drawn as rows, not as terminal art`() {
+        showCodeBlock(report())
+
+        // A label and its value, each a node of its own — which is what the padding used to encode.
+        compose.onNodeWithText("硬件质量体检报告").assertIsDisplayed()
+        compose.onNodeWithText("容器/虚拟化").assertIsDisplayed()
+        compose.onNodeWithText("KVM 虚拟机").assertIsDisplayed()
+
+        // Section headings survive without their numbering.
+        compose.onNodeWithText("CPU测评").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `capability markers become separate chips`() {
+        showCodeBlock(report())
+
+        compose.onNodeWithText("AES-NI").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("VT-x/AMD-V").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `the original stays one tap away`() {
+        showCodeBlock(report())
+
+        compose.onNodeWithText("查看原始报告").performScrollTo().performClick()
+
+        // The command that produced the report is in the banner and nowhere in the card, so finding
+        // it means the untouched text is on screen.
+        compose.onNodeWithText("bash <(curl -sL https://Check.Place) -H", substring = true).assertExists()
+    }
+
+    @Test
+    fun `the card collapses from its header`() {
+        showCodeBlock(report())
+
+        compose.onNodeWithText("CPU测评").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("硬件质量体检报告").performClick()
+
+        compose.onAllNodes(hasText("CPU测评")).assertCountEquals(0)
+    }
+
+    /** `language-ansi` is also how an ordinary coloured paste arrives, and that is not a report. */
+    @Test
+    fun `anything that is not a report stays a code block`() {
+        showCodeBlock("curl -sL https://run.nodequality.com | bash", language = "bash")
+
+        compose.onNodeWithText("curl -sL https://run.nodequality.com | bash").assertIsDisplayed()
+        assertEquals(null, QualityReportParser.parse("curl -sL https://run.nodequality.com | bash"))
+    }
+}

--- a/app/src/test/resources/fixtures/reports/hardware-quality.txt
+++ b/app/src/test/resources/fixtures/reports/hardware-quality.txt
@@ -1,0 +1,46 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+                          硬件质量体检报告：86.53.*.*
+                    https://github.com/xykt/HardwareQuality
+                    bash <(curl -sL https://Check.Place) -H
+            报告时间：2026-07-28 12:14:43 CST  脚本版本：v2026-05-21
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+一、操作系统信息
+容器/虚拟化：          KVM 虚拟机
+架构：                 x86_64
+操作系统/内核：        Debian GNU/Linux 12 (bookworm) 5.10.0-14-cloud-amd64
+运行时间：             0 天 7 小时 57 分钟
+负载：                 0.80, 0.36, 0.14
+进程：                 3 用户，87 进程，12/121 活跃/总服务
+区域设置：             C, UTF-8, Etc/UTC UTC +0000
+二、主板信息
+BIOS：    SeaBIOS, 版本1.16.0-1.module_el8.7.0+1140+ff0772f9
+芯片组：  Intel 82371SB PIIX3 ISA [Natoma/Triton II]
+          Intel 440FX - 82441FX PMC [Natoma]
+网卡：    Red Hat, Inc. Virtio network device
+三、CPU测评
+CPU：     AMD EPYC 7K62 48-Core Processor 步进0 (23代) 32/64-bit
+           ╚═ 2核心, 2线程, 2595.124MHz, 利用率2%               
+缓存：    L1d 64 KiB, L1i 64 KiB, L2 1 MiB, L3 384 MiB
+指令集：   ✘ VT-x/AMD-V    ✔ AES-NI    ✔ AVX2    ✔ BMI1/2    ✘ EPT/NPT 
+Sysbench：单线程 1471.21     多线程 2882.59
+GB5基准： J1900 N5105 N100 6700K 9900K 5900X 12900K 14900K 7713 7995WX
+GB5单核：      |945
+GB5多核：          |1832
+详细结果：https://browser.geekbench.com/v5/cpu/24484722
+五、内存测评
+内存：    总容量 3.8 GB,  已用 0.2 GB(6%),  可用 3.6 GB(94%)
+超开指标： ✔ 气球回收     ✘ KSM 复用 
+Sysbench：读取 43989.9 MB/s    写入 19808.9 MB/s    延迟 169 ns
+六、硬盘测评
+硬盘：    数量 1,  总容量 30G,  已用容量 2.3G(7%),  可用容量 26G(93%)
+测试设备：vda1(/r**t) -> DISK
+Fio测试： RND4K/Q1    IOPS||RND4K/Q32   IOPS||SEQ1M/Q1    IOPS||SEQ1M/Q8    IOPS
+读取：    37.9MB/s    9.7k||222MB/s      57k||2719MB/s    2.7k||5270MB/s    5.3k
+写入：    37.3MB/s    9.6k||163MB/s      42k||1494MB/s    1.5k||556MB/s      556
+七、HQ硬件加权评分
+项目：      总 分          CPU           GPU          内 存         硬 盘  
+分数：      42832    =    21839    +     N/A     +    18168    +    2825   
+排名：      13.9%         19.8%          N/A          15.7%         10.7%  
+================================================================================
+今日硬件检测量：215；总检测量：131861。感谢使用xy系列脚本！ 
+报告链接：https://Report.Check.Place/hardware/YKCFLFS1L.svg

--- a/app/src/test/resources/fixtures/reports/ip-quality.txt
+++ b/app/src/test/resources/fixtures/reports/ip-quality.txt
@@ -1,0 +1,48 @@
+########################################################################
+                       IP质量体检报告：86.53.*.*
+                   https://github.com/xykt/IPQuality
+                bash <(curl -sL https://Check.Place) -I
+        报告时间：2026-07-28 12:18:38 CST  脚本版本：v2026-03-29
+########################################################################
+一、基础信息（Maxmind 数据库）
+自治系统号：            AS3257
+组织：                  GTT Communications Inc.
+坐标：                  2°59′35″W, 51°35′21″N
+地图：                  https://check.place/51.5893,-2.9931,15,cn
+城市：                  威尔士, 纽波特, NP20
+使用地：                [DE]德国, [EU]欧洲
+注册地：                [GB]英国
+时区：                  Europe/London
+IP类型：                 广播IP 
+二、IP类型属性
+数据库：      IPinfo    ipregistry    ipapi    IP2Location   AbuseIPDB 
+使用类型：     家宽        家宽        家宽        机房        家宽    
+公司类型：     家宽        机房        家宽        机房    
+三、风险评分
+风险等级：      极低         低       中等       高         极高
+IP2Location：   3|低风险
+Scamalytics：      6|低风险
+ipapi：                    0.98%|较高风险
+AbuseIPDB：    0|低风险
+DB-IP：         |低风险
+四、风险因子
+库： IP2Location ipapi ipregistry IPQS Scamalytics ipdata IPinfo DB-IP
+地区：    [DE]    [DE]    [DE]     无     [DE]    [DE]    [DE]    [DE]
+代理：     否      否      否      无      否      否      否      否 
+Tor：      否      否      否      无      否      否      否      无 
+VPN：      否      否      否      无      否      无      否      无 
+服务器：   是      是      是      无      否      否      否      无 
+滥用：     否      否      否      无      否      否      无      否 
+机器人：   否      否      无      无      否      无      无      否 
+五、流媒体及AI服务解锁检测
+服务商：  TikTok   Disney+  Netflix Youtube  AmazonPV  Reddit   ChatGPT 
+状态：     解锁     解锁     解锁     解锁     解锁     解锁     解锁   
+地区：     [DE]     [DE]     [DE]     [DE]     [DE]     []     [DE]   
+方式：     原生     原生     原生     原生     原生     原生     原生   
+六、邮局连通性及黑名单检测
+本地25端口出站：可用
+通信：+Gmail+Outlook+Yahoo+Apple-QQ+MailRU+AOL-GMX-MailCOM+163-Sohu+Sina
+IP地址黑名单数据库：  有效 439   正常 413   已标记 26   黑名单 0
+========================================================================
+今日IP检测量：2081；总检测量：1828680。感谢使用xy系列脚本！ 
+报告链接：https://Report.Check.Place/ip/3D6BHSFPJ.svg

--- a/app/src/test/resources/fixtures/reports/nodequality-yabs.txt
+++ b/app/src/test/resources/fixtures/reports/nodequality-yabs.txt
@@ -1,0 +1,50 @@
+########################################################################
+                  bash <(curl -sL https://run.NodeQuality.com)
+                   https://github.com/LloydAsp/NodeQuality
+        报告时间：2025-03-24 10:39:57 CST  脚本版本：v0.0.1
+        频道: https://t.me/nodeselect 网站：https://NodeQuality.com
+########################################################################
+Basic System Information:
+---------------------------------
+Uptime     : 4 days, 12 hours, 34 minutes
+Processor  : Intel Xeon Processor (SierraForest)
+CPU cores  : 2 @ 2699.998 MHz
+AES-NI     : ✔ Enabled
+VM-x/AMD-V : ❌ Disabled
+RAM        : 2.0 GiB
+Swap       : 1024.0 MiB
+Disk       : 40.0 GiB
+Distro     : Debian GNU/Linux 12 (bookworm)
+Kernel     : 5.10.0-8-amd64
+VM Type    : KVM
+IPv4/IPv6  : ✔ Online / ❌ Offline
+IPv4 Network Information:
+---------------------------------
+ISP        : IT7 Networks Inc
+ASN        : AS25820 IT7 Networks Inc
+Host       : IT7 Networks Inc
+Location   : Hong Kong, Kowloon ()
+Country    : Hong Kong
+fio Disk Speed Tests (Mixed R/W 50/50) (Partition -):
+---------------------------------
+Block Size | 4k            (IOPS) | 64k           (IOPS)
+  ------   | ---            ----  | ----           ---- 
+Read       | 74.48 MB/s   (18.6k) | 905.08 MB/s  (14.1k)
+Write      | 74.68 MB/s   (18.6k) | 909.84 MB/s  (14.2k)
+Total      | 149.17 MB/s  (37.2k) | 1.81 GB/s    (28.3k)
+           |                      |                     
+Block Size | 512k          (IOPS) | 1m            (IOPS)
+  ------   | ---            ----  | ----           ---- 
+Read       | 1.29 GB/s     (2.5k) | 1.48 GB/s     (1.4k)
+Write      | 1.35 GB/s     (2.6k) | 1.58 GB/s     (1.5k)
+Total      | 2.65 GB/s     (5.1k) | 3.06 GB/s     (2.9k)
+iperf3 Network Speed Tests (IPv4):
+---------------------------------
+Provider        | Location (Link)           | Send Speed      | Recv Speed      | Ping           
+-----           | -----                     | ----            | ----            | ----           
+Clouvider       | London, UK (10G)          | 872 Mbits/sec   | 920 Mbits/sec   | 186 ms         
+Eranium         | Amsterdam, NL (100G)      | 858 Mbits/sec   | 783 Mbits/sec   | 213 ms         
+Uztelecom       | Tashkent, UZ (10G)        | 1.05 Gbits/sec  | 111 Mbits/sec   | 181 ms         
+Leaseweb        | Singapore, SG (10G)       | 1.04 Gbits/sec  | 992 Mbits/sec   | 182 ms         
+Clouvider       | Los Angeles, CA, US (10G) | 1.12 Gbits/sec  | 1.02 Gbits/sec  | 157 ms         
+Leaseweb        | NYC, NY, US (10G)         | 890 Mbits/sec   | 833 Mbits/sec   | 207 ms         


### PR DESCRIPTION
依赖升到 material3 `1.5.0-alpha24` 之后，foundation/ui 被拉到 `1.12.0-beta01`（比 BOM 声明的还新），一批组件从「官方没有」变成了「官方有」。逐屏审了一遍 UI 代码，把自造实现换回官方组件，并用新 API 简化了正文编辑这条链路。

推荐替换的 API 全部在本地 Gradle 缓存的实际构件里反编译核对过存在，不是照文档猜的。

## 换回官方组件

| 位置 | 原来 | 现在 |
|---|---|---|
| `AssetsScreen` 等级条/额度条 | 两只嵌套 `Box` 手绘 | `LinearProgressIndicator`（显式关掉 `gapSize` 与停止点圆点以保持原视觉） |
| `ConversationList` 未读数 | `Box`+`CircleShape`+`Text` 拼药丸 | `Badge`（容器色显式传 `primary`——未读不是出错） |
| `MessageThreadScreen` 发送键 | `Box`+`clickable`，双态色手工切 | `FilledIconButton` |
| `LuckyScreen` 时间选择 | `AlertDialog` 套 `TimePicker` | `TimePickerDialog`，**顺带解锁键盘输入模式**（之前只能拖表盘） |
| 翻页 / 用户行箭头 | 文本字符 `‹` `›` | `Icons.AutoMirrored.*`（字符不随 RTL 镜像，且 `FollowScreen` 早就用图标） |
| `Shape.kt` `ShapeLargeIncreased` | 顶层常量，注释称「M3 还没有槽位」 | 已过时，`Shapes.largeIncreased` 默认就是 20dp，常量删除 |

另外四屏（设置、通知设置、开源许可、社区工具）用了 Medium/Large 应用栏却**没传 `scrollBehavior`**，等于只拿了大标题的样子、丢了折叠行为、白占屏高——补上。Paging 列表的手写 `key` 改用官方 `itemKey`（原来用 index 兜底，占位符变实数据时 key 会跳变）。

## 正文编辑迁到 TextFieldState

这是最大的一处。整个 app 原本停在 `TextFieldValue`，光标与选区算术手写了三份，其中 `applyMarkdown` 在 `ui/common` 和 `ui/composer` 各有一份**并且已经开始漂移**。现在只剩 `ui/common` 一份，建在 `TextFieldBuffer` 上。

- **修掉一个真实缺陷**：图片上传是在打字过程中完成的，原来走 VM 的字符串路径整体重写正文，会把光标拽到末尾。现在 `bodyState.edit { appendBlock() }` 只动尾部，光标不动（已补回归测试）。
- 发帖器/回帖器的 `TextFieldState` 归 ViewModel 所有，UiState 经 `snapshotFlow` 单向镜像；「VM 存 String + LaunchedEffect 回同步」样板两处删除。提交路径直接读 `TextFieldState.text` 而非镜像——镜像天然慢一帧，发出去的必须就是屏幕上的。
- 标题长度改用 `InputTransformation.maxLength`，不再在 VM 里 `take()` 截断（截输入法组合文本会让字段发抖）。
- 安全页四个密码框换 `SecureTextField` + `RevealLastTyped`。手写的眼睛按钮、`PasswordVisualTransformation`、VM 里三个 `visible` 布尔全部消失。
- 补上一直缺失的 **autofill 语义**（`ContentType.Password` / `NewPassword`），密码管理器现在认得出这是改密表单。

## 审查时请重点看这三处判断

1. **两个编辑器的光标落点本来就不同，我没有统一它。** 正文编辑器加粗后**选中**包裹内容、链接落在 `https://` 之后；签名编辑器**放光标**、链接停在 `](`。重构不该悄悄改 UX，所以差异显式建模成 `MarkdownCaret` 三态，两边行为逐字保留，测试分别钉住。

2. **签名编辑器的 `TextFieldState` 放在 composition 里，不是 ViewModel。** 我先按发帖器的方式放进 VM，结果它让 `PostListScreenTest` 变得不稳定——ViewModel 持有的 `TextFieldState` 会在测试 JVM 里留下全局快照状态、污染后续 Compose 测试。放回 composition 后既解决问题，理由也更正当：签名框没有「后台写入抢光标」这回事，那正是发帖器需要 VM 持有的唯一理由。原来那段**在组合期间直接赋值、且丢选区**的同步也一并修掉。

3. **新增的 `ViewModelTracking.kt` 是在修我自己引入的测试不稳定。** 测试创建的 ViewModel 从来没被清理过，以前无害；现在它们用 `snapshotFlow` 观察全局快照，一个没退休的 ViewModel 会继续盯着同一 JVM 里后续每个测试的写入。`clear()` 取消作用域之后还必须把调度器排干，否则注销观察者的 `finally` 根本没机会跑。

## 验证

- `compileDebugKotlin`、`spotlessCheck`、`lintDebug` 全绿
- `testDebugUnitTest` **511 个测试，连续 4 次全量 `--rerun-tasks` 重跑全绿**（含 `PostListScreenTest` 原先必挂的那个执行位置）
- 未在真机/模拟器上跑过；视觉上会变化的两处建议扫一眼：四个设置类页面的大标题现在滚动会收起，未读徽章换成了 Badge 的标准尺寸

## 关于提交粒度

工作分三批交付，但合成了一个提交：三批的文件有交叉，且 `SecurityScreen` 第 1 批加的 autofill 语义已被第 3 批的 `SecureTextField` 整段重写——拆开会造出一个内容不复存在的中间提交，且那些中间态没有单独验证过是绿的。需要三段历史的话可以重新分拣。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
