### PR TITLE
搜索改走论坛管线，堵住触发 CF 的请求风暴

### DIFF
--- a/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
+++ b/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
@@ -158,6 +158,21 @@ object NodeSeekSite {
     /** `"#3"` → `3`. Anything else is a shape we did not expect, and the caller falls back to null. */
     fun parseFloorHash(hash: String?): Int? = hash?.trimStart('#')?.trim()?.toIntOrNull()
 
+    /**
+     * Post search. The same server-rendered list the boards serve, at a different route.
+     *
+     * Verified against the live site on 2026-08-01, because the app used to treat this route as if
+     * it were something special:
+     * - the response is one plain document — no XHR, no search API — carrying `#nsk-frame`,
+     *   `.post-list-item` **fifty to a page** and the ordinary `pager-next`, so [listPath]'s parser
+     *   reads it unchanged;
+     * - `category` is honoured **server-side**, and exactly one is accepted;
+     * - `sortBy=postTime` is honoured; its absence is the site's own relevance-ish ordering;
+     * - asking for a page past the end returns zero rows **but still renders `pager-next` as a
+     *   link**, so "are there more pages" cannot be read from the pager alone here — see
+     *   [io.github.nodyssey.core.html.SearchParser];
+     * - the route is throttled to one request per two seconds, answering 429 beyond that.
+     */
     fun postSearchPath(
         query: String,
         page: Int = 1,

--- a/app/src/main/java/io/github/nodyssey/core/html/SearchParser.kt
+++ b/app/src/main/java/io/github/nodyssey/core/html/SearchParser.kt
@@ -3,27 +3,30 @@ package io.github.nodyssey.core.html
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.core.net.NodeSeekException
-import io.github.nodyssey.model.PostSummary
+import io.github.nodyssey.model.PostListPage
 import org.jsoup.Jsoup
 
-data class PostSearchPage(
-    val posts: List<PostSummary>,
-    val totalPages: Int,
-    val hasNextPage: Boolean,
-)
-
 object SearchParser {
-    fun parsePosts(html: String, page: Int): PostSearchPage {
+    /**
+     * Reads `/search?q=…` with the board list's parser, then corrects the one thing it cannot know.
+     *
+     * The search pager lies past the end of the results: `/search?q=android&page=99` returns zero
+     * rows and *still* renders `pager-next` as an `<a>` pointing at page 2 (verified live
+     * 2026-08-01). Trusting it is what turned "scrolled to the bottom" into an endless walk —
+     * every empty page claimed another page followed, so Paging asked for one more, forever, at a
+     * rate the site's two-second throttle answers with 429 and Cloudflare eventually answers with a
+     * challenge.
+     *
+     * So an empty page ends the search, whatever the pager says. On a genuine last page the site
+     * renders `pager-next` as a disabled `<span>` and the ordinary rule already applies.
+     */
+    fun parsePosts(html: String, page: Int): PostListPage {
         val document = Jsoup.parse(html, NodeSeekSite.BASE_URL)
         if (document.getElementById("nsk-frame") == null) {
             throw NodeSeekException(NodeSeekError.LoginRequired)
         }
         // The list parser already reads the pager, "..100"-style elided totals included.
         val parsed = PostListParser.parse(html, page)
-        return PostSearchPage(
-            posts = parsed.posts,
-            totalPages = parsed.totalPages,
-            hasNextPage = parsed.hasNextPage,
-        )
+        return parsed.copy(hasNextPage = parsed.posts.isNotEmpty() && parsed.hasNextPage)
     }
 }

--- a/app/src/main/java/io/github/nodyssey/core/html/Selectors.kt
+++ b/app/src/main/java/io/github/nodyssey/core/html/Selectors.kt
@@ -74,4 +74,14 @@ object Selectors {
         "Just a moment...",
         "Checking your browser before accessing",
     )
+
+    /**
+     * NodeSeek's own throttle sentence, served as a JSON body on an HTML route.
+     *
+     * Captured live from `/search?q=…` on 2026-08-01: two requests inside two seconds and the second
+     * comes back `429 {"success":false,"message":"每隔2秒可以操作一次"}`. The status alone would be
+     * enough today, but the sentence is what makes the classification legible if the status ever
+     * softens to a 200.
+     */
+    val RATE_LIMIT_MARKERS = listOf("每隔2秒可以操作一次")
 }

--- a/app/src/main/java/io/github/nodyssey/core/net/ChallengeDetector.kt
+++ b/app/src/main/java/io/github/nodyssey/core/net/ChallengeDetector.kt
@@ -22,6 +22,13 @@ object ChallengeDetector {
         if (normalized["cf-mitigated"]?.lowercase() == "challenge") return NodeSeekError.Cloudflare
         if (Selectors.CLOUDFLARE_MARKERS.any { html.contains(it) }) return NodeSeekError.Cloudflare
 
+        // After the Cloudflare checks, before the generic status handling: a 429 that carried a
+        // challenge is Cloudflare's, everything else is the site's own two-second throttle, and
+        // "HTTP 429" as a screen title tells the reader nothing they can act on.
+        if (statusCode == 429 || Selectors.RATE_LIMIT_MARKERS.any { html.contains(it) }) {
+            return NodeSeekError.RateLimited
+        }
+
         if (statusCode !in 200..299) return NodeSeekError.Http(statusCode)
 
         return NodeSeekError.Unparsable

--- a/app/src/main/java/io/github/nodyssey/core/net/MinIntervalGate.kt
+++ b/app/src/main/java/io/github/nodyssey/core/net/MinIntervalGate.kt
@@ -1,0 +1,36 @@
+package io.github.nodyssey.core.net
+
+import io.github.nodyssey.core.AppClock
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Keeps consecutive calls at least [minIntervalMillis] apart.
+ *
+ * NodeSeek publishes a throttle on `/search` — one request per two seconds, 429 with
+ * `{"success":false,"message":"每隔2秒可以操作一次"}` beyond that — and answering a 429 with a retry
+ * is how a burst becomes a Cloudflare challenge. Waiting the difference out is both cheaper and the
+ * behaviour the site asked for.
+ *
+ * The lock is held only while the interval is measured and stamped, not for the call itself, so a
+ * slow request never blocks the next one beyond the interval it owes. The stamp is taken at
+ * dispatch because that is what the server times between.
+ */
+class MinIntervalGate(
+    private val minIntervalMillis: Long,
+    private val clock: AppClock,
+) {
+    private val mutex = Mutex()
+    private var lastStartedAtMillis = Long.MIN_VALUE
+
+    suspend fun <T> spaced(block: suspend () -> T): T {
+        mutex.withLock {
+            val owed = lastStartedAtMillis + minIntervalMillis - clock.nowMillis()
+            // A clock that jumped backwards would otherwise park the caller for as long as the jump.
+            if (owed > 0) delay(owed.coerceAtMost(minIntervalMillis))
+            lastStartedAtMillis = clock.nowMillis()
+        }
+        return block()
+    }
+}

--- a/app/src/main/java/io/github/nodyssey/core/net/NodeSeekError.kt
+++ b/app/src/main/java/io/github/nodyssey/core/net/NodeSeekError.kt
@@ -14,6 +14,16 @@ sealed interface NodeSeekError {
     /** The board or post requires a signed-in account. */
     data object LoginRequired : NodeSeekError
 
+    /**
+     * NodeSeek's own throttle, not Cloudflare's.
+     *
+     * `/search` answers a second request inside two seconds with **HTTP 429** and the body
+     * `{"success":false,"message":"每隔2秒可以操作一次"}` (verified live 2026-08-01). Kept apart from
+     * [Http] because the recovery is "wait a moment", not "retry now" — and apart from [Cloudflare]
+     * because opening a WebView solves nothing.
+     */
+    data object RateLimited : NodeSeekError
+
     /** An HTTP status we cannot use. */
     data class Http(val statusCode: Int) : NodeSeekError
 

--- a/app/src/main/java/io/github/nodyssey/data/FeedRemoteMediator.kt
+++ b/app/src/main/java/io/github/nodyssey/data/FeedRemoteMediator.kt
@@ -12,6 +12,7 @@ import io.github.nodyssey.data.local.FeedRemoteKeyEntity
 import io.github.nodyssey.data.local.NodeSeekDatabase
 import io.github.nodyssey.data.local.toEntity
 import io.github.nodyssey.model.FeedSort
+import io.github.nodyssey.model.PostListPage
 import kotlinx.coroutines.CancellationException
 
 /**
@@ -28,11 +29,17 @@ import kotlinx.coroutines.CancellationException
 @OptIn(ExperimentalPagingApi::class)
 class FeedRemoteMediator(
     private val feedKey: String,
-    private val categorySlug: String?,
-    private val sort: FeedSort,
     private val database: NodeSeekDatabase,
-    private val remote: PostRemoteDataSource,
     private val clock: AppClock,
+    /**
+     * How one page of this feed is fetched.
+     *
+     * A lambda rather than a `categorySlug` + `sort` pair because search is the same feed read from
+     * a different route: `/search?q=…` serves the same markup, pages the same way and must obey the
+     * same "one request per page, then write it to Room" rule. Everything below is about the
+     * database and applies unchanged to both.
+     */
+    private val loadPage: suspend (page: Int) -> PostListPage,
 ) : RemoteMediator<Int, FeedPostRow>() {
     /**
      * Decides whether opening the screen hits the network at all.
@@ -78,7 +85,7 @@ class FeedRemoteMediator(
             }
 
         return try {
-            val result = remote.loadList(categorySlug, page, sort)
+            val result = loadPage(page)
             val now = clock.nowMillis()
 
             database.withTransaction {
@@ -160,3 +167,31 @@ internal fun feedKeyFor(
 
 /** Empty string is safe as a key because NodeSeek slugs are never blank. */
 internal const val FRONT_PAGE_FEED_KEY = ""
+
+/**
+ * The key under which one search's results are stored.
+ *
+ * Prefixed so [SEARCH_FEED_KEY_PREFIX] can sweep them: a board feed is one of fifteen and worth
+ * keeping, while a search feed is one per query typed and would otherwise accumulate forever.
+ * Everything the query means is in the key — text, board, order — so changing any of them is a
+ * different feed rather than an append onto the previous answer.
+ */
+internal fun searchFeedKeyFor(
+    query: String,
+    categorySlug: String?,
+    sort: FeedSort,
+): String =
+    SEARCH_FEED_KEY_PREFIX +
+        listOf(
+            if (sort == FeedSort.POST_TIME) "postTime" else "",
+            categorySlug.orEmpty(),
+            query.trim(),
+        ).joinToString("|")
+
+/**
+ * `:` cannot appear in a board slug, so no board feed key can begin with this.
+ *
+ * Not `"search|"`: board keys are `slug` or `slug|postTime`, so a board actually called `search`
+ * would produce `search|postTime` and get swept along with the searches.
+ */
+internal const val SEARCH_FEED_KEY_PREFIX = "search:"

--- a/app/src/main/java/io/github/nodyssey/data/PostRemoteDataSource.kt
+++ b/app/src/main/java/io/github/nodyssey/data/PostRemoteDataSource.kt
@@ -1,9 +1,12 @@
 package io.github.nodyssey.data
 
+import io.github.nodyssey.core.AppClock
 import io.github.nodyssey.core.AppDispatchers
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.html.PostDetailParser
 import io.github.nodyssey.core.html.PostListParser
+import io.github.nodyssey.core.html.SearchParser
+import io.github.nodyssey.core.net.MinIntervalGate
 import io.github.nodyssey.core.net.NodeSeekClient
 import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.PostDetail
@@ -24,6 +27,17 @@ interface PostRemoteDataSource {
         sort: FeedSort,
     ): PostListPage
 
+    /**
+     * One page of `/search?q=…`, which is a board listing at a different route — same markup, same
+     * parser, same one-request-per-page contract as [loadList].
+     */
+    suspend fun loadSearch(
+        query: String,
+        page: Int,
+        categorySlug: String?,
+        sort: FeedSort,
+    ): PostListPage
+
     suspend fun loadDetail(
         postId: Long,
         page: Int,
@@ -33,7 +47,16 @@ interface PostRemoteDataSource {
 class NetworkPostDataSource(
     private val client: NodeSeekClient,
     private val dispatchers: AppDispatchers,
+    clock: AppClock = AppClock.System,
 ) : PostRemoteDataSource {
+    /**
+     * The site's published throttle, honoured on our side instead of discovered as a 429.
+     *
+     * Only search is gated. Board and post pages have never answered 429, and spacing them would
+     * slow ordinary scrolling for a limit that does not apply to them.
+     */
+    private val searchGate = MinIntervalGate(SEARCH_MIN_INTERVAL_MILLIS, clock)
+
     override suspend fun loadList(
         categorySlug: String?,
         page: Int,
@@ -44,11 +67,29 @@ class NetworkPostDataSource(
         return withContext(dispatchers.default) { PostListParser.parse(html, page) }
     }
 
+    override suspend fun loadSearch(
+        query: String,
+        page: Int,
+        categorySlug: String?,
+        sort: FeedSort,
+    ): PostListPage {
+        val html =
+            searchGate.spaced {
+                client.getHtml(NodeSeekSite.postSearchPath(query.trim(), page, categorySlug, sort))
+            }
+        return withContext(dispatchers.default) { SearchParser.parsePosts(html, page) }
+    }
+
     override suspend fun loadDetail(
         postId: Long,
         page: Int,
     ): PostDetail {
         val html = client.getHtml(NodeSeekSite.postPath(postId, page))
         return withContext(dispatchers.default) { PostDetailParser.parse(html, postId, page) }
+    }
+
+    companion object {
+        /** `/search` answers a second request inside two seconds with 429; see [MinIntervalGate]. */
+        const val SEARCH_MIN_INTERVAL_MILLIS = 2_000L
     }
 }

--- a/app/src/main/java/io/github/nodyssey/data/PostRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/PostRepository.kt
@@ -1,6 +1,8 @@
 package io.github.nodyssey.data
 
 import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -14,9 +16,11 @@ import io.github.nodyssey.data.local.NodeSeekDatabase
 import io.github.nodyssey.data.local.toSnapshot
 import io.github.nodyssey.data.local.toSummary
 import io.github.nodyssey.model.FeedSort
+import io.github.nodyssey.model.PostListPage
 import io.github.nodyssey.model.PostSummary
 import io.github.nodyssey.model.ThreadSnapshot
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 /**
@@ -33,6 +37,23 @@ data class FeedPost(
 )
 
 /**
+ * No results, and finished looking.
+ *
+ * A bare `PagingData.empty()` carries no load states, so every consumer sits in `Loading` forever —
+ * a spinner for a search nobody has run. Spelling the terminal states out is what lets the screen
+ * draw its empty state instead, and what stops `asSnapshot` in tests waiting for a page that is
+ * never coming.
+ */
+internal fun emptyLoadedPagingData(): PagingData<FeedPost> =
+    PagingData.empty(
+        LoadStates(
+            refresh = LoadState.NotLoading(endOfPaginationReached = true),
+            prepend = LoadState.NotLoading(endOfPaginationReached = true),
+            append = LoadState.NotLoading(endOfPaginationReached = true),
+        ),
+    )
+
+/**
  * The offline-first post repository.
  *
  * Reads come from Room and only from Room; the network's only role is to write into it. Callers get a
@@ -42,6 +63,23 @@ data class FeedPost(
 interface PostRepository {
     /** A pager backed by the database, refilled from the network by [FeedRemoteMediator]. */
     fun feed(
+        categorySlug: String?,
+        sort: FeedSort,
+    ): Flow<PagingData<FeedPost>>
+
+    /**
+     * The site's own `/search?q=…`, read exactly like a board feed.
+     *
+     * Deliberately the same return type, the same pager and the same mediator as [feed]: search is
+     * a list of NodeSeek posts served from a different route, and the moment it had a pipeline of
+     * its own it grew a second, worse one — several requests per load, nothing cached, and a pager
+     * that never admitted the end. Rows arrive with read state and reply badges for free, because
+     * they come out of the same table.
+     *
+     * @param categorySlug one board or none; the site accepts exactly one and filters server-side.
+     */
+    fun searchFeed(
+        query: String,
         categorySlug: String?,
         sort: FeedSort,
     ): Flow<PagingData<FeedPost>>
@@ -115,7 +153,37 @@ class OfflineFirstPostRepository(
         sort: FeedSort,
     ): Flow<PagingData<FeedPost>> {
         val feedKey = feedKeyFor(categorySlug, sort)
-        return Pager(
+        return pagedFeed(feedKey) { page -> remote.loadList(categorySlug, page, sort) }
+    }
+
+    override fun searchFeed(
+        query: String,
+        categorySlug: String?,
+        sort: FeedSort,
+    ): Flow<PagingData<FeedPost>> {
+        val normalized = query.trim()
+        if (normalized.isEmpty()) return flowOf(emptyLoadedPagingData())
+        val feedKey = searchFeedKeyFor(normalized, categorySlug, sort)
+        return pagedFeed(feedKey) { page ->
+            // Swept on the first page only, which is where a refresh always starts: appends have
+            // nothing to sweep, and doing it here rather than at submit time keeps it on the
+            // mediator's dispatcher, inside the load that is about to write the replacement.
+            if (page == FeedRemoteMediator.FIRST_PAGE) {
+                database.withTransaction {
+                    database.feedDao().clearOtherSearchFeeds(SEARCH_FEED_KEY_PREFIX, feedKey)
+                    database.feedDao().clearOtherSearchRemoteKeys(SEARCH_FEED_KEY_PREFIX, feedKey)
+                }
+            }
+            remote.loadSearch(normalized, page, categorySlug, sort)
+        }
+    }
+
+    /** One pager shape for every list of posts, so a feed and a search can never drift apart. */
+    private fun pagedFeed(
+        feedKey: String,
+        loadPage: suspend (page: Int) -> PostListPage,
+    ): Flow<PagingData<FeedPost>> =
+        Pager(
             config =
             PagingConfig(
                 pageSize = NETWORK_PAGE_SIZE,
@@ -127,19 +195,16 @@ class OfflineFirstPostRepository(
             remoteMediator =
             FeedRemoteMediator(
                 feedKey = feedKey,
-                categorySlug = categorySlug,
-                sort = sort,
                 database = database,
-                remote = remote,
                 clock = clock,
+                loadPage = loadPage,
             ),
             pagingSourceFactory = { database.feedDao().pagingSource(feedKey) },
         ).flow.map { pagingData -> pagingData.map(FeedPostRow::toFeedPost) }
-    }
 
     override fun search(query: String): Flow<List<FeedPost>> {
         val escaped = query.trim().escapeLikePattern()
-        if (escaped.isEmpty()) return kotlinx.coroutines.flow.flowOf(emptyList())
+        if (escaped.isEmpty()) return flowOf(emptyList())
         return database.feedDao().search(escaped).map { rows -> rows.map(FeedPostRow::toFeedPost) }
     }
 

--- a/app/src/main/java/io/github/nodyssey/data/SearchRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/SearchRepository.kt
@@ -2,14 +2,9 @@ package io.github.nodyssey.data
 
 import io.github.nodyssey.core.AppDispatchers
 import io.github.nodyssey.core.NodeSeekSite
-import io.github.nodyssey.core.html.SearchParser
-import io.github.nodyssey.core.net.HtmlSource
 import io.github.nodyssey.core.net.JsonSource
 import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.core.net.NodeSeekException
-import io.github.nodyssey.model.FeedSort
-import io.github.nodyssey.model.PostSummary
-import io.github.nodyssey.model.SearchSort
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -26,63 +21,23 @@ data class UserSearchResult(
     val commentCount: Int?,
 )
 
-/** One server page of post results, so the caller can page on demand instead of prefetching. */
-data class PostSearchResults(
-    val posts: List<PostSummary>,
-    val page: Int,
-    val totalPages: Int,
-    val hasNextPage: Boolean,
-)
-
+/**
+ * Member lookup, and only member lookup.
+ *
+ * Post search used to live here too, with a fetch-and-page implementation of its own. It is now
+ * [PostRepository.searchFeed] — `/search?q=…` is a board listing at another route, so it belongs on
+ * the pipeline that already knows how to read one. This half stays separate because it genuinely is
+ * different: `/api/account/find/…` is real JSON, unpaged, and answers in one request.
+ */
 interface SearchRepository {
-    suspend fun searchPosts(
-        query: String,
-        page: Int,
-        categorySlugs: Set<String>,
-        sort: SearchSort,
-    ): PostSearchResults
-
     suspend fun searchUsers(query: String): List<UserSearchResult>
 }
 
 class NetworkSearchRepository(
-    private val htmlSource: HtmlSource,
     private val jsonSource: JsonSource,
     private val dispatchers: AppDispatchers,
 ) : SearchRepository {
     private val json = Json { ignoreUnknownKeys = true }
-
-    /*
-     * Exactly one request per call, exactly the site's own search route. Prefetching every result
-     * page in parallel was what tripped Cloudflare's rate limiting: a popular keyword turned one
-     * search into dozens of simultaneous requests. Ordering is the server's — its relevance ranking
-     * for RELEVANCE, `sortBy=postTime` for TIME — so pages append without reshuffling.
-     */
-    override suspend fun searchPosts(
-        query: String,
-        page: Int,
-        categorySlugs: Set<String>,
-        sort: SearchSort,
-    ): PostSearchResults {
-        val feedSort = if (sort == SearchSort.TIME) FeedSort.POST_TIME else FeedSort.LAST_REPLY
-        // NodeSeek accepts one category per request. A single selected board goes to the server;
-        // a multi-board range searches globally and filters each page locally as it arrives.
-        val serverCategory = categorySlugs.singleOrNull()
-        val html =
-            htmlSource.getHtml(
-                NodeSeekSite.postSearchPath(query.trim(), page, serverCategory, feedSort),
-            )
-        val parsed = withContext(dispatchers.default) { SearchParser.parsePosts(html, page) }
-        return PostSearchResults(
-            posts =
-            parsed.posts
-                .filter { post -> categorySlugs.size < 2 || post.categorySlug in categorySlugs }
-                .distinctBy(PostSummary::postId),
-            page = page,
-            totalPages = parsed.totalPages,
-            hasNextPage = parsed.hasNextPage,
-        )
-    }
 
     override suspend fun searchUsers(query: String): List<UserSearchResult> {
         val normalized = query.trim()

--- a/app/src/main/java/io/github/nodyssey/data/local/FeedDao.kt
+++ b/app/src/main/java/io/github/nodyssey/data/local/FeedDao.kt
@@ -89,6 +89,20 @@ interface FeedDao {
     @Query("DELETE FROM feed_positions WHERE feedKey = :feedKey")
     suspend fun clearFeed(feedKey: String)
 
+    /**
+     * Drops every stored search except the one being run.
+     *
+     * Board feeds are a fixed set of fifteen and worth keeping; search feeds are one per query the
+     * user has ever typed, so without this the two feed tables grow with the search history. Only
+     * one search is ever on screen, so nothing reachable is lost — and re-running an old query is a
+     * fresh request rather than a stale answer, which is the honest behaviour for a search anyway.
+     */
+    @Query("DELETE FROM feed_positions WHERE feedKey LIKE :prefix || '%' AND feedKey <> :keepFeedKey")
+    suspend fun clearOtherSearchFeeds(prefix: String, keepFeedKey: String)
+
+    @Query("DELETE FROM feed_remote_keys WHERE feedKey LIKE :prefix || '%' AND feedKey <> :keepFeedKey")
+    suspend fun clearOtherSearchRemoteKeys(prefix: String, keepFeedKey: String)
+
     @Query("SELECT * FROM feed_remote_keys WHERE feedKey = :feedKey")
     suspend fun remoteKey(feedKey: String): FeedRemoteKeyEntity?
 

--- a/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
@@ -175,12 +175,13 @@ class SettingsRepository(
     /** Local mirror of the site's Remote 启用节日主题 switch; the sync authority is the account. */
     suspend fun setHolidayTheme(enabled: Boolean) = edit { it[KEY_HOLIDAY_THEME] = enabled }
 
-    suspend fun recordRecentBoards(boards: Set<String>) {
-        if (boards.isEmpty()) return
+    /** Most-recently-scoped board, kept at the top of the range sheet. Null — the whole site — is not a board. */
+    suspend fun recordRecentBoard(slug: String?) {
+        if (slug.isNullOrBlank()) return
         dataStore.edit { preferences ->
             val recent = decodeValues(preferences[KEY_RECENT_BOARDS])
             preferences[KEY_RECENT_BOARDS] =
-                encodeValues(boards.toList() + recent.filterNot(boards::contains), MAX_RECENT_BOARDS)
+                encodeValues(listOf(slug) + recent.filterNot { it == slug }, MAX_RECENT_BOARDS)
         }
     }
 
@@ -323,6 +324,13 @@ fun isTimedNightHour(hourOfDay: Int): Boolean =
 const val TIMED_NIGHT_START_HOUR = 19
 const val TIMED_NIGHT_END_HOUR = 7
 
+/**
+ * The stored field stays a list even though the domain now holds one board.
+ *
+ * Records written by the multi-select build are already on disk; keeping the shape means they still
+ * decode, taking their first board as the scope, rather than every user losing their history to a
+ * silent parse failure.
+ */
 @Serializable
 private data class StoredSearchHistory(
     val query: String,
@@ -338,8 +346,12 @@ private data class StoredSearchHistory(
                 "LAST_REPLY" -> SearchSort.RELEVANCE
                 else -> runCatching { SearchSort.valueOf(sort) }.getOrDefault(SearchSort.RELEVANCE)
             }
-        return SearchHistoryEntry(query.trim(), resolvedTarget, categorySlugs.toSet(), resolvedSort)
-            .takeIf { it.query.isNotEmpty() }
+        return SearchHistoryEntry(
+            query = query.trim(),
+            target = resolvedTarget,
+            categorySlug = categorySlugs.sorted().firstOrNull()?.ifBlank { null },
+            sort = resolvedSort,
+        ).takeIf { it.query.isNotEmpty() }
     }
 }
 
@@ -347,6 +359,6 @@ private fun SearchHistoryEntry.toStored() =
     StoredSearchHistory(
         query = query,
         target = target.name,
-        categorySlugs = categorySlugs.sorted(),
+        categorySlugs = listOfNotNull(categorySlug),
         sort = sort.name,
     )

--- a/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
@@ -153,7 +153,7 @@ class DefaultAppContainer(
     /** The offline-first SSOT. Everything below reads from it; only the data sources write to it. */
     private val database by lazy { NodeSeekDatabase.create(appContext) }
 
-    private val remotePosts by lazy { NetworkPostDataSource(htmlClient, dispatchers) }
+    private val remotePosts by lazy { NetworkPostDataSource(htmlClient, dispatchers, clock) }
 
     override val postRepository: PostRepository by lazy {
         OfflineFirstPostRepository(database, remotePosts, clock)
@@ -190,7 +190,7 @@ class DefaultAppContainer(
     }
 
     override val searchRepository: SearchRepository by lazy {
-        NetworkSearchRepository(htmlClient, jsonClient, dispatchers)
+        NetworkSearchRepository(jsonClient, dispatchers)
     }
 
     override val postComposerRepository: PostComposerRepository by lazy {

--- a/app/src/main/java/io/github/nodyssey/model/SearchModels.kt
+++ b/app/src/main/java/io/github/nodyssey/model/SearchModels.kt
@@ -7,9 +7,17 @@ enum class SearchSort { RELEVANCE, TIME }
 data class SearchHistoryEntry(
     val query: String,
     val target: SearchTarget,
-    val categorySlugs: Set<String> = emptySet(),
+    /**
+     * The single board the search was scoped to, or null for the whole site.
+     *
+     * Singular because the server is: `/search` accepts exactly one `category` and applies it on
+     * its side. The multi-select this replaced could only be honoured by fetching unfiltered pages
+     * and discarding rows locally, so a quiet board meant walking page after page — the request
+     * storm that kept ending in a Cloudflare challenge.
+     */
+    val categorySlug: String? = null,
     val sort: SearchSort = SearchSort.RELEVANCE,
 ) {
     val key: String
-        get() = listOf(target.name, query, categorySlugs.sorted().joinToString(","), sort.name).joinToString("\u001E")
+        get() = listOf(target.name, query, categorySlug.orEmpty(), sort.name).joinToString("\u001E")
 }

--- a/app/src/main/java/io/github/nodyssey/ui/account/AccountComponents.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/account/AccountComponents.kt
@@ -49,6 +49,7 @@ private fun NodeSeekError.messageRes(): Int =
         NodeSeekError.Network -> R.string.status_network_title
         NodeSeekError.Unparsable -> R.string.status_unparsable_title
         NodeSeekError.NotWired -> R.string.status_not_wired_title
+        NodeSeekError.RateLimited -> R.string.status_rate_limited_title
         is NodeSeekError.Http, NodeSeekError.Unknown -> R.string.status_unknown_title
     }
 

--- a/app/src/main/java/io/github/nodyssey/ui/common/StatusViews.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/StatusViews.kt
@@ -186,6 +186,7 @@ fun NodeSeekError.shortMessage(): String =
         NodeSeekError.LoginRequired -> stringResource(R.string.status_sign_in_title)
         NodeSeekError.Network -> stringResource(R.string.status_network_title)
         NodeSeekError.Unparsable -> stringResource(R.string.status_unparsable_title)
+        NodeSeekError.RateLimited -> stringResource(R.string.status_rate_limited_title)
         is NodeSeekError.Http -> stringResource(R.string.status_http_title, statusCode)
         NodeSeekError.NotWired -> stringResource(R.string.status_not_wired_title)
         NodeSeekError.Unknown -> stringResource(R.string.status_unknown_title)
@@ -278,6 +279,20 @@ fun NodeSeekErrorState(
                 primaryAction =
                 StatusAction(stringResource(R.string.action_open_in_browser), onOpenBrowser),
                 secondaryAction = retry,
+                modifier = modifier,
+            )
+
+        // The site's own throttle, not Cloudflare's — so no verify button. Waiting is the whole fix,
+        // and offering the web page would just spend another request against the same limit.
+        NodeSeekError.RateLimited ->
+            StatusView(
+                icon = Icons.Default.Info,
+                shape = StatusShapes.NetworkError,
+                containerColor = extra.warningContainer,
+                iconColor = extra.onWarningContainer,
+                title = stringResource(R.string.status_rate_limited_title),
+                description = stringResource(R.string.status_rate_limited_body),
+                primaryAction = retry,
                 modifier = modifier,
             )
 

--- a/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
@@ -13,7 +13,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -29,7 +30,6 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -39,8 +39,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SearchBarValue
@@ -113,7 +113,7 @@ fun SearchRoute(
         onHistoryClick = viewModel::selectHistory,
         onRemoveHistory = viewModel::removeHistory,
         onClearHistory = viewModel::clearHistory,
-        onBoardsChange = viewModel::setBoards,
+        onBoardChange = viewModel::selectBoard,
         onSortChange = viewModel::selectSort,
         onPostClick = onPostClick,
         onUserClick = onUserClick,
@@ -141,7 +141,7 @@ fun SearchScreen(
     onVerify: () -> Unit,
     modifier: Modifier = Modifier,
     postResults: LazyPagingItems<FeedPost>? = null,
-    onBoardsChange: (Set<String>) -> Unit = {},
+    onBoardChange: (String?) -> Unit = {},
     onSortChange: (SearchSort) -> Unit = {},
 ) {
     var showBoardSheet by remember { mutableStateOf(false) }
@@ -238,11 +238,9 @@ fun SearchScreen(
                         onClick = { showBoardSheet = true },
                         label = {
                             Text(
-                                if (state.selectedBoards.isEmpty()) {
-                                    stringResource(R.string.search_all_boards)
-                                } else {
-                                    stringResource(R.string.search_selected_boards, state.selectedBoards.size)
-                                },
+                                state.selectedBoard
+                                    ?.let { slug -> state.boards.firstOrNull { it.slug == slug }?.title ?: slug }
+                                    ?: stringResource(R.string.search_all_boards),
                             )
                         },
                         trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, contentDescription = null) },
@@ -292,11 +290,11 @@ fun SearchScreen(
     if (showBoardSheet) {
         BoardRangeSheet(
             boards = state.boards,
-            selected = state.selectedBoards,
+            selected = state.selectedBoard,
             recentBoards = state.recentBoards,
             onDismiss = { showBoardSheet = false },
             onApply = {
-                onBoardsChange(it)
+                onBoardChange(it)
                 showBoardSheet = false
             },
         )
@@ -523,9 +521,9 @@ private fun historyScope(
     boards: List<Board>,
 ): String {
     if (entry.target == SearchTarget.USERS) return stringResource(R.string.search_user_history_scope)
-    if (entry.categorySlugs.isEmpty()) return stringResource(R.string.search_history_scope)
-    val names = entry.categorySlugs.map { slug -> boards.firstOrNull { it.slug == slug }?.title ?: slug }
-    return stringResource(R.string.search_history_board_scope, names.joinToString("、"))
+    val slug = entry.categorySlug ?: return stringResource(R.string.search_history_scope)
+    val name = boards.firstOrNull { it.slug == slug }?.title ?: slug
+    return stringResource(R.string.search_history_board_scope, name)
 }
 
 @Composable
@@ -572,16 +570,25 @@ private fun userDetail(user: UserSearchResult): String =
         if (user.bio == null) user.joinedText?.let { add("加入 $it") }
     }.joinToString(" · ")
 
+/**
+ * Picks the one board the search is scoped to.
+ *
+ * Single choice because `/search` takes a single `category` and applies it itself. The checkbox
+ * version of this sheet could only pretend to filter by several: it searched the whole site and
+ * dropped the rows that did not match, so a board with few hits made the app walk page after page
+ * looking for something to show. 全部版块 is a real option here, not an empty selection — it is what
+ * the site does when the parameter is absent.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BoardRangeSheet(
     boards: List<Board>,
-    selected: Set<String>,
+    selected: String?,
     recentBoards: List<String>,
     onDismiss: () -> Unit,
-    onApply: (Set<String>) -> Unit,
+    onApply: (String?) -> Unit,
 ) {
-    var checked by remember(selected) { mutableStateOf(selected) }
+    var picked by remember(selected) { mutableStateOf(selected) }
     val recent = recentBoards.mapNotNull { slug -> boards.firstOrNull { it.slug == slug } }
     val remaining = boards.filterNot { board -> recent.any { it.slug == board.slug } }
     ModalBottomSheet(
@@ -592,9 +599,6 @@ private fun BoardRangeSheet(
             enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
         ),
     ) {
-        val toggle: (Board, Boolean) -> Unit = { board, isChecked ->
-            board.slug?.let { slug -> checked = if (isChecked) checked + slug else checked - slug }
-        }
         Column(
             Modifier.fillMaxWidth().padding(horizontal = Spacing.xl, vertical = Spacing.md),
             verticalArrangement = Arrangement.spacedBy(Spacing.sm),
@@ -605,55 +609,56 @@ private fun BoardRangeSheet(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            // The board list scrolls on its own so the reset/apply row below stays reachable even
-            // on a short window; the buttons are the whole point of opening the sheet.
+            // The board list scrolls on its own so the apply row below stays reachable even on a
+            // short window; the button is the whole point of opening the sheet.
             Column(
                 Modifier
                     .weight(1f, fill = false)
+                    .selectableGroup()
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(Spacing.sm),
             ) {
+                BoardRadioRow(
+                    title = stringResource(R.string.search_all_boards),
+                    selected = picked == null,
+                    onSelect = { picked = null },
+                )
                 if (recent.isNotEmpty()) {
                     Text(
                         stringResource(R.string.search_recent_boards),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    BoardCheckboxGrid(recent, checked, toggle)
+                    BoardRadioGrid(recent, picked) { picked = it }
                 }
                 Text(
-                    stringResource(R.string.search_all_boards),
+                    stringResource(R.string.search_board_all_boards_heading),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                BoardCheckboxGrid(remaining, checked, toggle)
+                BoardRadioGrid(remaining, picked) { picked = it }
             }
-            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                OutlinedButton(onClick = { checked = emptySet() }, modifier = Modifier.weight(1f)) {
-                    Text(stringResource(R.string.search_reset))
-                }
-                Button(onClick = { onApply(checked) }, modifier = Modifier.weight(1f)) {
-                    Text(stringResource(R.string.search_apply_boards, checked.size))
-                }
+            Button(onClick = { onApply(picked) }, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.search_apply_board))
             }
         }
     }
 }
 
-/** Two columns: fourteen boards in seven rows fit a phone screen without a scroll to the buttons. */
+/** Two columns: fourteen boards in seven rows fit a phone screen without a scroll to the button. */
 @Composable
-private fun BoardCheckboxGrid(
+private fun BoardRadioGrid(
     boards: List<Board>,
-    checked: Set<String>,
-    onToggle: (Board, Boolean) -> Unit,
+    selected: String?,
+    onSelect: (String?) -> Unit,
 ) {
     boards.chunked(2).forEach { row ->
         Row(Modifier.fillMaxWidth()) {
             row.forEach { board ->
-                BoardCheckboxRow(
-                    board = board,
-                    checked = board.slug in checked,
-                    onCheckedChange = { onToggle(board, it) },
+                BoardRadioRow(
+                    title = board.title,
+                    selected = board.slug != null && board.slug == selected,
+                    onSelect = { onSelect(board.slug) },
                     modifier = Modifier.weight(1f),
                 )
             }
@@ -663,24 +668,24 @@ private fun BoardCheckboxGrid(
 }
 
 @Composable
-private fun BoardCheckboxRow(
-    board: Board,
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
+private fun BoardRadioRow(
+    title: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier =
-        modifier.toggleable(
-            value = checked,
-            role = Role.Checkbox,
-            onValueChange = onCheckedChange,
+        modifier.selectable(
+            selected = selected,
+            role = Role.RadioButton,
+            onClick = onSelect,
         ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Checkbox(checked = checked, onCheckedChange = null)
+        RadioButton(selected = selected, onClick = null)
         Text(
-            board.title,
+            title,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),

--- a/app/src/main/java/io/github/nodyssey/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/search/SearchViewModel.kt
@@ -8,21 +8,20 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
 import androidx.paging.PagingData
-import androidx.paging.PagingSource
-import androidx.paging.PagingState
 import androidx.paging.cachedIn
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.data.Board
 import io.github.nodyssey.data.CategoryRepository
 import io.github.nodyssey.data.FeedPost
+import io.github.nodyssey.data.PostRepository
 import io.github.nodyssey.data.SearchRepository
 import io.github.nodyssey.data.UserSearchResult
+import io.github.nodyssey.data.emptyLoadedPagingData
 import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.di.AppContainer
+import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.SearchHistoryEntry
 import io.github.nodyssey.model.SearchSort
 import io.github.nodyssey.model.SearchTarget
@@ -30,6 +29,7 @@ import io.github.nodyssey.ui.postlist.toNodeSeekError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,6 +42,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModel(
+    private val postRepository: PostRepository,
     private val searchRepository: SearchRepository,
     private val categoryRepository: CategoryRepository,
     private val settings: SettingsRepository,
@@ -57,21 +58,34 @@ class SearchViewModel(
     private val _uiState = MutableStateFlow(SearchUiState())
     val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
+    /**
+     * Post results, straight off the forum's own pipeline.
+     *
+     * There is no search-specific pager, paging source or cache here any more. A request describes
+     * a feed; [PostRepository.searchFeed] turns it into the same Room-backed, mediator-filled pager
+     * a board gets, which is what makes one page cost one request, returning to the screen cost
+     * none, and the results carry read state.
+     *
+     * A [MutableStateFlow] rather than a channel because it conflates: assigning a request equal to
+     * the current one emits nothing, so re-submitting the same search keeps the pager it already has
+     * instead of rebuilding it and spending a refresh proving the answer has not changed.
+     */
     private val postRequest = MutableStateFlow<PostSearchRequest?>(null)
-    val postResults: kotlinx.coroutines.flow.Flow<PagingData<FeedPost>> =
+    val postResults: Flow<PagingData<FeedPost>> =
         postRequest
             .flatMapLatest { request ->
                 if (request == null) {
-                    flowOf(PagingData.empty())
+                    flowOf(emptyLoadedPagingData())
                 } else {
-                    Pager(PagingConfig(pageSize = POST_PAGE_SIZE, initialLoadSize = POST_PAGE_SIZE)) {
-                        SearchPostsPagingSource(searchRepository, request)
-                    }.flow
+                    postRepository.searchFeed(
+                        query = request.query,
+                        categorySlug = request.board,
+                        sort = request.sort.toFeedSort(),
+                    )
                 }
             }.cachedIn(viewModelScope)
 
     private var userJob: Job? = null
-    private var postRequestGeneration = 0
 
     init {
         observeQuery()
@@ -114,7 +128,10 @@ class SearchViewModel(
         val state = _uiState.value
         val submitted = state.submittedQuery ?: return
         if (target == SearchTarget.POSTS) {
-            if (postRequest.value?.query != submitted) startPostSearch(submitted)
+            // Unconditional now that the request conflates: asking for the feed already on screen
+            // emits nothing, and the old "only if the query changed" guard missed a board or order
+            // picked while the users tab was in front.
+            startPostSearch(submitted)
         } else if (state.userLoadState == SearchLoadState.Idle) {
             startUserSearch(submitted)
         }
@@ -131,7 +148,7 @@ class SearchViewModel(
             SearchHistoryEntry(
                 query = typed,
                 target = state.target,
-                categorySlugs = if (state.target == SearchTarget.POSTS) state.selectedBoards else emptySet(),
+                categorySlug = if (state.target == SearchTarget.POSTS) state.selectedBoard else null,
                 sort = state.sort,
             ),
         )
@@ -142,7 +159,7 @@ class SearchViewModel(
         _uiState.update {
             it.copy(
                 target = entry.target,
-                selectedBoards = entry.categorySlugs,
+                selectedBoard = entry.categorySlug,
                 sort = entry.sort,
             )
         }
@@ -158,9 +175,11 @@ class SearchViewModel(
         viewModelScope.launch { settings.clearSearchHistory(target) }
     }
 
-    fun setBoards(boards: Set<String>) {
-        _uiState.update { it.copy(selectedBoards = boards) }
-        viewModelScope.launch { settings.recordRecentBoards(boards) }
+    /** Null scopes the search to the whole site, which is what the site does without a `category`. */
+    fun selectBoard(slug: String?) {
+        if (_uiState.value.selectedBoard == slug) return
+        _uiState.update { it.copy(selectedBoard = slug) }
+        viewModelScope.launch { settings.recordRecentBoard(slug) }
         rerunSubmittedSearch()
     }
 
@@ -175,13 +194,15 @@ class SearchViewModel(
         startUserSearch(state.submittedQuery ?: query.text.toString())
     }
 
-    fun challengeUrl(): String =
-        NodeSeekSite.BASE_URL +
+    fun challengeUrl(): String {
+        val state = _uiState.value
+        return NodeSeekSite.BASE_URL +
             NodeSeekSite.postSearchPath(
-                query = _uiState.value.submittedQuery ?: query.text.toString(),
-                categorySlug = _uiState.value.selectedBoards.singleOrNull(),
-                sort = if (_uiState.value.sort == SearchSort.TIME) io.github.nodyssey.model.FeedSort.POST_TIME else io.github.nodyssey.model.FeedSort.LAST_REPLY,
+                query = state.submittedQuery ?: query.text.toString(),
+                categorySlug = state.selectedBoard,
+                sort = state.sort.toFeedSort(),
             )
+    }
 
     private fun rerunSubmittedSearch() {
         val state = _uiState.value
@@ -192,7 +213,7 @@ class SearchViewModel(
             SearchHistoryEntry(
                 query = state.submittedQuery,
                 target = SearchTarget.POSTS,
-                categorySlugs = state.selectedBoards,
+                categorySlug = state.selectedBoard,
                 sort = state.sort,
             ),
         )
@@ -207,7 +228,6 @@ class SearchViewModel(
         // The box is trimmed to what was actually searched, the way it used to be when the UiState
         // held the text — otherwise a stray space stays visible next to results that ignored it.
         if (this.query.text.toString() != normalized) this.query.setTextAndPlaceCursorAtEnd(normalized)
-        postRequest.value = null
         userJob?.cancel()
         _uiState.update {
             it.copy(
@@ -222,19 +242,21 @@ class SearchViewModel(
         if (_uiState.value.target == SearchTarget.POSTS) {
             startPostSearch(normalized)
         } else {
+            postRequest.value = null
             startUserSearch(normalized)
         }
     }
 
+    /**
+     * Re-submitting the same search does *not* clear the request first.
+     *
+     * Dropping to null and back used to be how the results were reset, but it tears down the pager
+     * and rebuilds it, and the rebuild re-requests page one. Emitting the request as-is lets
+     * [distinctUntilChanged] recognise it, keep the pager, and serve the cached page.
+     */
     private fun startPostSearch(query: String) {
         val state = _uiState.value
-        postRequest.value =
-            PostSearchRequest(
-                query = query,
-                boards = state.selectedBoards,
-                sort = state.sort,
-                generation = ++postRequestGeneration,
-            )
+        postRequest.value = PostSearchRequest(query = query, board = state.selectedBoard, sort = state.sort)
     }
 
     private fun startUserSearch(query: String) {
@@ -259,13 +281,11 @@ class SearchViewModel(
     }
 
     companion object {
-        internal const val MAX_PAGES_PER_LOAD = 3
-        private const val POST_PAGE_SIZE = 20
-
         fun factory(container: AppContainer): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
                     SearchViewModel(
+                        postRepository = container.postRepository,
                         searchRepository = container.searchRepository,
                         categoryRepository = container.categoryRepository,
                         settings = container.settingsRepository,
@@ -274,6 +294,10 @@ class SearchViewModel(
             }
     }
 }
+
+/** The site expresses both orders with the one `sortBy` parameter the boards use. */
+internal fun SearchSort.toFeedSort(): FeedSort =
+    if (this == SearchSort.TIME) FeedSort.POST_TIME else FeedSort.LAST_REPLY
 
 sealed interface SearchLoadState {
     data object Idle : SearchLoadState
@@ -292,64 +316,16 @@ data class SearchUiState(
     val searchHistory: List<SearchHistoryEntry> = emptyList(),
     val recentBoards: List<String> = emptyList(),
     val boards: List<Board> = emptyList(),
-    val selectedBoards: Set<String> = emptySet(),
+    /** One board, or null for the whole site — the only two scopes `/search` can express. */
+    val selectedBoard: String? = null,
     val sort: SearchSort = SearchSort.RELEVANCE,
     val userResults: List<UserSearchResult> = emptyList(),
     val userLoadState: SearchLoadState = SearchLoadState.Idle,
 )
 
+/** Everything that names one search feed. Equality is what decides whether the pager is rebuilt. */
 internal data class PostSearchRequest(
     val query: String,
-    val boards: Set<String>,
+    val board: String?,
     val sort: SearchSort,
-    val generation: Int,
 )
-
-internal class SearchPostsPagingSource(
-    private val repository: SearchRepository,
-    private val request: PostSearchRequest,
-) : PagingSource<Int, FeedPost>() {
-    private val seenPostIds = mutableSetOf<Long>()
-
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FeedPost> =
-        try {
-            val startPage = params.key ?: 1
-            val knownIds = seenPostIds.toSet()
-            val summaries = mutableListOf<io.github.nodyssey.model.PostSummary>()
-            var currentPage = startPage
-            var lastLoadedPage = startPage
-            var hasNext = true
-            var fetchedPages = 0
-            do {
-                val result =
-                    repository.searchPosts(
-                        query = request.query,
-                        page = currentPage,
-                        categorySlugs = request.boards,
-                        sort = request.sort,
-                    )
-                summaries += result.posts.filter { it.postId !in knownIds }
-                lastLoadedPage = result.page
-                hasNext = result.hasNextPage
-                fetchedPages++
-                if (summaries.isEmpty() && hasNext) currentPage = result.page + 1
-            } while (
-                summaries.isEmpty() &&
-                hasNext &&
-                fetchedPages < SearchViewModel.MAX_PAGES_PER_LOAD
-            )
-
-            val unique = summaries.distinctBy { it.postId }
-            seenPostIds += unique.map { it.postId }
-            LoadResult.Page(
-                data = unique.map { FeedPost(it, isRead = false, newCommentCount = 0) },
-                prevKey = null,
-                nextKey = if (hasNext) lastLoadedPage + 1 else null,
-            )
-        } catch (throwable: Throwable) {
-            if (throwable is CancellationException) throw throwable
-            LoadResult.Error(throwable)
-        }
-
-    override fun getRefreshKey(state: PagingState<Int, FeedPost>): Int? = null
-}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,7 +167,6 @@
     <string name="search_posts_tab">帖子</string>
     <string name="search_users_tab">用户</string>
     <string name="search_all_boards">全部版块</string>
-    <string name="search_selected_boards">已选 %1$d 个版块</string>
     <string name="search_sort_relevance">相关度</string>
     <string name="search_sort_time">时间</string>
     <string name="search_history_empty">还没有搜索记录</string>
@@ -175,10 +174,10 @@
     <string name="search_user_history_scope">用户</string>
     <string name="search_history_board_scope">帖子 · %1$s</string>
     <string name="search_board_range">版块范围</string>
-    <string name="search_board_range_hint">选择要搜索的版块，最近使用会置顶</string>
+    <string name="search_board_range_hint">只能选一个版块，站点搜索接口本身只支持单版块；最近使用会置顶</string>
     <string name="search_recent_boards">最近使用</string>
-    <string name="search_reset">重置</string>
-    <string name="search_apply_boards">应用 %1$d 个版块</string>
+    <string name="search_apply_board">应用</string>
+    <string name="search_board_all_boards_heading">全部</string>
     <string name="search_clear_query">清空关键词</string>
     <string name="search_recent">最近搜索</string>
     <string name="search_clear_all">全部清除</string>
@@ -513,6 +512,9 @@
 
     <string name="status_unparsable_title">这个页面读不出来</string>
     <string name="status_unparsable_body">页面结构和预期不一致，多半是站点改版了。先去网页里看看。</string>
+
+    <string name="status_rate_limited_title">请求太频繁了</string>
+    <string name="status_rate_limited_body">NodeSeek 的搜索每 2 秒只接受一次请求。等一下再试就好，不用去网页验证。</string>
 
     <string name="status_http_title">服务器返回了 HTTP %1$d</string>
     <string name="status_unknown_title">加载失败</string>

--- a/app/src/test/java/io/github/nodyssey/core/html/SearchParserTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/html/SearchParserTest.kt
@@ -1,6 +1,8 @@
 package io.github.nodyssey.core.html
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SearchParserTest {
@@ -12,5 +14,23 @@ class SearchParserTest {
         assertEquals(1, page.posts.size)
         assertEquals(838790L, page.posts.single().postId)
         assertEquals("daily", page.posts.single().categorySlug)
+        assertTrue(page.hasNextPage)
+    }
+
+    /**
+     * The endless-walk regression. Past the last page of results the site serves nothing but still
+     * renders `pager-next` as a link, so "there are more pages" had to stop being read off the
+     * pager alone — every empty page used to buy another request, at a rate the site answers with
+     * 429 and Cloudflare eventually answers with a challenge.
+     */
+    @Test
+    fun `a page with no results ends the search even while the pager still offers a next link`() {
+        val html = Fixtures.load("search-results-past-end.html")
+
+        assertTrue("fixture no longer reproduces the live pager", html.contains("class=\"pager-next\" href"))
+        val page = SearchParser.parsePosts(html, page = 99)
+
+        assertEquals(emptyList<Long>(), page.posts.map { it.postId })
+        assertFalse(page.hasNextPage)
     }
 }

--- a/app/src/test/java/io/github/nodyssey/data/FeedRemoteMediatorTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/FeedRemoteMediatorTest.kt
@@ -46,12 +46,9 @@ class FeedRemoteMediatorTest {
     private fun mediator(slug: String? = null) =
         FeedRemoteMediator(
             feedKey = feedKeyFor(slug),
-            categorySlug = slug,
-            sort = FeedSort.LAST_REPLY,
             database = database,
-            remote = remote,
             clock = clock,
-        )
+        ) { page -> remote.loadList(slug, page, FeedSort.LAST_REPLY) }
 
     private fun emptyPagingState() =
         PagingState<Int, FeedPostRow>(

--- a/app/src/test/java/io/github/nodyssey/data/SearchFeedTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/SearchFeedTest.kt
@@ -1,0 +1,139 @@
+package io.github.nodyssey.data
+
+import androidx.paging.testing.asSnapshot
+import io.github.nodyssey.data.local.NodeSeekDatabase
+import io.github.nodyssey.model.FeedSort
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Post search read as a feed.
+ *
+ * These are the promises the old search pipeline broke, which is why they are pinned here rather
+ * than left to the shared feed tests: one request per page, one board sent to the server instead of
+ * filtered locally, a cache window that makes coming back free, and a stored search that does not
+ * accumulate one entry per query ever typed.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SearchFeedTest {
+    private lateinit var database: NodeSeekDatabase
+    private val remote = FakePostRemoteDataSource()
+    private val clock = MutableClock()
+    private lateinit var repository: OfflineFirstPostRepository
+
+    @Before
+    fun setUp() {
+        database = inMemoryDatabase()
+        repository = OfflineFirstPostRepository(database, remote, clock)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    /** Every fixture below serves a single last page, so one snapshot is the whole result list. */
+    private suspend fun search(
+        query: String = "android",
+        board: String? = null,
+        sort: FeedSort = FeedSort.LAST_REPLY,
+    ): List<Long> =
+        repository
+            .searchFeed(query, board, sort)
+            .asSnapshot()
+            .map { it.summary.postId }
+
+    @Test
+    fun `one page of results costs exactly one request`() =
+        runTest {
+            remote.searchResult = { request ->
+                FakePostRemoteDataSource.page(null, request.page, firstId = 100, count = 3, hasNextPage = false)
+            }
+
+            assertEquals(listOf(100L, 101L, 102L), search())
+            assertEquals(1, remote.searchRequests.size)
+        }
+
+    @Test
+    fun `the selected board and order go to the server, not to a local filter`() =
+        runTest {
+            remote.searchResult = { request ->
+                FakePostRemoteDataSource.page("tech", request.page, firstId = 700, count = 2, hasNextPage = false)
+            }
+
+            search(query = " android ", board = "tech", sort = FeedSort.POST_TIME)
+
+            assertEquals(
+                FakePostRemoteDataSource.SearchRequest(
+                    query = "android",
+                    page = 1,
+                    categorySlug = "tech",
+                    sort = FeedSort.POST_TIME,
+                ),
+                remote.searchRequests.single(),
+            )
+        }
+
+    /** The acceptance criterion the boards already meet: coming back inside the window is free. */
+    @Test
+    fun `re-reading the same search inside the cache window issues no request`() =
+        runTest {
+            remote.searchResult = { request ->
+                FakePostRemoteDataSource.page(null, request.page, firstId = 100, count = 3, hasNextPage = false)
+            }
+            search()
+            val before = remote.searchRequests.size
+
+            clock.advanceBy(FeedRemoteMediator.CACHE_TTL_MILLIS - 1)
+
+            assertEquals(listOf(100L, 101L, 102L), search())
+            assertEquals(before, remote.searchRequests.size)
+        }
+
+    @Test
+    fun `a different board is a different search rather than an append onto the last one`() =
+        runTest {
+            remote.searchResult = { request ->
+                val first = if (request.categorySlug == "tech") 700L else 100L
+                FakePostRemoteDataSource.page(request.categorySlug, request.page, first, count = 2, hasNextPage = false)
+            }
+
+            assertEquals(listOf(100L, 101L), search(board = null))
+            assertEquals(listOf(700L, 701L), search(board = "tech"))
+        }
+
+    /**
+     * Board feeds are fifteen and stay; search feeds are one per query typed. Without the sweep the
+     * two feed tables would grow with the search history for as long as the app is installed.
+     */
+    @Test
+    fun `running a new search drops the previous one from the cache`() =
+        runTest {
+            remote.searchResult = { request ->
+                FakePostRemoteDataSource.page(null, request.page, firstId = 100, count = 2, hasNextPage = false)
+            }
+            search(query = "first")
+            val firstKey = searchFeedKeyFor("first", null, FeedSort.LAST_REPLY)
+            assertEquals(2, database.feedDao().nextSortIndex(firstKey))
+
+            search(query = "second")
+
+            assertEquals(0, database.feedDao().nextSortIndex(firstKey))
+            assertEquals(null, database.feedDao().remoteKey(firstKey))
+            // The board feeds are untouched by the sweep — only search keys carry the prefix.
+            assertTrue(searchFeedKeyFor("second", null, FeedSort.LAST_REPLY).startsWith(SEARCH_FEED_KEY_PREFIX))
+        }
+
+    @Test
+    fun `an empty query asks the site nothing`() =
+        runTest {
+            assertEquals(emptyList<Long>(), search(query = "   "))
+            assertEquals(0, remote.searchRequests.size)
+        }
+}

--- a/app/src/test/java/io/github/nodyssey/data/SearchRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/SearchRepositoryTest.kt
@@ -2,9 +2,7 @@ package io.github.nodyssey.data
 
 import io.github.nodyssey.core.AppDispatchers
 import io.github.nodyssey.core.html.Fixtures
-import io.github.nodyssey.core.net.HtmlSource
 import io.github.nodyssey.core.net.JsonSource
-import io.github.nodyssey.model.SearchSort
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -12,73 +10,12 @@ import org.junit.Test
 
 class SearchRepositoryTest {
     @Test
-    fun `post search makes exactly one request per page`() =
-        runTest {
-            val dispatcher = StandardTestDispatcher(testScheduler)
-            val html = RecordingHtmlSource(Fixtures.load("search-results.html"))
-            val repository =
-                NetworkSearchRepository(
-                    htmlSource = html,
-                    jsonSource = RecordingJsonSource("{}"),
-                    dispatchers = AppDispatchers(dispatcher, dispatcher),
-                )
-
-            val results = repository.searchPosts("Android TV", page = 1, emptySet(), SearchSort.TIME)
-
-            // One search must never fan out into a request per result page — that is what used to
-            // trip Cloudflare's rate limiting.
-            assertEquals(listOf("/search?q=Android%20TV&sortBy=postTime"), html.paths)
-            assertEquals(1, results.posts.size)
-            assertEquals(1, results.page)
-            assertEquals(3, results.totalPages)
-        }
-
-    @Test
-    fun `post search requests the page it is asked for`() =
-        runTest {
-            val dispatcher = StandardTestDispatcher(testScheduler)
-            val html = RecordingHtmlSource(Fixtures.load("search-results.html"))
-            val repository =
-                NetworkSearchRepository(
-                    htmlSource = html,
-                    jsonSource = RecordingJsonSource("{}"),
-                    dispatchers = AppDispatchers(dispatcher, dispatcher),
-                )
-
-            repository.searchPosts("Android TV", page = 2, emptySet(), SearchSort.TIME)
-
-            assertEquals(listOf("/search?q=Android%20TV&page=2&sortBy=postTime"), html.paths)
-        }
-
-    @Test
-    fun `a single selected board goes to the server, a range filters locally`() =
-        runTest {
-            val dispatcher = StandardTestDispatcher(testScheduler)
-            val html = RecordingHtmlSource(Fixtures.load("search-results.html"))
-            val repository =
-                NetworkSearchRepository(
-                    htmlSource = html,
-                    jsonSource = RecordingJsonSource("{}"),
-                    dispatchers = AppDispatchers(dispatcher, dispatcher),
-                )
-
-            repository.searchPosts("tv", page = 1, setOf("tech"), SearchSort.RELEVANCE)
-            assertEquals(listOf("/search?q=tv&category=tech"), html.paths)
-
-            html.paths.clear()
-            val filtered = repository.searchPosts("tv", page = 1, setOf("tech", "trade"), SearchSort.RELEVANCE)
-            assertEquals(listOf("/search?q=tv"), html.paths)
-            filtered.posts.forEach { post -> assertEquals(true, post.categorySlug in setOf("tech", "trade")) }
-        }
-
-    @Test
     fun `user search uses account endpoint and maps all real fields`() =
         runTest {
             val dispatcher = StandardTestDispatcher(testScheduler)
             val json = RecordingJsonSource(Fixtures.load("user-search-results.json"))
             val repository =
                 NetworkSearchRepository(
-                    htmlSource = FailingHtmlSource,
                     jsonSource = json,
                     dispatchers = AppDispatchers(dispatcher, dispatcher),
                 )
@@ -94,19 +31,6 @@ class SearchRepositoryTest {
             assertEquals(87, user.commentCount)
             assertEquals("22days ago", user.joinedText)
         }
-}
-
-private object FailingHtmlSource : HtmlSource {
-    override suspend fun getHtml(path: String): String = error("HTML must not be used for user search")
-}
-
-private class RecordingHtmlSource(private val body: String) : HtmlSource {
-    val paths = mutableListOf<String>()
-
-    override suspend fun getHtml(path: String): String {
-        paths += path
-        return body
-    }
 }
 
 private class RecordingJsonSource(private val body: String) : JsonSource {

--- a/app/src/test/java/io/github/nodyssey/data/TestDoubles.kt
+++ b/app/src/test/java/io/github/nodyssey/data/TestDoubles.kt
@@ -80,9 +80,21 @@ internal class FakePostRemoteDataSource : PostRemoteDataSource {
     /** When set, both loaders suspend until it completes. */
     var gate: CompletableDeferred<Unit>? = null
 
+    /** Search answers with [listResult] too, unless a test overrides it. */
+    var searchResult: ((SearchRequest) -> PostListPage)? = null
+
     val listRequests = mutableListOf<Pair<String?, Int>>()
     val sortRequests = mutableListOf<FeedSort>()
+    val searchRequests = mutableListOf<SearchRequest>()
     val detailRequests = mutableListOf<Pair<Long, Int>>()
+
+    /** What one `/search` call was asked for, so a test can assert the whole shape at once. */
+    data class SearchRequest(
+        val query: String,
+        val page: Int,
+        val categorySlug: String?,
+        val sort: FeedSort,
+    )
 
     override suspend fun loadList(
         categorySlug: String?,
@@ -94,6 +106,19 @@ internal class FakePostRemoteDataSource : PostRemoteDataSource {
         gate?.await()
         listError?.let { throw it }
         return listResult(categorySlug, page)
+    }
+
+    override suspend fun loadSearch(
+        query: String,
+        page: Int,
+        categorySlug: String?,
+        sort: FeedSort,
+    ): PostListPage {
+        val request = SearchRequest(query, page, categorySlug, sort)
+        searchRequests += request
+        gate?.await()
+        listError?.let { throw it }
+        return searchResult?.invoke(request) ?: listResult(categorySlug, page)
     }
 
     override suspend fun loadDetail(

--- a/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
@@ -263,6 +263,12 @@ private class FakeProfileRepository(
 private object NoOpPostRepository : PostRepository {
     override fun feed(categorySlug: String?, sort: FeedSort): Flow<PagingData<FeedPost>> = emptyFlow()
 
+    override fun searchFeed(
+        query: String,
+        categorySlug: String?,
+        sort: FeedSort,
+    ): Flow<PagingData<FeedPost>> = emptyFlow()
+
     override fun search(query: String): Flow<List<FeedPost>> = emptyFlow()
 
     override suspend fun invalidateCaches() = Unit

--- a/app/src/test/java/io/github/nodyssey/ui/search/SearchViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/search/SearchViewModelTest.kt
@@ -1,135 +1,221 @@
 package io.github.nodyssey.ui.search
 
-import androidx.paging.PagingSource
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.paging.PagingData
+import androidx.paging.testing.asSnapshot
+import io.github.nodyssey.core.net.JsonSource
 import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.core.net.NodeSeekException
-import io.github.nodyssey.data.PostSearchResults
+import io.github.nodyssey.data.CategoryRepository
+import io.github.nodyssey.data.FakePostRemoteDataSource
+import io.github.nodyssey.data.FeedPost
+import io.github.nodyssey.data.MutableClock
+import io.github.nodyssey.data.OfflineFirstPostRepository
 import io.github.nodyssey.data.SearchRepository
 import io.github.nodyssey.data.UserSearchResult
-import io.github.nodyssey.model.PostSummary
+import io.github.nodyssey.data.inMemoryDatabase
+import io.github.nodyssey.data.local.NodeSeekDatabase
+import io.github.nodyssey.data.testSettingsRepository
+import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.SearchSort
+import io.github.nodyssey.model.SearchTarget
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+/**
+ * What the ViewModel still decides now that post search is a feed.
+ *
+ * The paging itself moved to `OfflineFirstPostRepository.searchFeed` and is covered by
+ * `SearchFeedTest`; what is left here is which feed gets asked for, and — the part that used to
+ * cost requests — when a new one is asked for at all.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
 class SearchViewModelTest {
-    @Test
-    fun `append scans consecutive duplicate-only pages until it finds a new post`() =
-        runTest {
-            val repository = FakeSearchRepository { page ->
-                when (page) {
-                    1 -> page(page = 1, ids = listOf(1), totalPages = 4)
-                    2, 3 -> page(page = page, ids = listOf(1), totalPages = 4)
-                    else -> page(page = 4, ids = listOf(4), totalPages = 4, hasNext = false)
-                }
-            }
-            val source = pagingSource(repository)
+    private val dispatcher = StandardTestDispatcher()
+    private val remote = FakePostRemoteDataSource()
+    private val clock = MutableClock()
+    private lateinit var database: NodeSeekDatabase
 
-            val first = source.load(refresh()) as PagingSource.LoadResult.Page
-            val second = source.load(append(2)) as PagingSource.LoadResult.Page
-
-            assertEquals(listOf(1, 2, 3, 4), repository.requestedPages)
-            assertEquals(listOf(1L), first.data.map { it.summary.postId })
-            assertEquals(listOf(4L), second.data.map { it.summary.postId })
-            assertEquals(null, second.nextKey)
+    /** Fails on purpose, so the board strip falls back to the offline list instead of the network. */
+    private val failingJson =
+        object : JsonSource {
+            override suspend fun getJson(
+                path: String,
+                referer: String,
+            ): String = throw NodeSeekException(NodeSeekError.Network)
         }
 
-    @Test
-    fun `one append is capped after three duplicate-only pages`() =
-        runTest {
-            val repository = FakeSearchRepository { page -> page(page, listOf(1), totalPages = 20) }
-            val source = pagingSource(repository)
-
-            source.load(refresh())
-            val append = source.load(append(2)) as PagingSource.LoadResult.Page
-
-            assertEquals(listOf(1, 2, 3, 4), repository.requestedPages)
-            assertTrue(append.data.isEmpty())
-            assertEquals(5, append.nextKey)
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        database = inMemoryDatabase(dispatcher)
+        remote.searchResult = { request ->
+            FakePostRemoteDataSource.page(
+                request.categorySlug,
+                request.page,
+                firstId = 100,
+                count = 2,
+                hasNextPage = false,
+            )
         }
-
-    @Test
-    fun `append failure keeps loaded rows and exposes a retry state`() =
-        runTest {
-            var failPageTwo = true
-            val repository = FakeSearchRepository { page ->
-                when {
-                    page == 1 -> page(page = 1, ids = listOf(1), totalPages = 2)
-                    failPageTwo -> throw NodeSeekException(NodeSeekError.Network)
-                    else -> page(page = 2, ids = listOf(2), totalPages = 2, hasNext = false)
-                }
-            }
-            val source = pagingSource(repository)
-
-            val first = source.load(refresh()) as PagingSource.LoadResult.Page
-            val failure = source.load(append(2))
-
-            assertEquals(listOf(1L), first.data.map { it.summary.postId })
-            assertTrue(failure is PagingSource.LoadResult.Error)
-
-            failPageTwo = false
-            val retry = source.load(append(2)) as PagingSource.LoadResult.Page
-
-            assertEquals(listOf(2L), retry.data.map { it.summary.postId })
-            assertEquals(null, retry.nextKey)
-        }
-
-    private fun pagingSource(repository: SearchRepository) =
-        SearchPostsPagingSource(
-            repository = repository,
-            request = PostSearchRequest("paging", emptySet(), SearchSort.RELEVANCE, generation = 1),
-        )
-
-    private fun refresh() =
-        PagingSource.LoadParams.Refresh<Int>(key = null, loadSize = 20, placeholdersEnabled = false)
-
-    private fun append(page: Int) =
-        PagingSource.LoadParams.Append(key = page, loadSize = 20, placeholdersEnabled = false)
-}
-
-private class FakeSearchRepository(
-    private val result: (Int) -> PostSearchResults,
-) : SearchRepository {
-    val requestedPages = mutableListOf<Int>()
-
-    override suspend fun searchPosts(
-        query: String,
-        page: Int,
-        categorySlugs: Set<String>,
-        sort: SearchSort,
-    ): PostSearchResults {
-        requestedPages += page
-        return result(page)
     }
 
-    override suspend fun searchUsers(query: String): List<UserSearchResult> = emptyList()
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        database.close()
+    }
+
+    private fun TestScope.viewModel() =
+        SearchViewModel(
+            postRepository = OfflineFirstPostRepository(database, remote, clock),
+            searchRepository = NoUsersSearchRepository,
+            categoryRepository = CategoryRepository(failingJson, database.boardDao(), clock),
+            settings = testSettingsRepository(backgroundScope),
+        )
+
+    /**
+     * Types into the box the way the UI does.
+     *
+     * [Snapshot.sendApplyNotifications] is what a Compose frame would do: without it the
+     * `snapshotFlow` watching the field never sees the edit, and the ViewModel keeps results the
+     * box no longer describes — in the test only, which is exactly why it has to be spelled out.
+     */
+    private fun TestScope.type(
+        viewModel: SearchViewModel,
+        text: String,
+    ) {
+        viewModel.query.setTextAndPlaceCursorAtEnd(text)
+        Snapshot.sendApplyNotifications()
+        advanceUntilIdle()
+    }
+
+    private suspend fun Flow<PagingData<FeedPost>>.ids(): List<Long> = asSnapshot().map { it.summary.postId }
+
+    @Test
+    fun `submitting a search asks for the feed named by the box, the board and the order`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.selectBoard("tech")
+            vm.selectSort(SearchSort.TIME)
+            type(vm, "  android  ")
+
+            vm.submitSearch()
+            advanceUntilIdle()
+            vm.postResults.ids()
+
+            assertEquals(
+                FakePostRemoteDataSource.SearchRequest(
+                    query = "android",
+                    page = 1,
+                    categorySlug = "tech",
+                    sort = FeedSort.POST_TIME,
+                ),
+                remote.searchRequests.single(),
+            )
+            assertEquals("android", vm.uiState.value.submittedQuery)
+        }
+
+    /**
+     * The regression that made a search screen expensive to sit on: submitting the same query again
+     * used to tear the pager down and rebuild it, and every rebuild started at page one.
+     */
+    @Test
+    fun `re-submitting an unchanged search spends no further request`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            type(vm, "android")
+            vm.submitSearch()
+            advanceUntilIdle()
+            vm.postResults.ids()
+            val before = remote.searchRequests.size
+
+            vm.submitSearch()
+            advanceUntilIdle()
+            vm.postResults.ids()
+
+            assertEquals(before, remote.searchRequests.size)
+        }
+
+    @Test
+    fun `changing the board re-runs the search against the new one`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            type(vm, "android")
+            vm.submitSearch()
+            advanceUntilIdle()
+            vm.postResults.ids()
+
+            vm.selectBoard("tech")
+            advanceUntilIdle()
+            vm.postResults.ids()
+
+            assertEquals(listOf(null, "tech"), remote.searchRequests.map { it.categorySlug })
+        }
+
+    @Test
+    fun `editing the box drops the results it no longer describes`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            type(vm, "android")
+            vm.submitSearch()
+            advanceUntilIdle()
+            vm.postResults.ids()
+
+            type(vm, "androi")
+
+            assertEquals(null, vm.uiState.value.submittedQuery)
+            assertEquals(emptyList<Long>(), vm.postResults.ids())
+        }
+
+    /** A posts search must not spend a request for the users tab the reader may never open. */
+    @Test
+    fun `searching users asks the site for no posts`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.selectTarget(SearchTarget.USERS)
+            type(vm, "android")
+
+            vm.submitSearch()
+            advanceUntilIdle()
+
+            assertEquals(0, remote.searchRequests.size)
+        }
+
+    @Test
+    fun `history remembers the single board the search was scoped to`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            vm.selectBoard("tech")
+            type(vm, "android")
+
+            vm.submitSearch()
+            advanceUntilIdle()
+
+            // The DataStore write lands off the test scheduler, so the assertion waits for the
+            // state to carry it rather than assuming one advanceUntilIdle covered the file.
+            val entry = vm.uiState.first { it.searchHistory.isNotEmpty() }.searchHistory.single()
+            assertEquals("android", entry.query)
+            assertEquals("tech", entry.categorySlug)
+        }
 }
 
-private fun page(
-    page: Int,
-    ids: List<Long>,
-    totalPages: Int,
-    hasNext: Boolean = page < totalPages,
-): PostSearchResults =
-    PostSearchResults(
-        posts = ids.map(::post),
-        page = page,
-        totalPages = totalPages,
-        hasNextPage = hasNext,
-    )
-
-private fun post(id: Long): PostSummary =
-    PostSummary(
-        postId = id,
-        title = "post $id",
-        authorName = "tester",
-        authorUid = id,
-        avatarUrl = null,
-        categoryTitle = "技术",
-        categorySlug = "tech",
-        viewCount = null,
-        commentCount = null,
-        lastActiveText = null,
-        lastActiveTitle = null,
-    )
+private object NoUsersSearchRepository : SearchRepository {
+    override suspend fun searchUsers(query: String): List<UserSearchResult> = emptyList()
+}

--- a/app/src/test/resources/fixtures/search-results-past-end.html
+++ b/app/src/test/resources/fixtures/search-results-past-end.html
@@ -1,0 +1,24 @@
+<!--
+  /search?q=android&page=99 as the live site served it on 2026-08-01.
+
+  Note the pager: zero results, yet `pager-next` is still an <a href> pointing at page 2, because
+  the pager renders as though the current page were unknown. Trusting it is what turned the end of
+  a search into an endless walk.
+-->
+<!doctype html>
+<html>
+<body>
+<section id="nsk-frame">
+  <div id="nsk-body">
+    <div role="navigation" aria-label="pagination">
+      <a class="pager-pos" href="/search?q=android&amp;page=1">1</a>
+      <a class="pager-pos" href="/search?q=android&amp;page=2">2</a>
+      <a class="pager-pos" href="/search?q=android&amp;page=3">3</a>
+      <a class="pager-pos" href="/search?q=android&amp;page=4">4</a>
+      <a class="pager-next" href="/search?q=android&amp;page=2" rel="next"><div class="triangle-right"></div></a>
+    </div>
+    <div>未找到有效帖子，请更换搜索词后重试</div>
+  </div>
+</section>
+</body>
+</html>

--- a/app/src/test/resources/fixtures/search-results.html
+++ b/app/src/test/resources/fixtures/search-results.html
@@ -6,6 +6,7 @@
     <span class="pager-pos">1</span>
     <a class="pager-pos" href="/search?q=Android&amp;page=2">2</a>
     <a class="pager-pos" href="/search?q=Android&amp;page=3">3</a>
+    <a class="pager-next" href="/search?q=Android&amp;page=2" rel="next"><div class="triangle-right"></div></a>
   </div>
   <ul class="post-list">
     <li class="post-list-item">


### PR DESCRIPTION
## 问题

搜索经常把用户顶到 Cloudflare 人机验证。根因是搜索自建了一套和论坛完全不同的取数逻辑，三处缺陷叠加成请求风暴。

**站点行为 2026-08-01 在真站核对过**（`www.nodeseek.com`，签出态浏览器）：

| 事实 | 影响 |
| --- | --- |
| `/search?q=` 是服务端渲染的普通文档——`#nsk-frame` + `.post-list-item`（**50/页**）+ 标准 `pager-next`，与 `/categories/xxx` 同构 | 接口本身没选错，论坛的解析器可以原样复用 |
| `category=tech` 服务端真生效（43 条全 tech）；`sortBy=postTime` 也真生效；**只接受一个 category** | 多选只能靠本地过滤，这是坑的源头 |
| 请求超出末页（`page=99`）返回 0 条帖子，**分页器仍把 `pager-next` 渲染成 `<a>`** | `hasNextPage` 永远为真 → 无限翻页 |
| 两次请求间隔 <2s 直接 **429**，body 为 `{"success":false,"message":"每隔2秒可以操作一次"}` | 连发必撞限流 |

三者合起来：`SearchPostsPagingSource` 一次 load 连发 3 个请求（`MAX_PAGES_PER_LOAD`），多选版块时页页被本地过滤滤空，返回空页后 Paging 立刻再 append，而 `hasNext` 又永不为假 —— 无限连发，2 秒限流必中 429，反复撞下去就吃到 CF 挑战。

## 改动

**搜索 = 论坛的一个 feed。** `FeedRemoteMediator` 把 `categorySlug`/`sort` 换成 `loadPage: suspend (Int) -> PostListPage`，`feed()` 与新增的 `PostRepository.searchFeed()` 共用同一个 `pagedFeed()` —— 同一套 Room 缓存、同样的 5 分钟 TTL、同样的 `pageSize=50 / prefetchDistance=8`。`SearchPostsPagingSource`、`PostSearchResults` 和整个三页循环随之删除。

副产品：搜索结果行现在和论坛一样带已读态与「N 条新回复」角标（同一张表出来的），返回搜索页 / 转屏 / 进程重建都不再发请求。

其余修正：

- **分页终止**：`SearchParser` 里空页即终止，不再听信分页器。
- **版块单选**：UI 从 Checkbox 换成 RadioButton（含「全部版块」一项），本地过滤彻底移除。`SearchHistoryEntry.categorySlugs: Set<String>` → `categorySlug: String?`。
- **限流**：新增 `MinIntervalGate`，只给搜索请求间隔 ≥2s；新增 `NodeSeekError.RateLimited`，把 429 显示成「请求太频繁了，等一下再试」而不是「HTTP 429」，且**不给**「去网页验证」按钮——那只会再耗一次配额。
- **缓存不膨胀**：搜索 feed 用 `search:` 前缀存 key，新搜索时清扫上一次的。前缀特意用 `:` 而非 `|`，否则名为 `search` 的版块在时间序下会生成 `search|postTime` 被误扫。
- `PagingData.empty()` 换成带终止 LoadStates 的版本——裸的那个不带 load state，消费方会永远停在 Loading。

## 需要 reviewer 留意

- **DataStore 兼容**：`StoredSearchHistory.categorySlugs` 存储字段**保持 `List<String>` 不变**，读时取第一个版块。老版本写下的多选记录仍能解码，历史不会因为解析失败而整个丢掉。
- **抓取选择器**：新增了对 `/search` 分页器的假设（空页即终止），依据是上表实测；`Selectors.RATE_LIMIT_MARKERS` 是新的限流句式匹配。
- **无 schema / 依赖锁变更**：搜索复用现有的 `posts` / `feed_positions` / `feed_remote_keys` 三张表，未改实体，`gradle.lockfile` 未动。
- 删除了 `search_selected_boards` / `search_reset` / `search_apply_boards` 三个字符串，新增 `search_apply_board`、`search_board_all_boards_heading`、`status_rate_limited_*`。

## 验证

\`\`\`
./gradlew :app:testDebugUnitTest :app:lintDebug spotlessCheck
\`\`\`

全绿，545 个测试通过，lint 零警告。新增覆盖：

- `SearchParserTest` — 分页器仍给 next 链接时，空页必须终止分页（配 `search-results-past-end.html`，真站抓下来的 fixture）
- `SearchFeedTest`（新）— 一页只发一个请求 / 版块与排序走服务端 / TTL 内重读零请求 / 换版块是新搜索而非续接 / 新搜索清扫旧 search feed / 空关键词零请求
- `SearchViewModelTest`（重写）— 重复提交同一搜索不再发请求 / 编辑输入框丢弃已不匹配的结果 / 历史记住单个版块

**未做真机验证**：沙箱 curl 拿不到站点，浏览器面板只能签出态读页面。搜索页的实际手感——尤其是单选 sheet 的排版和 429 提示——建议装到设备上看一眼（`./gradlew :app:installDebug`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)