### PR TITLE
搜索改成先指定再搜索：输入框钉在顶上，排序换回站点真有的那两档

### DIFF
--- a/app/src/androidTest/java/io/github/nodyssey/TopLevelNavigationJourneyTest.kt
+++ b/app/src/androidTest/java/io/github/nodyssey/TopLevelNavigationJourneyTest.kt
@@ -50,13 +50,10 @@ class TopLevelNavigationJourneyTest {
     }
 
     /**
-     * The search screen opens expanded, and an expanded Material 3 search bar keeps two input fields
-     * in the tree at once: the collapsed one still sitting in the top bar, and the full-screen one
-     * drawn over it. Matching on `hasSetTextAction()` alone therefore finds two nodes and fails in
-     * `fetchOneOrThrow` — which surfaces as "Failed to perform text input", naming the wrong cause.
-     *
-     * Focus is what tells them apart, and it is also the honest question to ask: of the two, the
-     * focused one is the field the user is typing into.
+     * The search screen has one field and focuses it on arrival, so waiting for the focused one is
+     * also waiting for the screen to be ready: matching on `hasSetTextAction()` alone can land on
+     * the frame before the field exists, which surfaces as "Failed to perform text input" and names
+     * the wrong cause.
      */
     @OptIn(ExperimentalTestApi::class)
     private fun searchInputField(): SemanticsNodeInteraction {

--- a/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.github.nodyssey.data.NotificationCounts
+import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.SearchHistoryEntry
-import io.github.nodyssey.model.SearchSort
 import io.github.nodyssey.model.SearchTarget
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -275,7 +275,7 @@ class SettingsRepository(
 
     /**
      * Deduplicated because decoding is lossy: a stored row's board list collapses to its first
-     * board and the retired sorts fold into [SearchSort.RELEVANCE], so two rows written by an older
+     * board and the retired sorts fold into their [FeedSort] equivalents, so two rows written by an older
      * build can land on one domain entry. The list is read straight into a LazyColumn keyed on
      * [SearchHistoryEntry.key], which throws the moment a key repeats — and the first write after
      * this drops the collapsed twin from disk for good.
@@ -368,15 +368,18 @@ private data class StoredSearchHistory(
     val query: String,
     val target: String,
     val categorySlugs: List<String> = emptyList(),
-    val sort: String = SearchSort.RELEVANCE.name,
+    val sort: String = FeedSort.POST_TIME.name,
 ) {
     fun toDomain(): SearchHistoryEntry? {
         val resolvedTarget = runCatching { SearchTarget.valueOf(target) }.getOrNull() ?: return null
         val resolvedSort =
             when (sort) {
-                "POST_TIME" -> SearchSort.TIME
-                "LAST_REPLY" -> SearchSort.RELEVANCE
-                else -> runCatching { SearchSort.valueOf(sort) }.getOrDefault(SearchSort.RELEVANCE)
+                // The retired labels for the same two `sortBy` values the site has always taken.
+                "TIME" -> FeedSort.POST_TIME
+
+                "RELEVANCE" -> FeedSort.LAST_REPLY
+
+                else -> runCatching { FeedSort.valueOf(sort) }.getOrDefault(FeedSort.LAST_REPLY)
             }
         return SearchHistoryEntry(
             query = query.trim(),

--- a/app/src/main/java/io/github/nodyssey/model/SearchModels.kt
+++ b/app/src/main/java/io/github/nodyssey/model/SearchModels.kt
@@ -2,8 +2,6 @@ package io.github.nodyssey.model
 
 enum class SearchTarget { POSTS, USERS }
 
-enum class SearchSort { RELEVANCE, TIME }
-
 data class SearchHistoryEntry(
     val query: String,
     val target: SearchTarget,
@@ -16,7 +14,15 @@ data class SearchHistoryEntry(
      * storm that kept ending in a Cloudflare challenge.
      */
     val categorySlug: String? = null,
-    val sort: SearchSort = SearchSort.RELEVANCE,
+    /**
+     * The site's own two orders, the same pair the board lists use.
+     *
+     * `/search` takes the boards' `sortBy` verbatim — 新评论 is `replyTime`, 新帖子 is `postTime` — and
+     * defaults to the latter when the parameter is absent, which is why [FeedSort.POST_TIME] is the
+     * default here and not the feed's. There is no relevance order to offer: the label this replaced
+     * said 相关度 while sending `sortBy=replyTime`.
+     */
+    val sort: FeedSort = FeedSort.POST_TIME,
 ) {
     val key: String
         get() = listOf(target.name, query, categorySlug.orEmpty(), sort.name).joinToString("\u001E")

--- a/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -69,9 +70,13 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -578,6 +583,7 @@ private fun BoardPill(
 internal fun PostRow(
     post: FeedPost,
     onClick: () -> Unit,
+    highlight: String? = null,
 ) {
     val summary = post.summary
     Row(
@@ -623,7 +629,7 @@ internal fun PostRow(
         Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = summary.title,
+                    text = highlighted(summary.title, highlight, MaterialTheme.colorScheme.primary),
                     // Trimmed at the top so the glyphs start at the row's top edge instead of 3sp
                     // below it: 15/21 leaves leading above the first line, and against a 40dp avatar
                     // that gap read as the avatar sitting higher than the title beside it.
@@ -673,6 +679,33 @@ internal fun PostRow(
             }
             PostMetaRow(post)
         }
+    }
+}
+
+/**
+ * The searched-for words picked out of the title.
+ *
+ * Literal and case-insensitive, because that is what the search itself is: the site matches the raw
+ * string, so a cleverer match here would paint a word the results were not chosen for. Returns the
+ * plain title when nothing is being searched, which is every list but the search results.
+ */
+internal fun highlighted(
+    title: String,
+    query: String?,
+    color: Color,
+): AnnotatedString {
+    val needle = query?.trim().orEmpty()
+    if (needle.isEmpty() || !title.contains(needle, ignoreCase = true)) return AnnotatedString(title)
+    return buildAnnotatedString {
+        var cursor = 0
+        while (true) {
+            val match = title.indexOf(needle, cursor, ignoreCase = true)
+            if (match < 0) break
+            append(title, cursor, match)
+            withStyle(SpanStyle(color = color)) { append(title, match, match + needle.length) }
+            cursor = match + needle.length
+        }
+        append(title, cursor, title.length)
     }
 }
 

--- a/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
@@ -1,9 +1,12 @@
 package io.github.nodyssey.ui.search
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,32 +14,33 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExpandedFullScreenSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryTabRow
@@ -48,23 +52,25 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopSearchBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -74,12 +80,11 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import io.github.nodyssey.R
-import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.data.Board
 import io.github.nodyssey.data.FeedPost
 import io.github.nodyssey.data.UserSearchResult
+import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.SearchHistoryEntry
-import io.github.nodyssey.model.SearchSort
 import io.github.nodyssey.model.SearchTarget
 import io.github.nodyssey.ui.common.LoadingState
 import io.github.nodyssey.ui.common.NoSearchResultsState
@@ -91,7 +96,6 @@ import io.github.nodyssey.ui.postlist.toNodeSeekError
 import io.github.nodyssey.ui.theme.NodysseyTheme
 import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.readableWidth
-import kotlinx.coroutines.launch
 
 @Composable
 fun SearchRoute(
@@ -124,7 +128,16 @@ fun SearchRoute(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Search, in the order the site itself asks for it: say what kind of thing, say where, then type.
+ *
+ * The input is pinned to the top and the rest of the screen is the search view — tabs, the board the
+ * search is scoped to, and either the history or the results. It used to be a collapsing
+ * [androidx.compose.material3.AppBarWithSearch] over an
+ * [androidx.compose.material3.ExpandedFullScreenSearchBar], which meant the history existed twice
+ * (once in the dialog, once behind it) and the board could only be picked from the results screen —
+ * after a search had already gone out with the wrong scope.
+ */
 @Composable
 fun SearchScreen(
     state: SearchUiState,
@@ -142,82 +155,30 @@ fun SearchScreen(
     modifier: Modifier = Modifier,
     postResults: LazyPagingItems<FeedPost>? = null,
     onBoardChange: (String?) -> Unit = {},
-    onSortChange: (SearchSort) -> Unit = {},
+    onSortChange: (FeedSort) -> Unit = {},
 ) {
     var showBoardSheet by remember { mutableStateOf(false) }
-    var showSortMenu by remember { mutableStateOf(false) }
-    val scope = rememberCoroutineScope()
-    // Expanded on arrival: you reached this screen in order to type, and the expanded bar is where
-    // the history lives. It used to occupy the results area whenever nothing had been submitted,
-    // which is the same thing said with a hand-written branch.
-    val searchBarState = rememberSearchBarState(initialValue = SearchBarValue.Expanded)
 
-    val inputField = @Composable {
-        SearchBarDefaults.InputField(
-            textFieldState = queryState,
-            searchBarState = searchBarState,
-            onSearch = {
-                onSearch()
-                scope.launch { searchBarState.animateToCollapsed() }
-            },
-            placeholder = {
-                Text(
-                    stringResource(
-                        if (state.target == SearchTarget.USERS) R.string.search_user_hint else R.string.search_hint,
-                    ),
-                )
-            },
-            // Expanded, the full-screen bar covers the navigation bar, so the leading slot has to be
-            // the way out — a magnifier there is decoration on a screen with no other exit.
-            leadingIcon = {
-                if (searchBarState.currentValue == SearchBarValue.Expanded) {
-                    IconButton(onClick = { scope.launch { searchBarState.animateToCollapsed() } }) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.action_back),
-                        )
-                    }
-                } else {
-                    Icon(Icons.Default.Search, contentDescription = null)
-                }
-            },
-            trailingIcon = {
-                if (queryState.text.isNotEmpty()) {
-                    IconButton(onClick = { queryState.clearText() }) {
-                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.search_clear_query))
-                    }
-                }
-            },
-        )
-    }
-
-    Scaffold(
-        modifier = modifier,
-        topBar = { TopSearchBar(state = searchBarState, inputField = inputField) },
-    ) { padding ->
-        ExpandedFullScreenSearchBar(state = searchBarState, inputField = inputField) {
-            SearchHistory(
-                searches = state.searchHistory.filter { it.target == state.target },
-                boards = state.boards,
-                onHistoryClick = {
-                    onHistoryClick(it)
-                    scope.launch { searchBarState.animateToCollapsed() }
-                },
-                onRemoveHistory = onRemoveHistory,
-                onClearHistory = onClearHistory,
-            )
-        }
+    Scaffold(modifier = modifier) { padding ->
         Column(
             modifier = Modifier.padding(padding).fillMaxSize().readableWidth(),
         ) {
+            SearchInputField(
+                queryState = queryState,
+                placeholder = searchPlaceholder(state),
+                // Arriving with nothing searched yet means arriving to type; arriving back on a
+                // result list does not, and a keyboard over the results would only hide them.
+                autoFocus = state.submittedQuery == null,
+                onSearch = onSearch,
+            )
+
             PrimaryTabRow(selectedTabIndex = state.target.ordinal) {
                 SearchTab(
                     selected = state.target == SearchTarget.POSTS,
                     title = stringResource(R.string.search_posts_tab),
-                    count =
-                    postResults
-                        ?.itemCount
-                        ?.takeIf { postResults.loadState.refresh is LoadState.NotLoading },
+                    // No count: `/search` never returns a total, and the number of rows loaded so
+                    // far is not one — it grows as you scroll, which reads as the site changing.
+                    count = null,
                     onClick = { onTargetChange(SearchTarget.POSTS) },
                 )
                 SearchTab(
@@ -228,62 +189,33 @@ fun SearchScreen(
                 )
             }
 
-            if (state.target == SearchTarget.POSTS) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg, vertical = Spacing.sm),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    AssistChip(
-                        onClick = { showBoardSheet = true },
-                        label = {
-                            Text(
-                                state.selectedBoard
-                                    ?.let { slug -> state.boards.firstOrNull { it.slug == slug }?.title ?: slug }
-                                    ?: stringResource(R.string.search_all_boards),
-                            )
-                        },
-                        trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, contentDescription = null) },
+            if (state.submittedQuery == null) {
+                SearchSetup(
+                    state = state,
+                    onBoardChange = onBoardChange,
+                    onHistoryClick = onHistoryClick,
+                    onRemoveHistory = onRemoveHistory,
+                    onClearHistory = onClearHistory,
+                )
+            } else {
+                if (state.target == SearchTarget.POSTS) {
+                    ResultScopeRow(
+                        state = state,
+                        onOpenBoardSheet = { showBoardSheet = true },
+                        onSortChange = onSortChange,
                     )
-                    if (state.submittedQuery != null) {
-                        Box {
-                            AssistChip(
-                                onClick = { showSortMenu = true },
-                                label = {
-                                    Text(
-                                        stringResource(
-                                            if (state.sort == SearchSort.TIME) {
-                                                R.string.search_sort_time
-                                            } else {
-                                                R.string.search_sort_relevance
-                                            },
-                                        ),
-                                    )
-                                },
-                                trailingIcon = { Icon(Icons.Default.KeyboardArrowDown, contentDescription = null) },
-                            )
-                            DropdownMenu(expanded = showSortMenu, onDismissRequest = { showSortMenu = false }) {
-                                SortMenuItem(SearchSort.RELEVANCE, state.sort, onSortChange) { showSortMenu = false }
-                                SortMenuItem(SearchSort.TIME, state.sort, onSortChange) { showSortMenu = false }
-                            }
-                        }
-                    }
                 }
+                SearchResults(
+                    state = state,
+                    queryState = queryState,
+                    onPostClick = onPostClick,
+                    onUserClick = onUserClick,
+                    postResults = postResults,
+                    onRetry = onRetry,
+                    onSignIn = onSignIn,
+                    onVerify = onVerify,
+                )
             }
-
-            SearchContent(
-                state = state,
-                queryState = queryState,
-                onHistoryClick = onHistoryClick,
-                onRemoveHistory = onRemoveHistory,
-                onClearHistory = onClearHistory,
-                onPostClick = onPostClick,
-                onUserClick = onUserClick,
-                postResults = postResults,
-                onRetry = onRetry,
-                onSignIn = onSignIn,
-                onVerify = onVerify,
-            )
         }
     }
 
@@ -301,6 +233,79 @@ fun SearchScreen(
     }
 }
 
+/**
+ * The search box, always editable and always at the top.
+ *
+ * [SearchBarDefaults.InputField] is used on its own rather than inside a
+ * [androidx.compose.material3.SearchBar]: the collapsed search bar wraps its field in
+ * `DisableSoftKeyboard`, because in that pattern typing happens in the expanded copy drawn over it.
+ * This screen has no collapsed state to speak of — it is a destination whose whole body is the
+ * search view — so the field has to be the one that takes the keyboard. The [SearchBarValue.Expanded]
+ * state passed to it is the same statement: what is below the field is the expanded view.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SearchInputField(
+    queryState: TextFieldState,
+    placeholder: String,
+    autoFocus: Boolean,
+    onSearch: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+    val searchBarState = rememberSearchBarState(initialValue = SearchBarValue.Expanded)
+    val submit = {
+        onSearch()
+        // The results are what was asked for; the keyboard would cover four of them.
+        focusManager.clearFocus()
+    }
+
+    SearchBarDefaults.InputField(
+        textFieldState = queryState,
+        searchBarState = searchBarState,
+        onSearch = { submit() },
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Spacing.lg, vertical = Spacing.sm)
+            .focusRequester(focusRequester),
+        placeholder = { Text(placeholder, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+        // The field's own container is transparent by default because a search bar paints it from
+        // the outside. Standing on its own, it has to paint itself — same token the bar would use.
+        colors =
+        SearchBarDefaults.inputFieldColors(
+            focusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ),
+        trailingIcon = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (queryState.text.isNotEmpty()) {
+                    IconButton(onClick = { queryState.clearText() }) {
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.search_clear_query))
+                    }
+                }
+                FilledIconButton(onClick = submit) {
+                    Icon(Icons.Default.Search, contentDescription = stringResource(R.string.search_submit))
+                }
+            }
+        },
+    )
+
+    LaunchedEffect(Unit) {
+        if (autoFocus) focusRequester.requestFocus()
+    }
+}
+
+/** Placeholder as the third step of the sentence the two pickers above it have already started. */
+@Composable
+private fun searchPlaceholder(state: SearchUiState): String {
+    if (state.target == SearchTarget.USERS) return stringResource(R.string.search_user_hint)
+    val board = state.selectedBoard ?: return stringResource(R.string.search_hint)
+    return stringResource(R.string.search_hint_board, state.boards.title(board))
+}
+
+private fun List<Board>.title(slug: String): String = firstOrNull { it.slug == slug }?.title ?: slug
+
 @Composable
 private fun SearchTab(
     selected: Boolean,
@@ -315,13 +320,182 @@ private fun SearchTab(
     )
 }
 
+/**
+ * Everything between opening search and submitting one: what to scope it to, and what was searched
+ * before. The board picker is a permanent chip group rather than the sheet the results screen opens,
+ * because here it is part of writing the query — the placeholder finishes the sentence it starts.
+ */
 @Composable
-private fun SearchContent(
+private fun ColumnScope.SearchSetup(
     state: SearchUiState,
-    queryState: TextFieldState,
+    onBoardChange: (String?) -> Unit,
     onHistoryClick: (SearchHistoryEntry) -> Unit,
     onRemoveHistory: (SearchHistoryEntry) -> Unit,
     onClearHistory: () -> Unit,
+) {
+    // The users tab has no scope to pick — the site matches a name fragment and returns the lot —
+    // so it goes straight to the history, with the tab row's own line as its separator.
+    if (state.target == SearchTarget.POSTS) {
+        BoardChips(
+            boards = state.boards,
+            selected = state.selectedBoard,
+            onSelect = onBoardChange,
+        )
+        HorizontalDivider(modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.lg))
+    } else {
+        Spacer(Modifier.size(Spacing.md))
+    }
+    SearchHistory(
+        searches = state.searchHistory.filter { it.target == state.target },
+        boards = state.boards,
+        onHistoryClick = onHistoryClick,
+        onRemoveHistory = onRemoveHistory,
+        onClearHistory = onClearHistory,
+    )
+}
+
+/**
+ * One board, or the whole site.
+ *
+ * Single choice because `/search` takes a single `category` and applies it itself — the same reason
+ * [BoardRangeSheet] is a radio list. 全部 is a real option, not an empty selection: it is what the
+ * site does when the parameter is absent.
+ */
+@Composable
+private fun BoardChips(
+    boards: List<Board>,
+    selected: String?,
+    onSelect: (String?) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg, vertical = Spacing.md),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            stringResource(R.string.search_board_section),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            stringResource(R.string.search_board_single_hint),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    FlowRow(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+    ) {
+        BoardChip(
+            title = stringResource(R.string.search_board_chip_all),
+            selected = selected == null,
+            onSelect = { onSelect(null) },
+        )
+        boards.forEach { board ->
+            BoardChip(
+                title = board.title,
+                selected = board.slug != null && board.slug == selected,
+                onSelect = { onSelect(board.slug) },
+            )
+        }
+    }
+}
+
+/**
+ * No leading tick, deliberately.
+ *
+ * A tick makes the selected chip ~26dp wider, and in a wrapping group that re-flows every chip after
+ * it: on a narrow phone picking a board moved the rest of the list between three and four rows,
+ * under the finger that was still choosing. The filled container against the outlined ones already
+ * says which one is on, TalkBack reads 已选中 from [FilterChip]'s own semantics either way, and the
+ * tick is optional decoration in Material's own spec — so it is the part that goes.
+ */
+@Composable
+private fun BoardChip(
+    title: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
+) {
+    FilterChip(
+        selected = selected,
+        onClick = onSelect,
+        label = { Text(title) },
+    )
+}
+
+/**
+ * Board and order on the results screen, where changing either re-runs the search that is showing.
+ *
+ * Both are server parameters, not local filtering: `category` picks the one board `/search` accepts,
+ * and `sortBy` is the boards' own 新评论 / 新帖子 — which is why the order reads the same here as it
+ * does on the home feed.
+ */
+@Composable
+private fun ResultScopeRow(
+    state: SearchUiState,
+    onOpenBoardSheet: () -> Unit,
+    onSortChange: (FeedSort) -> Unit,
+) {
+    var showSortMenu by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Selected when the search is scoped to one board, so the row says at a glance whether the
+        // results are the whole site or a corner of it.
+        FilterChip(
+            selected = state.selectedBoard != null,
+            onClick = onOpenBoardSheet,
+            label = {
+                Text(
+                    state.selectedBoard
+                        ?.let { slug -> state.boards.title(slug) }
+                        ?: stringResource(R.string.search_all_boards),
+                )
+            },
+            leadingIcon =
+            if (state.selectedBoard != null) {
+                {
+                    Icon(
+                        Icons.Default.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(FilterChipDefaults.IconSize),
+                    )
+                }
+            } else {
+                null
+            },
+            trailingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
+        )
+        Box {
+            TextButton(onClick = { showSortMenu = true }) {
+                Icon(
+                    NodysseyIcons.SwapVert,
+                    contentDescription = stringResource(R.string.action_sort),
+                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                )
+                Spacer(Modifier.size(Spacing.xs))
+                Text(stringResource(state.sort.labelRes()))
+                Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+            }
+            DropdownMenu(expanded = showSortMenu, onDismissRequest = { showSortMenu = false }) {
+                SortMenuItem(FeedSort.LAST_REPLY, state.sort, onSortChange) { showSortMenu = false }
+                SortMenuItem(FeedSort.POST_TIME, state.sort, onSortChange) { showSortMenu = false }
+            }
+        }
+    }
+}
+
+@StringRes
+private fun FeedSort.labelRes(): Int =
+    if (this == FeedSort.POST_TIME) R.string.sort_by_post_time else R.string.sort_by_reply_time
+
+@Composable
+private fun SearchResults(
+    state: SearchUiState,
+    queryState: TextFieldState,
     onPostClick: (Long) -> Unit,
     onUserClick: (Long) -> Unit,
     postResults: LazyPagingItems<FeedPost>?,
@@ -329,21 +503,6 @@ private fun SearchContent(
     onSignIn: () -> Unit,
     onVerify: () -> Unit,
 ) {
-    // Collapsed with nothing submitted is a real state — the bar can be collapsed from the expanded
-    // history, or the query cleared from a result list — and it used to show the history. Leaving it
-    // blank was measured on device: an empty screen under an empty search box, with the history only
-    // reachable by tapping the bar again.
-    if (state.submittedQuery == null) {
-        SearchHistory(
-            searches = state.searchHistory.filter { it.target == state.target },
-            boards = state.boards,
-            onHistoryClick = onHistoryClick,
-            onRemoveHistory = onRemoveHistory,
-            onClearHistory = onClearHistory,
-        )
-        return
-    }
-
     if (state.target == SearchTarget.USERS) {
         when (val loadState = state.userLoadState) {
             SearchLoadState.Idle,
@@ -387,69 +546,90 @@ private fun SearchContent(
             if (posts.itemCount == 0) {
                 Box(Modifier.fillMaxSize()) { NoSearchResultsState(onClearQuery = { queryState.clearText() }) }
             } else {
-                PostResults(posts = posts, onPostClick = onPostClick)
+                PostResults(
+                    posts = posts,
+                    highlight = state.submittedQuery,
+                    onPostClick = onPostClick,
+                )
             }
         }
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PostResults(
     posts: LazyPagingItems<FeedPost>,
+    highlight: String?,
     onPostClick: (Long) -> Unit,
 ) {
-    LazyColumn {
-        items(
-            count = posts.itemCount,
-            key = posts.itemKey { it.summary.postId },
-        ) { index ->
-            posts[index]?.let { post ->
-                PostRow(post = post, onClick = { onPostClick(post.summary.postId) })
+    PullToRefreshBox(
+        isRefreshing = posts.loadState.refresh is LoadState.Loading,
+        onRefresh = posts::refresh,
+    ) {
+        LazyColumn {
+            items(
+                count = posts.itemCount,
+                key = posts.itemKey { it.summary.postId },
+            ) { index ->
+                posts[index]?.let { post ->
+                    PostRow(
+                        post = post,
+                        onClick = { onPostClick(post.summary.postId) },
+                        highlight = highlight,
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                }
             }
+            appendRow(posts)
         }
-        when (posts.loadState.append) {
-            LoadState.Loading ->
-                item("appending") {
-                    Box(Modifier.fillMaxWidth().padding(Spacing.lg), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator(Modifier.size(24.dp))
-                    }
-                }
+    }
+}
 
-            is LoadState.Error ->
-                item("append-failed") {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(Spacing.md),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            stringResource(R.string.search_load_more_failed),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        TextButton(onClick = posts::retry) { Text(stringResource(R.string.action_retry)) }
-                    }
+/** The tail of the result list: the next page arriving, or the one that did not. */
+private fun LazyListScope.appendRow(posts: LazyPagingItems<FeedPost>) {
+    when (posts.loadState.append) {
+        LoadState.Loading ->
+            item("appending") {
+                Box(Modifier.fillMaxWidth().padding(Spacing.lg), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(Modifier.size(24.dp))
                 }
+            }
 
-            is LoadState.NotLoading -> Unit
-        }
+        is LoadState.Error ->
+            item("append-failed") {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(Spacing.md),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        stringResource(R.string.search_load_more_failed),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    TextButton(onClick = posts::retry) { Text(stringResource(R.string.action_retry)) }
+                }
+            }
+
+        is LoadState.NotLoading -> Unit
     }
 }
 
 @Composable
 private fun SortMenuItem(
-    sort: SearchSort,
-    selectedSort: SearchSort,
-    onSortChange: (SearchSort) -> Unit,
+    sort: FeedSort,
+    selectedSort: FeedSort,
+    onSortChange: (FeedSort) -> Unit,
     closeMenu: () -> Unit,
 ) {
+    val isCurrent = sort == selectedSort
     DropdownMenuItem(
-        text = {
-            Text(
-                stringResource(
-                    if (sort == SearchSort.TIME) R.string.search_sort_time else R.string.search_sort_relevance,
-                ),
-                fontWeight = if (sort == selectedSort) FontWeight.Bold else FontWeight.Normal,
-            )
+        text = { Text(stringResource(sort.labelRes())) },
+        // Same reason as the home feed's menu: the tick is decoration, `selected` is what TalkBack
+        // reads out as 已选中.
+        modifier = Modifier.semantics { selected = isCurrent },
+        trailingIcon = {
+            if (isCurrent) Icon(Icons.Default.Check, contentDescription = null)
         },
         onClick = {
             closeMenu()
@@ -458,6 +638,12 @@ private fun SortMenuItem(
     )
 }
 
+/**
+ * Past searches, each one a whole search rather than a word.
+ *
+ * The second line is the scope it ran with, so the same word searched in two boards is two rows and
+ * tapping either re-runs exactly what it says.
+ */
 @Composable
 private fun SearchHistory(
     searches: List<SearchHistoryEntry>,
@@ -467,10 +653,14 @@ private fun SearchHistory(
     onClearHistory: () -> Unit,
 ) {
     Row(
-        Modifier.fillMaxWidth().padding(start = Spacing.lg, end = Spacing.sm, top = Spacing.md),
+        Modifier.fillMaxWidth().padding(start = Spacing.lg, end = Spacing.sm),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(stringResource(R.string.search_recent), style = MaterialTheme.typography.titleSmall, modifier = Modifier.weight(1f))
+        Text(
+            stringResource(R.string.search_recent),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.weight(1f),
+        )
         TextButton(onClick = onClearHistory) { Text(stringResource(R.string.search_clear_all)) }
     }
     if (searches.isEmpty()) {
@@ -482,34 +672,30 @@ private fun SearchHistory(
     } else {
         LazyColumn {
             items(searches, key = SearchHistoryEntry::key) { recent ->
-                Row(
-                    Modifier
-                        .fillMaxWidth()
-                        .clickable { onHistoryClick(recent) }
-                        .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        if (recent.target == SearchTarget.POSTS) NodysseyIcons.History else NodysseyIcons.PersonSearch,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp),
-                    )
-                    Column(Modifier.weight(1f).padding(horizontal = Spacing.md)) {
-                        Text(recent.query)
-                        Text(
-                            historyScope(recent, boards),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    IconButton(onClick = { onRemoveHistory(recent) }) {
+                ListItem(
+                    headlineContent = { Text(recent.query, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                    supportingContent = { Text(historyScope(recent, boards)) },
+                    leadingContent = {
                         Icon(
-                            Icons.Default.Close,
-                            contentDescription = stringResource(R.string.search_remove_recent, recent.query),
+                            if (recent.target == SearchTarget.POSTS) {
+                                NodysseyIcons.History
+                            } else {
+                                NodysseyIcons.PersonSearch
+                            },
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
-                    }
-                }
+                    },
+                    trailingContent = {
+                        IconButton(onClick = { onRemoveHistory(recent) }) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = stringResource(R.string.search_remove_recent, recent.query),
+                            )
+                        }
+                    },
+                    modifier = Modifier.clickable { onHistoryClick(recent) },
+                )
             }
         }
     }
@@ -522,8 +708,7 @@ private fun historyScope(
 ): String {
     if (entry.target == SearchTarget.USERS) return stringResource(R.string.search_user_history_scope)
     val slug = entry.categorySlug ?: return stringResource(R.string.search_history_scope)
-    val name = boards.firstOrNull { it.slug == slug }?.title ?: slug
-    return stringResource(R.string.search_history_board_scope, name)
+    return stringResource(R.string.search_history_board_scope, boards.title(slug))
 }
 
 @Composable
@@ -571,7 +756,7 @@ private fun userDetail(user: UserSearchResult): String =
     }.joinToString(" · ")
 
 /**
- * Picks the one board the search is scoped to.
+ * Picks the one board the search is scoped to, from the results screen.
  *
  * Single choice because `/search` takes a single `category` and applies it itself. The checkbox
  * version of this sheet could only pretend to filter by several: it searched the whole site and
@@ -700,10 +885,22 @@ private fun SearchPreview() {
         SearchScreen(
             state =
             SearchUiState(
+                boards =
+                listOf(
+                    Board("daily", "日常", null),
+                    Board("tech", "技术", null),
+                    Board("info", "情报", null),
+                    Board("review", "测评", null),
+                    Board("trade", "交易", null),
+                    Board("carpool", "拼车", null),
+                    Board("dev", "Dev", null),
+                ),
+                selectedBoard = "trade",
                 searchHistory =
                 listOf(
+                    SearchHistoryEntry("腾讯云轻量", SearchTarget.POSTS, categorySlug = "trade"),
                     SearchHistoryEntry("腾讯云轻量", SearchTarget.POSTS),
-                    SearchHistoryEntry("NodeSeek", SearchTarget.USERS),
+                    SearchHistoryEntry("nodequality", SearchTarget.POSTS, categorySlug = "tech"),
                 ),
             ),
             queryState = rememberTextFieldState(),

--- a/app/src/main/java/io/github/nodyssey/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/search/SearchViewModel.kt
@@ -23,7 +23,6 @@ import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.di.AppContainer
 import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.SearchHistoryEntry
-import io.github.nodyssey.model.SearchSort
 import io.github.nodyssey.model.SearchTarget
 import io.github.nodyssey.ui.postlist.toNodeSeekError
 import kotlinx.coroutines.CancellationException
@@ -80,7 +79,7 @@ class SearchViewModel(
                     postRepository.searchFeed(
                         query = request.query,
                         categorySlug = request.board,
-                        sort = request.sort.toFeedSort(),
+                        sort = request.sort,
                     )
                 }
             }.cachedIn(viewModelScope)
@@ -183,7 +182,7 @@ class SearchViewModel(
         rerunSubmittedSearch()
     }
 
-    fun selectSort(sort: SearchSort) {
+    fun selectSort(sort: FeedSort) {
         if (_uiState.value.sort == sort) return
         _uiState.update { it.copy(sort = sort) }
         rerunSubmittedSearch()
@@ -200,7 +199,7 @@ class SearchViewModel(
             NodeSeekSite.postSearchPath(
                 query = state.submittedQuery ?: query.text.toString(),
                 categorySlug = state.selectedBoard,
-                sort = state.sort.toFeedSort(),
+                sort = state.sort,
             )
     }
 
@@ -295,10 +294,6 @@ class SearchViewModel(
     }
 }
 
-/** The site expresses both orders with the one `sortBy` parameter the boards use. */
-internal fun SearchSort.toFeedSort(): FeedSort =
-    if (this == SearchSort.TIME) FeedSort.POST_TIME else FeedSort.LAST_REPLY
-
 sealed interface SearchLoadState {
     data object Idle : SearchLoadState
 
@@ -318,7 +313,8 @@ data class SearchUiState(
     val boards: List<Board> = emptyList(),
     /** One board, or null for the whole site — the only two scopes `/search` can express. */
     val selectedBoard: String? = null,
-    val sort: SearchSort = SearchSort.RELEVANCE,
+    /** `/search` reads the boards' own `sortBy`, and reads it as 新帖子 when it is absent. */
+    val sort: FeedSort = FeedSort.POST_TIME,
     val userResults: List<UserSearchResult> = emptyList(),
     val userLoadState: SearchLoadState = SearchLoadState.Idle,
 )
@@ -327,5 +323,5 @@ data class SearchUiState(
 internal data class PostSearchRequest(
     val query: String,
     val board: String?,
-    val sort: SearchSort,
+    val sort: FeedSort,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,13 +168,16 @@
     <string name="tab_profile">我的</string>
 
     <!-- Search: authenticated remote results and condition-aware local history -->
-    <string name="search_hint">搜索帖子、用户</string>
+    <string name="search_hint">搜索帖子</string>
+    <string name="search_hint_board">在 %1$s 版块搜帖子</string>
     <string name="search_user_hint">搜索用户名</string>
+    <string name="search_submit">搜索</string>
     <string name="search_posts_tab">帖子</string>
     <string name="search_users_tab">用户</string>
     <string name="search_all_boards">全部版块</string>
-    <string name="search_sort_relevance">相关度</string>
-    <string name="search_sort_time">时间</string>
+    <string name="search_board_section">版块</string>
+    <string name="search_board_single_hint">单选 · 只能指定一个</string>
+    <string name="search_board_chip_all">全部</string>
     <string name="search_history_empty">还没有搜索记录</string>
     <string name="search_history_scope">帖子 · 全部版块</string>
     <string name="search_user_history_scope">用户</string>
@@ -185,9 +188,9 @@
     <string name="search_apply_board">应用</string>
     <string name="search_board_all_boards_heading">全部</string>
     <string name="search_clear_query">清空关键词</string>
-    <string name="search_recent">最近搜索</string>
-    <string name="search_clear_all">全部清除</string>
-    <string name="search_remove_recent">删除最近搜索：%1$s</string>
+    <string name="search_recent">搜索历史</string>
+    <string name="search_clear_all">清除</string>
+    <string name="search_remove_recent">删除搜索历史：%1$s</string>
 
     <!-- Notifications: the site has three groups, and 私信 is a conversation list rather than rows -->
     <!-- Unread counts past the cap. Without the +, a capped 150 reads as an exact 99. -->

--- a/app/src/test/java/io/github/nodyssey/data/settings/SettingsHistoryMigrationTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/settings/SettingsHistoryMigrationTest.kt
@@ -18,7 +18,7 @@ import java.nio.file.Files
  * Search history written by an older build, read by this one.
  *
  * Decoding a stored row is lossy — the multi-select's board list collapses to its first board and
- * the retired sorts fold into `RELEVANCE` — so rows that were distinct on disk can arrive as one
+ * the retired sort labels fold into the two `FeedSort` values — so rows that were distinct on disk can arrive as one
  * entry. The list goes straight into a LazyColumn keyed on [SearchHistoryEntry.key], and a repeated
  * key there is a crash on the next frame, not a cosmetic duplicate: tapping into search with two
  * such rows stored took the app down every time.

--- a/app/src/test/java/io/github/nodyssey/ui/postlist/PostTitleHighlightTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/postlist/PostTitleHighlightTest.kt
@@ -1,0 +1,40 @@
+package io.github.nodyssey.ui.postlist
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The keyword the search results were chosen for, picked out of the titles that came back. */
+class PostTitleHighlightTest {
+    private val marked = Color.Red
+
+    @Test
+    fun `every occurrence is marked, whatever case the title used`() {
+        val title = "Zouter JP 首发，zouter 香港也有"
+
+        val highlighted = highlighted(title, "zouter", marked)
+
+        assertEquals(title, highlighted.text)
+        assertEquals(
+            listOf(0 to 6, title.indexOf("zouter") to title.indexOf("zouter") + 6),
+            highlighted.spanStyles.map { it.start to it.end },
+        )
+        assertTrue(highlighted.spanStyles.all { it.item.color == marked })
+    }
+
+    @Test
+    fun `a title without the keyword is left as plain text`() {
+        val highlighted = highlighted("腾讯云轻量", "zouter", marked)
+
+        assertEquals("腾讯云轻量", highlighted.text)
+        assertTrue(highlighted.spanStyles.isEmpty())
+    }
+
+    /** Every list but the search results passes null, and none of them may pay for a rebuild. */
+    @Test
+    fun `no keyword means no styling`() {
+        assertTrue(highlighted("腾讯云轻量", null, marked).spanStyles.isEmpty())
+        assertTrue(highlighted("腾讯云轻量", "   ", marked).spanStyles.isEmpty())
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/ui/search/SearchViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/search/SearchViewModelTest.kt
@@ -18,7 +18,6 @@ import io.github.nodyssey.data.inMemoryDatabase
 import io.github.nodyssey.data.local.NodeSeekDatabase
 import io.github.nodyssey.data.testSettingsRepository
 import io.github.nodyssey.model.FeedSort
-import io.github.nodyssey.model.SearchSort
 import io.github.nodyssey.model.SearchTarget
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -113,7 +112,7 @@ class SearchViewModelTest {
         runTest(dispatcher) {
             val vm = viewModel()
             vm.selectBoard("tech")
-            vm.selectSort(SearchSort.TIME)
+            vm.selectSort(FeedSort.POST_TIME)
             type(vm, "  android  ")
 
             vm.submitSearch()

--- a/docs/design-implementation.md
+++ b/docs/design-implementation.md
@@ -41,6 +41,42 @@ App 的总体真实状态以 [`implementation-status.md`](implementation-status.
 - 页面内容来自 NodeSeek 原文，不把约 6.9k 字复制进资源文件；标题、日期、段落和列表解析由 JVM 测试覆盖。
 - 原文外链交给浏览器（默认 Custom Tab，设置里可改成系统浏览器）；受限 WebView 只在原生加载或解析失败后由用户主动选择。
 
+## 搜索
+
+| 画板 | 实现状态 | 主要代码 | 仍需注意 |
+|---|---|---|---|
+| 6e 搜索 · 先指定再搜索 | 已按稿重做 | `ui/search/SearchScreen.kt` | 输入框常驻顶部，帖子 Tab 下方是版块单选 chip 组，排序只在结果页 |
+| 6f 搜索 · 帖子结果 | 已按稿对齐 | `ui/search/SearchScreen.kt`、`ui/postlist/PostListScreen.kt`、`model/SearchModels.kt` | 版块与排序都是服务端参数；「最后回复人」还没有数据来源 |
+
+## 6e 验收对照
+
+- 输入框固定在最顶部并始终可编辑：直接使用 `SearchBarDefaults.InputField`，不再是
+  `AppBarWithSearch` + `ExpandedFullScreenSearchBar` 的折叠/展开对。折叠态的搜索栏会用
+  `DisableSoftKeyboard` 包住输入框（那套交互里打字发生在覆盖其上的展开副本中），本页没有折叠态，
+  所以输入框必须自己接键盘；容器色也要自己上，因为折叠态的容器本来由外层 Surface 绘制。
+- 帖子 Tab：`版块` 标题 + 「单选 · 只能指定一个」+ `FlowRow` 里的 `FilterChip` 单选组，
+  服务端 `category` 只接受一个。placeholder 跟随所选版块变为「在 X 版块搜帖子」。
+- chip **不带选中勾**（画板上有）：勾让选中的 chip 宽约 26dp，折行组里它会把后面所有 chip 重排，
+  窄屏上点一次版块整组在三行和四行之间跳。填充容器对描边空心已经说清哪个是选中，
+  `FilterChip` 的 selected 语义照样让 TalkBack 报「已选中」，勾在 Material 里本就是可选装饰。
+- 用户 Tab：无版块，也不放说明卡（那是设计稿给人看的注解），直接进搜索历史。
+- 搜索历史用 `ListItem` 两行：关键词 + 「类型 · 版块」，同词不同版块是两条记录。
+- 与画板的差异：**没有返回键**——本 App 的搜索是底部导航的一级 Tab，退出靠切 Tab，
+  画板是按二级页面画的；帖子 Tab **不显示计数**，`/search` 不返回总数，已加载行数不是总数。
+
+## 6f 验收对照
+
+- 排序就是站点的两档「新评论 / 新帖子」= `sortBy=replyTime|postTime`，文案与首页统一为
+  「按回复时间 / 按发帖时间」。原来的 `SearchSort.RELEVANCE`（显示「相关度」）是假的：它发出去的
+  就是 `replyTime`，站点没有相关度排序。`SearchSort` 已删除，搜索直接用 `FeedSort`，默认
+  `POST_TIME`——`/search` 缺省即 `postTime`。旧记录里的 `RELEVANCE`/`TIME` 在读取时折回这两档。
+- 版块 chip 用 `FilterChip`：指定了版块才是选中态（带勾），点开仍是 6g 的版块范围 Sheet。
+- 结果标题里的关键词高亮：`PostRow(highlight = )`，字面、忽略大小写；其余列表传 null，不受影响。
+- 结果列表支持下拉刷新（`PullToRefreshBox`）与追加分页，行间有分隔线。
+- 与画板的差异：结果页顶部**仍是可编辑的输入框**，不是「返回 + 关键词 + ×」的标题栏——本 App
+  的 6e/6f 是同一个页面的两个状态，× 清空关键词即回到 6e；行内**没有「最后回复人」**，
+  `PostSummary` 目前不解析这个字段，补它要动解析器和 Room schema，超出本次范围。
+
 ## 修改流程
 
 1. 先读 `design/src/<id>.html`、对应 dark 稿和 `design/meta/<id>.json`。


### PR DESCRIPTION
按设计稿 6e（搜索入口）与 6f（帖子结果）重做搜索页。

## 问题

- 搜索是折叠搜索栏 + 全屏展开搜索栏那一对，**搜索历史因此存在两份**：弹层里一份、弹层后面一份。
- **版块只能在结果页选**，也就是搜错范围之后才改得了。
- 排序里的「相关度」是假的：`SearchSort.RELEVANCE` 发出去的参数就是 `sortBy=replyTime`，站点没有相关度排序，只有「新评论 / 新帖子」。

## 改了什么

**一个页面，输入框钉在顶上**（6e）。下面依次是帖子/用户 Tab、版块单选 chip 组、搜索历史或结果。

输入框不能套 `SearchBar` / `AppBarWithSearch`：折叠态的搜索栏会用 `DisableSoftKeyboard` 包住输入框——那套交互里打字发生在覆盖其上的展开副本中。本页没有折叠态，所以直接用 `SearchBarDefaults.InputField`（1.5 里唯一没废弃的重载），容器色也要自己上，因为折叠态的容器本来由外层 `Surface` 绘制。这两点在代码里都有注释。顺带去掉已废弃的 `TopSearchBar`。

**排序换成站点真有的两档**（6f）。删除 `SearchSort`，搜索直接用首页那套 `FeedSort`，文案与首页统一为「按回复时间 / 按发帖时间」，默认 `POST_TIME`——`/search` 缺省即 `postTime`。磁盘上旧记录里的 `RELEVANCE` / `TIME` 在读取时折回这两档，历史不会丢失或重复（`SettingsHistoryMigrationTest` 覆盖）。

其余：搜索历史改 `ListItem` 两行（关键词 + 「类型 · 版块」）；结果页补关键词高亮、下拉刷新、行间分隔线；帖子 Tab 不再显示计数——服务端不返回总数，已加载行数会随滚动变大，那不是总数。

## 审阅时值得看一眼的

- **版块 chip 没有选中勾**（画板上有）。勾让选中的 chip 宽约 26dp，折行组里它会把后面所有 chip 重排，窄屏上点一次版块整组在三行和四行之间跳。填充容器对描边空心已经说清哪个是选中，`FilterChip` 的 selected 语义照样让 TalkBack 报「已选中」。
- **没有返回键**：本 App 的搜索是底部导航一级 Tab，退出靠切 Tab，画板是按二级页面画的。
- **行内没有「最后回复人」**：`PostSummary` 目前不解析这个字段，补它要动解析器和 Room schema，超出本次范围。
- `PostRow` 多了一个 `highlight` 参数，默认 null——首页和推荐阅读走的是默认值，不受影响。

三处差异都记在 `docs/design-implementation.md` 的 6e / 6f 验收对照里。

## 验证

`./gradlew :app:testDebugUnitTest :app:lintDebug spotlessCheck :app:compileDebugAndroidTestKotlin` 全绿（含新增的 `PostTitleHighlightTest`）。

真机（SM-S9310 / Android 16）走了一遍：选版块 → placeholder 变「在 X 版块搜帖子」→ 提交（键盘收起、结果出、关键词高亮）→ 切排序重新拉取 → 用户 Tab 出「用户 · 1」→ 清空回到入口页看到新历史 → 反复点版块 chip，整组不再跳行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)