### PR TITLE
首页板块栏可自定义：长按拖动排序，角标移出/加回

### DIFF
--- a/app/src/main/java/io/github/nodyssey/data/settings/HomeBoards.kt
+++ b/app/src/main/java/io/github/nodyssey/data/settings/HomeBoards.kt
@@ -28,3 +28,45 @@ fun visibleHomeBoards(boards: List<Board>, hidden: Set<String>): List<Board> {
     if (effective.isEmpty()) return boards
     return boards.filterNot { it.slug in effective }
 }
+
+/**
+ * The strip split in two: the pills that are on, and the pills parked behind them.
+ *
+ * Two lists rather than one list plus a predicate because that is what the strip draws — the parked
+ * boards are always the tail, greyed, and the boundary between the halves is the thing the edit mode
+ * moves pills across.
+ */
+data class HomeBoardArrangement(
+    val enabled: List<Board>,
+    val parked: List<Board>,
+)
+
+/**
+ * Applies the user's saved strip arrangement to the boards the site currently has.
+ *
+ * The stored order is a *ranking*, not a list of boards: it can name slugs the API has since dropped,
+ * and the API can return boards it has never heard of. Neither is an error, and neither may lose a
+ * board — so ranked-and-still-real boards come first in their saved order, and anything the ranking
+ * has no opinion about is appended, enabled, in the order the API gave it. A board added to the site
+ * next month therefore shows up rather than silently going missing.
+ *
+ * [boards] is the real boards only, already narrowed by [visibleHomeBoards]: the site's own 首页版块
+ * switches and this arrangement are separate mechanisms, and a board the account switched off is gone
+ * from the strip entirely rather than parked in it. 综合 is not a board, has no slug, and is prepended
+ * by whoever draws the strip — it is never reordered and never parked.
+ */
+fun homeBoardArrangement(
+    boards: List<Board>,
+    order: List<String>,
+    parked: Set<String>,
+): HomeBoardArrangement {
+    if (order.isEmpty() && parked.isEmpty()) return HomeBoardArrangement(boards, emptyList())
+    val bySlug = boards.associateBy { it.slug }
+    val ranked = order.mapNotNull { bySlug[it] }
+    val rankedSlugs = order.toSet()
+    val unranked = boards.filterNot { it.slug in rankedSlugs }
+    // `partition` keeps relative order within each half, so freshly discovered boards land at the end
+    // of the enabled half rather than jumping to the front of it.
+    val (off, on) = (ranked + unranked).partition { it.slug in parked }
+    return HomeBoardArrangement(enabled = on, parked = off)
+}

--- a/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
@@ -58,6 +58,8 @@ class SettingsRepository(
                     // store (a renamed slug, a bad write) must not silently thin out the feed.
                     .filter { it in OPTIONAL_HOME_BOARD_SLUGS }
                     .toSet(),
+                homeBoardOrder = decodeValues(preferences[KEY_HOME_BOARD_ORDER]),
+                disabledHomeBoards = decodeValues(preferences[KEY_DISABLED_HOME_BOARDS]).toSet(),
                 notificationsEnabled = preferences[KEY_NOTIFICATIONS_ENABLED] ?: false,
                 notificationPollMinutes =
                 (preferences[KEY_NOTIFICATION_POLL_MINUTES] ?: DEFAULT_POLL_MINUTES)
@@ -178,6 +180,38 @@ class SettingsRepository(
         }
     }
 
+    /**
+     * The home strip's own arrangement: what order the pills sit in, and which ones the user parked.
+     *
+     * Written as one pair because they are one edit. Splitting them into two `edit` calls would let
+     * the flow emit an order that has already moved a board to the tail while it is still marked
+     * enabled — a frame where the strip is visibly wrong, for no benefit.
+     *
+     * This is *not* the site's 首页版块 preference ([setHomeBoardHidden]). That one is the account's
+     * and can only touch three boards; this one is local, covers every board, and is reversible from
+     * the strip itself. The two narrow the list independently and on purpose.
+     */
+    suspend fun setHomeBoardArrangement(
+        order: List<String>,
+        disabled: Set<String>,
+    ) {
+        dataStore.edit { preferences ->
+            if (order.isEmpty()) {
+                preferences.remove(KEY_HOME_BOARD_ORDER)
+            } else {
+                preferences[KEY_HOME_BOARD_ORDER] = encodeValues(order, MAX_HOME_BOARDS)
+            }
+            // Only slugs the order still knows about; a disabled board with no rank would come back
+            // as a fresh board on the next read and silently re-enable itself.
+            val ranked = disabled.filter { it in order }
+            if (ranked.isEmpty()) {
+                preferences.remove(KEY_DISABLED_HOME_BOARDS)
+            } else {
+                preferences[KEY_DISABLED_HOME_BOARDS] = encodeValues(ranked, MAX_HOME_BOARDS)
+            }
+        }
+    }
+
     /** Local mirror of the site's Remote 启用节日主题 switch; the sync authority is the account. */
     suspend fun setHolidayTheme(enabled: Boolean) = edit { it[KEY_HOLIDAY_THEME] = enabled }
 
@@ -238,6 +272,8 @@ class SettingsRepository(
         private val KEY_SEARCH_HISTORY = stringPreferencesKey("search_history_v3")
         private val KEY_RECENT_BOARDS = stringPreferencesKey("recent_boards")
         private val KEY_HIDDEN_HOME_BOARDS = stringPreferencesKey("hidden_home_boards")
+        private val KEY_HOME_BOARD_ORDER = stringPreferencesKey("home_board_order")
+        private val KEY_DISABLED_HOME_BOARDS = stringPreferencesKey("disabled_home_boards")
         private val KEY_HOLIDAY_THEME = booleanPreferencesKey("holiday_theme")
         private val KEY_NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
         private val KEY_NOTIFICATION_POLL_MINUTES = intPreferencesKey("notification_poll_minutes")
@@ -253,6 +289,9 @@ class SettingsRepository(
         private const val RECENT_SEARCH_SEPARATOR = '\u001F'
         private const val MAX_RECENT_SEARCHES = 8
         private const val MAX_RECENT_BOARDS = 6
+
+        /** The site has fifteen boards. The cap is only here so a corrupt write cannot grow forever. */
+        private const val MAX_HOME_BOARDS = 64
 
         private fun decodeRecentSearches(value: String?): List<String> =
             value.orEmpty().split(RECENT_SEARCH_SEPARATOR).filter(String::isNotBlank)
@@ -307,6 +346,13 @@ data class UserSettings(
     val recentBoards: List<String> = emptyList(),
     /** Boards switched off the home feed. Empty — the default — hides nothing; see `setHomeBoardHidden`. */
     val hiddenHomeBoards: Set<String> = emptySet(),
+    /**
+     * The strip's arrangement, as edited by long-pressing it. Empty means "never customised": the
+     * boards keep the order the API returned them in and none of them are parked.
+     */
+    val homeBoardOrder: List<String> = emptyList(),
+    /** Boards parked at the tail of the strip. A subset of [homeBoardOrder]; see `setHomeBoardArrangement`. */
+    val disabledHomeBoards: Set<String> = emptySet(),
     /*
      * App notification polling (board f4). Off by default: polling costs battery and needs the
      * POST_NOTIFICATIONS runtime permission, so it starts only when the user asks for it.

--- a/app/src/main/java/io/github/nodyssey/ui/postlist/BoardStrip.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postlist/BoardStrip.kt
@@ -1,0 +1,797 @@
+package io.github.nodyssey.ui.postlist
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationException
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChangeIgnoreConsumed
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import io.github.nodyssey.R
+import io.github.nodyssey.data.Board
+import io.github.nodyssey.ui.theme.Spacing
+import kotlinx.coroutines.launch
+
+/**
+ * Fifteen boards do not fit on a 360dp strip, and a bottom sheet was the other candidate.
+ *
+ * This is the inline version: the strip *is* the picker. Collapsed it scrolls sideways through the
+ * same pills; expanded it wraps them onto as many rows as they need, in place. One list drawn once —
+ * an earlier version dropped a second panel underneath and simply repeated the strip's contents.
+ *
+ * It costs vertical space while open, but the finger never leaves the top of the screen and the list
+ * underneath stays visible — which a sheet cannot claim.
+ *
+ * Expanded, a long press turns the same pills into an editor: drag to reorder, and tap a pill's
+ * corner badge to park it at the tail or bring it back. Parked boards are only drawn while editing —
+ * out of the way is the whole point of parking one — so the editor is also the only place they can be
+ * recovered, which is why the long press is on the strip rather than buried in 设置.
+ *
+ * [parkedBoards] is deliberately a second list rather than a flag inside [boards]: outside edit mode
+ * a parked board is not selectable, and [boards] is exactly the list the feed may page through.
+ */
+@Composable
+internal fun BoardStrip(
+    boards: List<Board>,
+    parkedBoards: List<Board>,
+    selectedSlug: String?,
+    onBoardClick: (String?) -> Unit,
+    onArrangementChange: (order: List<String>, parked: Set<String>) -> Unit,
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    var editing by rememberSaveable { mutableStateOf(false) }
+    val rowState = rememberLazyListState()
+    val haptics = LocalHapticFeedback.current
+
+    /*
+     * The editor works on its own copy of the strip.
+     *
+     * Every edit is written through immediately — a drag that survives to the finger lifting is a
+     * decision, and losing it because the app was backgrounded would be indefensible — but the draft
+     * stays authoritative until the editor closes. Following the store instead would mean the write
+     * we just made races back through the flow and replaces the list mid-gesture.
+     *
+     * Keyed on `editing` alone for the same reason: a board list refresh landing while a finger is
+     * down must not reshuffle what is under it.
+     */
+    var draft by remember { mutableStateOf(emptyList<BoardSlot>()) }
+    LaunchedEffect(editing) {
+        if (editing) {
+            draft =
+                boards.map { BoardSlot(it, parked = false) } +
+                parkedBoards.map { BoardSlot(it, parked = true) }
+        }
+    }
+
+    fun commit(slots: List<BoardSlot>) {
+        onArrangementChange(
+            slots.mapNotNull { it.board.slug },
+            slots.filter { it.parked }.mapNotNull { it.board.slug }.toSet(),
+        )
+    }
+
+    fun togglePark(key: String) {
+        val index = draft.indexOfFirst { it.key == key }
+        if (index < 0) return
+        val slot = draft[index]
+        if (slot.locked) return
+        val next = draft.toMutableList()
+        next.removeAt(index)
+        if (slot.parked) {
+            // Back to the end of the live half, not to wherever it used to sit: the strip has moved
+            // on, and dropping it into a slot the user has since given to something else is worse
+            // than an obvious "it came back at the end".
+            val boundary = next.indexOfFirst { it.parked }.takeIf { it >= 0 } ?: next.size
+            next.add(boundary, slot.copy(parked = false))
+        } else {
+            next.add(slot.copy(parked = true))
+        }
+        draft = next
+        commit(next)
+        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+    }
+
+    // Collapsing back to one row must not hide the board the user just picked behind the fold.
+    val selectedIndex = boards.indexOfFirst { it.slug == selectedSlug }
+    LaunchedEffect(expanded, selectedIndex) {
+        if (!expanded && selectedIndex > 0) rowState.animateScrollToItem(selectedIndex)
+    }
+
+    // Back is what every other transient mode on this screen answers to, and the editor is one.
+    BackHandler(enabled = editing) { editing = false }
+
+    Column(
+        Modifier.animateContentSize(
+            animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
+        ),
+    ) {
+        /*
+         * A box with the toggle laid over the corner, not a row with the toggle beside the pills.
+         *
+         * A row makes the toggle's width a column that every wrapped row of pills has to keep clear,
+         * so an expanded strip left a tall empty gutter down its right edge with a single button at
+         * the top of it. Only the *first* row shares its line with the toggle, and that is exactly
+         * what [BoardFlow] insets — the rows below it run the full width of the screen.
+         */
+        Box(Modifier.fillMaxWidth()) {
+            if (expanded) {
+                ExpandedBoards(
+                    slots = if (editing) draft else boards.map { BoardSlot(it, parked = false) },
+                    selectedSlug = selectedSlug,
+                    editing = editing,
+                    // Clear of the toggle, its own end inset, and a pill's worth of breathing room.
+                    firstRowInset = ToggleSlotWidth + Spacing.sm,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = Spacing.lg),
+                    onBoardClick = { slug ->
+                        onBoardClick(slug)
+                        expanded = false
+                    },
+                    onEnterEditing = {
+                        editing = true
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                    onReorder = { moved ->
+                        draft = moved
+                        commit(moved)
+                        haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    },
+                    onTogglePark = ::togglePark,
+                )
+            } else {
+                Row(Modifier.fillMaxWidth()) {
+                    LazyRow(
+                        state = rowState,
+                        modifier = Modifier.weight(1f),
+                        contentPadding = PaddingValues(horizontal = Spacing.lg),
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                    ) {
+                        items(count = boards.size, key = { boards[it].slug ?: FRONT_PAGE_KEY }) { index ->
+                            val board = boards[index]
+                            BoardPill(
+                                board = board,
+                                selected = board.slug == selectedSlug,
+                                onClick = { onBoardClick(board.slug) },
+                            )
+                        }
+                    }
+                    // The scrolling row stops where the toggle starts, rather than running under it.
+                    Spacer(Modifier.width(ToggleSlotWidth))
+                }
+            }
+            // The band a pill occupies is 48dp — a 32dp shape centred inside the touch target Material
+            // reserves for it — while this button is pinned to 32dp and would otherwise hang 8dp above
+            // the first row of pills it is supposed to sit on. Giving it the same band, from the same
+            // composition local the pills read, aligns the two shapes by construction rather than by a
+            // hardcoded offset that a theme could invalidate.
+            //
+            // The end inset is the same 16dp the pills are laid out against on the left, so the strip
+            // is symmetric: the button used to sit flush against the display edge because it was the
+            // only thing in this row without padding of its own.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .heightIn(min = LocalMinimumInteractiveComponentSize.current)
+                    .padding(end = Spacing.lg),
+                contentAlignment = Alignment.Center,
+            ) {
+                // The tonal button *is* the pill, rather than a plain IconButton with one drawn inside
+                // it: the ripple is clipped to the shape it draws instead of spilling above and below
+                // the 32dp pill.
+                //
+                // While editing it is the way out, so it turns into a tick. One control, because a
+                // separate 完成 button would mean two things in a corner that only ever does one.
+                val container by animateColorAsState(
+                    targetValue =
+                    if (editing) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainer
+                    },
+                    animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                    label = "board-toggle-container",
+                )
+                val content by animateColorAsState(
+                    targetValue =
+                    if (editing) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                    animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                    label = "board-toggle-content",
+                )
+                FilledTonalIconButton(
+                    onClick = {
+                        when {
+                            editing -> editing = false
+                            else -> expanded = !expanded
+                        }
+                    },
+                    modifier = Modifier.size(width = ToggleWidth, height = 32.dp),
+                    shape = CircleShape,
+                    colors =
+                    IconButtonDefaults.filledTonalIconButtonColors(
+                        containerColor = container,
+                        contentColor = content,
+                    ),
+                ) {
+                    // Three states through one 40dp hole, so they trade places rather than cut. The
+                    // specs are read out here because a transition spec is not a composable scope.
+                    val fade = MaterialTheme.motionScheme.fastEffectsSpec<Float>()
+                    val pop = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
+                    AnimatedContent(
+                        targetState = editing to expanded,
+                        transitionSpec = {
+                            (fadeIn(fade) + scaleIn(pop, initialScale = ICON_SWAP_SCALE))
+                                .togetherWith(fadeOut(fade) + scaleOut(pop, targetScale = ICON_SWAP_SCALE))
+                        },
+                        label = "board-toggle-icon",
+                    ) { (isEditing, isExpanded) ->
+                        Icon(
+                            imageVector =
+                            when {
+                                isEditing -> Icons.Default.Check
+                                isExpanded -> Icons.Default.KeyboardArrowUp
+                                else -> Icons.Default.KeyboardArrowDown
+                            },
+                            contentDescription =
+                            stringResource(
+                                when {
+                                    isEditing -> R.string.action_finish_editing_boards
+                                    isExpanded -> R.string.action_hide_all_boards
+                                    else -> R.string.action_show_all_boards
+                                },
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+        AnimatedVisibility(visible = editing) {
+            Text(
+                text = stringResource(R.string.board_edit_hint),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = Spacing.lg, bottom = Spacing.sm),
+            )
+        }
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+    }
+}
+
+/**
+ * The wrapped grid of pills, and — while [editing] — the drag surface over it.
+ *
+ * Both gestures live on this container rather than on the pills. A chip's own `clickable` consumes
+ * the pointer down, so a long-press detector sitting on a chip would never see one; watching from the
+ * parent on the initial pass is the only place both gestures can be read without fighting the chips
+ * for their taps. It is also simply less machinery: one detector instead of fifteen.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun ExpandedBoards(
+    slots: List<BoardSlot>,
+    selectedSlug: String?,
+    editing: Boolean,
+    firstRowInset: Dp,
+    modifier: Modifier,
+    onBoardClick: (String?) -> Unit,
+    onEnterEditing: () -> Unit,
+    onReorder: (List<BoardSlot>) -> Unit,
+    onTogglePark: (String) -> Unit,
+) {
+    // Where each pill's *slot* is, in this container's coordinates. Recorded on the outer box of each
+    // pill, which carries neither the drag transform nor the placement animation, so a pill gliding
+    // under the finger cannot feed its own offset back into the hit testing that decides where it
+    // lands. These are settled positions by construction.
+    val slotBounds = remember { mutableStateMapOf<String, Rect>() }
+    var containerCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
+    var draggedKey by remember { mutableStateOf<String?>(null) }
+    // Finger position and where inside the pill it grabbed, both in container coordinates.
+    var pointer by remember { mutableStateOf(Offset.Zero) }
+    var grabWithinPill by remember { mutableStateOf(Offset.Zero) }
+
+    /*
+     * Letting go is its own animation.
+     *
+     * The pill is held to the finger by an offset from its slot, so dropping it by simply forgetting
+     * the drag would teleport it home. Instead the key stays live for one more animation and the
+     * offset is scaled to zero, which glides it into the slot it earned — including a slot it was
+     * reordered into on the way there, since the offset is recomputed from the current slot each
+     * frame rather than baked in at release.
+     */
+    val scope = rememberCoroutineScope()
+    val settle = remember { Animatable(0f) }
+    var releasingKey by remember { mutableStateOf<String?>(null) }
+    val settleSpec = MaterialTheme.motionScheme.defaultSpatialSpec<Float>()
+    val liftSpec = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
+
+    fun release() {
+        val key = draggedKey ?: return
+        draggedKey = null
+        releasingKey = key
+        scope.launch {
+            settle.snapTo(1f)
+            settle.animateTo(0f, settleSpec)
+            if (releasingKey == key) releasingKey = null
+        }
+    }
+
+    // A pill that leaves the list mid-drag — a board list refresh, an editor closed by the back key —
+    // must not leave a floating ghost behind.
+    if (draggedKey != null && slots.none { it.key == draggedKey }) draggedKey = null
+
+    val gestures =
+        if (editing) {
+            Modifier.pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = { start ->
+                        pointer = start
+                        releasingKey = null
+                        val slot =
+                            slots.firstOrNull { slotBounds[it.key]?.contains(start) == true }
+                        // Locked 综合 stays first, and reordering the parked tail would be sorting a
+                        // bin. Both are still perfectly tappable; they are just not draggable.
+                        draggedKey = slot?.takeIf { !it.locked && !it.parked }?.key
+                        grabWithinPill =
+                            draggedKey?.let { key -> start - (slotBounds[key]?.center ?: start) }
+                                ?: Offset.Zero
+                    },
+                    onDrag = { change, delta ->
+                        if (draggedKey == null) return@detectDragGestures
+                        change.consume()
+                        pointer += delta
+                        val moved = slots.reorderedFor(draggedKey, pointer, slotBounds)
+                        if (moved != null) onReorder(moved)
+                    },
+                    onDragEnd = ::release,
+                    onDragCancel = ::release,
+                )
+            }
+        } else {
+            Modifier.longPressToEdit(onEnterEditing)
+        }
+
+    // Lookahead is what lets a pill animate into a slot it has already been placed in: the layout
+    // jumps, the drawing follows. Every pill below reads this scope through `animateBounds`.
+    LookaheadScope {
+        BoardFlow(
+            firstRowInset = firstRowInset,
+            // Editing widens the gaps so the corner badges have somewhere to sit: at the resting 8dp
+            // a badge would overlap the pill beside it rather than the pill it belongs to.
+            horizontalGap = if (editing) Spacing.lg else Spacing.sm,
+            modifier = modifier
+                .onGloballyPositioned { containerCoords = it }
+                .then(gestures),
+        ) {
+            slots.forEach { slot ->
+                // Identity, not position. Without it Compose would reuse each node for whatever pill
+                // now sits at that index — the content would teleport and there would be nothing left
+                // for the placement animation to animate.
+                key(slot.key) {
+                    val active = slot.key == draggedKey
+                    val held = active || slot.key == releasingKey
+                    val lift = animateFloatAsState(
+                        targetValue = if (active) 1f else 0f,
+                        animationSpec = liftSpec,
+                        label = "board-pill-lift",
+                    )
+                    Box(
+                        modifier = Modifier
+                            // The held pill draws over its neighbours instead of sliding beneath them.
+                            .zIndex(if (held) 1f else 0f)
+                            .onGloballyPositioned { coords ->
+                                val container = containerCoords ?: return@onGloballyPositioned
+                                slotBounds[slot.key] = container.localBoundingBoxOf(coords)
+                            },
+                    ) {
+                        Box(
+                            // Inner node, so neither transform below is visible to the measurement
+                            // above. A held pill is already glued to the finger, so it is the one
+                            // pill that must *not* animate towards its slot.
+                            modifier = (
+                                if (held) {
+                                    Modifier
+                                } else {
+                                    Modifier.animateBounds(this@LookaheadScope)
+                                }
+                                ).graphicsLayer {
+                                if (held) {
+                                    val home = slotBounds[slot.key]
+                                    if (home != null) {
+                                        val factor = if (active) 1f else settle.value
+                                        val target = pointer - grabWithinPill
+                                        translationX = (target.x - home.center.x) * factor
+                                        translationY = (target.y - home.center.y) * factor
+                                    }
+                                }
+                                val raised = lift.value
+                                if (raised > 0f) {
+                                    val scale = 1f + (DRAG_SCALE - 1f) * raised
+                                    scaleX = scale
+                                    scaleY = scale
+                                    shadowElevation = DRAG_ELEVATION.toPx() * raised
+                                    shape = CircleShape
+                                    clip = false
+                                }
+                            },
+                        ) {
+                            BoardPill(
+                                board = slot.board,
+                                selected = !editing && slot.board.slug == selectedSlug,
+                                parked = slot.parked,
+                                onClick = { if (!editing) onBoardClick(slot.board.slug) },
+                            )
+                            AnimatedVisibility(
+                                visible = editing && !slot.locked,
+                                enter = scaleIn(MaterialTheme.motionScheme.fastSpatialSpec()) +
+                                    fadeIn(MaterialTheme.motionScheme.fastEffectsSpec()),
+                                exit = scaleOut(MaterialTheme.motionScheme.fastSpatialSpec()) +
+                                    fadeOut(MaterialTheme.motionScheme.fastEffectsSpec()),
+                                modifier = Modifier.align(Alignment.TopEnd),
+                            ) {
+                                ParkBadge(
+                                    parked = slot.parked,
+                                    onClick = { onTogglePark(slot.key) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Pills wrapped onto as many lines as they need, with [firstRowInset] kept clear at the end of the
+ * first line only.
+ *
+ * `FlowRow` cannot express that, and the difference is the whole reason this exists: the expand
+ * toggle shares a line with the first row of pills, so reserving its width by putting it in a `Row`
+ * beside the flow narrowed *every* line and left a tall empty gutter down the right of the block. One
+ * line gives way to the toggle; the rest run the full width.
+ *
+ * Deliberately minimal — no vertical gap parameter, no alignment, no `maxLines`. Each pill is a 32dp
+ * shape centred in a 48dp touch band, so the lines already clear each other by 16dp and anything this
+ * layout added on top would read as a list rather than as a grid of chips.
+ */
+@Composable
+private fun BoardFlow(
+    firstRowInset: Dp,
+    horizontalGap: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Layout(content = content, modifier = modifier) { measurables, constraints ->
+        val gap = horizontalGap.roundToPx()
+        val width = constraints.maxWidth
+        val inset = firstRowInset.roundToPx()
+        val placeables = measurables.map { it.measure(constraints.copy(minWidth = 0, minHeight = 0)) }
+
+        val rows = mutableListOf<List<Placeable>>()
+        var row = mutableListOf<Placeable>()
+        var rowWidth = 0
+        placeables.forEach { placeable ->
+            // Only the first line has to leave room for the toggle sitting on it.
+            val limit = if (rows.isEmpty()) width - inset else width
+            val extended = if (row.isEmpty()) placeable.width else rowWidth + gap + placeable.width
+            // A pill that does not fit even on a line of its own still has to go somewhere, so an
+            // empty row always accepts one rather than looping forever looking for a wider line.
+            if (row.isNotEmpty() && extended > limit) {
+                rows += row
+                row = mutableListOf(placeable)
+                rowWidth = placeable.width
+            } else {
+                row += placeable
+                rowWidth = extended
+            }
+        }
+        if (row.isNotEmpty()) rows += row
+
+        layout(width, rows.sumOf { line -> line.maxOf { it.height } }) {
+            var y = 0
+            rows.forEach { line ->
+                var x = 0
+                line.forEach { placeable ->
+                    placeable.place(x, y)
+                    x += placeable.width + gap
+                }
+                y += line.maxOf { it.height }
+            }
+        }
+    }
+}
+
+/**
+ * The ✕ / ＋ on a pill's shoulder.
+ *
+ * One control with two meanings rather than two controls, because parking and restoring are the same
+ * decision seen from either side, and the pill is 32dp tall — there is room for exactly one badge.
+ */
+@Composable
+private fun ParkBadge(
+    parked: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val description = stringResource(if (parked) R.string.board_restore else R.string.board_park)
+    val container by animateColorAsState(
+        targetValue = if (parked) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+        animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+        label = "park-badge-container",
+    )
+    Surface(
+        onClick = onClick,
+        modifier = modifier
+            .size(BADGE_SIZE)
+            .semantics { contentDescription = description },
+        shape = CircleShape,
+        color = container,
+        contentColor =
+        if (parked) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onError,
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            // The two glyphs are the same stroke rotated, so they turn into each other rather than
+            // cutting — the badge is 20dp and a cut at that size reads as a flicker.
+            val fade = MaterialTheme.motionScheme.fastEffectsSpec<Float>()
+            val pop = MaterialTheme.motionScheme.fastSpatialSpec<Float>()
+            AnimatedContent(
+                targetState = parked,
+                transitionSpec = {
+                    (fadeIn(fade) + scaleIn(pop, initialScale = ICON_SWAP_SCALE))
+                        .togetherWith(fadeOut(fade) + scaleOut(pop, targetScale = ICON_SWAP_SCALE))
+                },
+                label = "park-badge-icon",
+            ) { isParked ->
+                Icon(
+                    imageVector = if (isParked) Icons.Default.Add else Icons.Default.Close,
+                    // The Surface already carries the description; repeating it here would have
+                    // TalkBack read the badge twice.
+                    contentDescription = null,
+                    modifier = Modifier.size(BADGE_ICON_SIZE),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoardPill(
+    board: Board,
+    selected: Boolean,
+    onClick: () -> Unit,
+    parked: Boolean = false,
+) {
+    val parkedLabel = stringResource(R.string.board_parked)
+    val colorSpec = MaterialTheme.motionScheme.defaultEffectsSpec<androidx.compose.ui.graphics.Color>()
+    // Parking a board is a move *and* a fade, and the two read as one gesture only if the colour
+    // takes as long as the flight to the tail does.
+    val container by animateColorAsState(
+        targetValue =
+        if (parked) {
+            MaterialTheme.colorScheme.surfaceContainerHighest
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerLow
+        },
+        animationSpec = colorSpec,
+        label = "board-pill-container",
+    )
+    val label by animateColorAsState(
+        targetValue =
+        if (parked) {
+            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = PARKED_ALPHA)
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        animationSpec = colorSpec,
+        label = "board-pill-label",
+    )
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = {
+            Text(
+                text = board.title,
+                style = MaterialTheme.typography.labelMedium,
+                maxLines = 1,
+            )
+        },
+        // A parked board is still a board — it is only out of the way — so it keeps its shape and its
+        // label and loses its contrast. TalkBack gets told in words, since grey is not a word.
+        modifier =
+        if (parked) Modifier.semantics { contentDescription = "${board.title}, $parkedLabel" } else Modifier,
+        // Boards the site refuses to anyone signed out are worth flagging before the tap, not after.
+        // Described rather than decorative: the warning is the whole point of the icon, and it is
+        // nowhere else in the chip, so leaving it null hides the restriction from TalkBack.
+        trailingIcon =
+        if (board.adminOnly) {
+            {
+                Icon(
+                    Icons.Default.Lock,
+                    contentDescription = stringResource(R.string.board_admin_only),
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        } else {
+            null
+        },
+        shape = CircleShape,
+        colors =
+        FilterChipDefaults.filterChipColors(
+            containerColor = container,
+            labelColor = label,
+            iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            selectedContainerColor = MaterialTheme.colorScheme.primary,
+            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+            selectedTrailingIconColor = MaterialTheme.colorScheme.onPrimary,
+        ),
+        border = null,
+    )
+}
+
+/**
+ * One pill's place in the strip while it is being rearranged.
+ *
+ * [parked] rather than two lists: a drag and a park are both "move this slot", and splitting the
+ * halves apart would mean every index in the reorder maths had to know which list it was counting in.
+ */
+internal data class BoardSlot(
+    val board: Board,
+    val parked: Boolean,
+) {
+    val key: String get() = board.slug ?: FRONT_PAGE_KEY
+
+    /** 综合 is the front page rather than a board: it cannot be moved and it cannot be parked. */
+    val locked: Boolean get() = board.slug == null
+}
+
+/**
+ * The list with the held pill moved to whatever slot the finger is over, or null if nothing changed.
+ *
+ * Settled slot bounds and a plain hit test, rather than midpoint thresholds along an axis: the pills
+ * wrap onto several rows, so "past halfway" has no single direction to be past halfway *in*.
+ *
+ * It settles by construction. After a move the held pill occupies the slot the finger is in, and the
+ * only candidates considered are other pills, so a finger held still cannot swap back and forth.
+ */
+internal fun List<BoardSlot>.reorderedFor(
+    draggedKey: String?,
+    pointer: Offset,
+    bounds: Map<String, Rect>,
+): List<BoardSlot>? {
+    val key = draggedKey ?: return null
+    val from = indexOfFirst { it.key == key }
+    if (from < 0) return null
+    val to =
+        indexOfFirst { slot ->
+            // The parked tail is not a landing strip: dropping a pill there would park it silently,
+            // and parking is what the badge is for. 综合 keeps the first slot.
+            slot.key != key && !slot.locked && !slot.parked && bounds[slot.key]?.contains(pointer) == true
+        }
+    if (to < 0) return null
+    return toMutableList().apply { add(to, removeAt(from)) }
+}
+
+/**
+ * Fires once when a press is held without moving.
+ *
+ * Hand-rolled rather than `combinedClickable` because this sits *above* the chips: they consume the
+ * pointer down for their own ripple, so anything watching on the main pass never sees a gesture
+ * start. Reading the initial pass gets the press before the chip claims it, and watching for slop
+ * means a scroll or a drag still cancels it.
+ */
+private fun Modifier.longPressToEdit(onLongPress: () -> Unit): Modifier =
+    pointerInput(Unit) {
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+            val heldStill =
+                try {
+                    withTimeout(viewConfiguration.longPressTimeoutMillis) {
+                        var travelled = Offset.Zero
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                            if (!change.pressed) break
+                            travelled += change.positionChangeIgnoreConsumed()
+                            if (travelled.getDistance() > viewConfiguration.touchSlop) break
+                        }
+                    }
+                    // Lifted, or moved far enough to be a scroll: either way, not a long press.
+                    false
+                } catch (_: PointerEventTimeoutCancellationException) {
+                    true
+                }
+            if (heldStill) onLongPress()
+        }
+    }
+
+/** 综合 has no slug, and a list key has to be something. */
+internal const val FRONT_PAGE_KEY = "front"
+
+private val ToggleWidth = 40.dp
+
+/** The toggle plus the end inset it is drawn against — the width the first row of pills gives up. */
+private val ToggleSlotWidth = ToggleWidth + Spacing.lg
+
+private const val DRAG_SCALE = 1.06f
+private val DRAG_ELEVATION = 8.dp
+private const val PARKED_ALPHA = 0.55f
+private val BADGE_SIZE = 20.dp
+private val BADGE_ICON_SIZE = 13.dp
+private const val ICON_SWAP_SCALE = 0.7f

--- a/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
@@ -130,6 +130,7 @@ fun PostListRoute(
         onPostClick = onPostClick,
         onCreatePost = onCreatePost,
         onBoardClick = viewModel::selectCategory,
+        onArrangementChange = viewModel::saveBoardArrangement,
         onSortChange = viewModel::selectSort,
         onSignInClick = onSignIn,
         // The challenge is cleared on the URL that failed, so the WebView loads the same list page the
@@ -158,6 +159,8 @@ fun PostListScreen(
     onSignInClick: () -> Unit,
     onRecoverInBrowser: () -> Unit,
     modifier: Modifier = Modifier,
+    /** Commits an edit made on the board strip itself: the pill order, and which boards are parked. */
+    onArrangementChange: (order: List<String>, parked: Set<String>) -> Unit = { _, _ -> },
     onCreatePost: () -> Unit = {},
     /** Keeps the host navigation bar hidden until the user deliberately scrolls toward the list start. */
     onNavigationBarHiddenChanged: (Boolean) -> Unit = {},
@@ -196,8 +199,10 @@ fun PostListScreen(
                 HomeTopBar(sort = state.sort, onSortChange = onSortChange)
                 BoardStrip(
                     boards = state.boards,
+                    parkedBoards = state.parkedBoards,
                     selectedSlug = state.categorySlug,
                     onBoardClick = onBoardClick,
+                    onArrangementChange = onArrangementChange,
                 )
             }
         },
@@ -408,167 +413,6 @@ private fun SortMenuItem(
                 )
             }
         },
-    )
-}
-
-/**
- * Fifteen boards do not fit on a 360dp strip, and a bottom sheet was the other candidate.
- *
- * This is the inline version: the strip *is* the picker. Collapsed it scrolls sideways through the
- * same pills; expanded it wraps them onto as many rows as they need, in place. One list drawn once —
- * an earlier version dropped a second panel underneath and simply repeated the strip's contents.
- *
- * It costs vertical space while open, but the finger never leaves the top of the screen and the list
- * underneath stays visible — which a sheet cannot claim.
- */
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun BoardStrip(
-    boards: List<Board>,
-    selectedSlug: String?,
-    onBoardClick: (String?) -> Unit,
-) {
-    var expanded by rememberSaveable { mutableStateOf(false) }
-    val rowState = rememberLazyListState()
-
-    // Collapsing back to one row must not hide the board the user just picked behind the fold.
-    val selectedIndex = boards.indexOfFirst { it.slug == selectedSlug }
-    LaunchedEffect(expanded, selectedIndex) {
-        if (!expanded && selectedIndex > 0) rowState.animateScrollToItem(selectedIndex)
-    }
-
-    Column(
-        Modifier.animateContentSize(
-            animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
-        ),
-    ) {
-        Row(
-            // No state-dependent padding anywhere in here: the first row of pills has to sit at the
-            // same y whether the block is open or shut, or opening it reads as a jump rather than as
-            // growth. Every pill already carries 8dp of its own touch band above and below.
-            modifier = Modifier.fillMaxWidth(),
-            // Top rather than centre so the toggle keeps sitting on the first row of pills once the
-            // block grows downwards instead of drifting to the middle of it.
-            verticalAlignment = Alignment.Top,
-        ) {
-            if (expanded) {
-                FlowRow(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(start = Spacing.lg),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    // Zero, not sm. Each pill is a 32dp shape centred in a 48dp touch band, so the
-                    // rows already clear each other by 16dp; adding sm on top would space them 24dp
-                    // apart and the block would read as a list rather than a grid of chips.
-                    verticalArrangement = Arrangement.spacedBy(0.dp),
-                ) {
-                    boards.forEach { board ->
-                        BoardPill(
-                            board = board,
-                            selected = board.slug == selectedSlug,
-                            onClick = {
-                                onBoardClick(board.slug)
-                                expanded = false
-                            },
-                        )
-                    }
-                }
-            } else {
-                LazyRow(
-                    state = rowState,
-                    modifier = Modifier.weight(1f),
-                    contentPadding = PaddingValues(horizontal = Spacing.lg),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                ) {
-                    items(count = boards.size, key = { boards[it].slug ?: "front" }) { index ->
-                        val board = boards[index]
-                        BoardPill(
-                            board = board,
-                            selected = board.slug == selectedSlug,
-                            onClick = { onBoardClick(board.slug) },
-                        )
-                    }
-                }
-            }
-            // The band a pill occupies is 48dp — a 32dp shape centred inside the touch target Material
-            // reserves for it — while this button is pinned to 32dp and would otherwise hang 8dp above
-            // the first row of pills it is supposed to sit on. Giving it the same band, from the same
-            // composition local the pills read, aligns the two shapes by construction rather than by a
-            // hardcoded offset that a theme could invalidate.
-            Box(
-                modifier = Modifier.heightIn(min = LocalMinimumInteractiveComponentSize.current),
-                contentAlignment = Alignment.Center,
-            ) {
-                // The tonal button *is* the pill, rather than a plain IconButton with one drawn inside
-                // it: the ripple is clipped to the shape it draws instead of spilling above and below
-                // the 32dp pill.
-                FilledTonalIconButton(
-                    onClick = { expanded = !expanded },
-                    modifier = Modifier.size(width = 40.dp, height = 32.dp),
-                    shape = CircleShape,
-                    colors =
-                    IconButtonDefaults.filledTonalIconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    ),
-                ) {
-                    Icon(
-                        imageVector =
-                        if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                        contentDescription =
-                        stringResource(
-                            if (expanded) R.string.action_hide_all_boards else R.string.action_show_all_boards,
-                        ),
-                    )
-                }
-            }
-        }
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-    }
-}
-
-@Composable
-private fun BoardPill(
-    board: Board,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = {
-            Text(
-                text = board.title,
-                style = MaterialTheme.typography.labelMedium,
-                maxLines = 1,
-            )
-        },
-        // Boards the site refuses to anyone signed out are worth flagging before the tap, not after.
-        // Described rather than decorative: the warning is the whole point of the icon, and it is
-        // nowhere else in the chip, so leaving it null hides the restriction from TalkBack.
-        trailingIcon =
-        if (board.adminOnly) {
-            {
-                Icon(
-                    Icons.Default.Lock,
-                    contentDescription = stringResource(R.string.board_admin_only),
-                    modifier = Modifier.size(14.dp),
-                )
-            }
-        } else {
-            null
-        },
-        shape = CircleShape,
-        colors =
-        FilterChipDefaults.filterChipColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-            labelColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            iconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            selectedContainerColor = MaterialTheme.colorScheme.primary,
-            selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
-            selectedTrailingIconColor = MaterialTheme.colorScheme.onPrimary,
-        ),
-        border = null,
     )
 }
 

--- a/app/src/main/java/io/github/nodyssey/ui/postlist/PostListViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postlist/PostListViewModel.kt
@@ -17,6 +17,7 @@ import io.github.nodyssey.data.PostRepository
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.nodyssey.data.session.SessionState
 import io.github.nodyssey.data.settings.SettingsRepository
+import io.github.nodyssey.data.settings.homeBoardArrangement
 import io.github.nodyssey.data.settings.visibleHomeBoards
 import io.github.nodyssey.di.AppContainer
 import io.github.nodyssey.model.FeedSort
@@ -49,7 +50,7 @@ import kotlinx.coroutines.launch
 class PostListViewModel(
     private val repository: PostRepository,
     private val categoryRepository: CategoryRepository,
-    settingsRepository: SettingsRepository,
+    private val settingsRepository: SettingsRepository,
     session: StateFlow<SessionState> = MutableStateFlow(SessionState()),
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PostListUiState())
@@ -85,24 +86,36 @@ class PostListViewModel(
     init {
         /*
          * Boards are owned by the repository; the ViewModel mirrors them into UiState but never
-         * becomes their source of truth. The 首页版块 preference narrows what the strip shows without
-         * touching that list — 综合 is always kept, since it is the front page rather than a board.
+         * becomes their source of truth. Two independent preferences then narrow that list, in this
+         * order, because they mean different things:
          *
-         * Hiding the board the user is currently reading would leave a selected pill with no pill,
-         * so the selection falls back to the front page when its board goes away.
+         *  1. The account's 首页版块 switches remove a board outright — it is not on the strip at all,
+         *     in either half, and only 账号设置 can bring it back.
+         *  2. The strip's own arrangement reorders what is left and parks some of it at the tail,
+         *     where it stays visible and one tap from coming back.
+         *
+         * 综合 survives both: it is the front page rather than a board, so it is split off first and
+         * prepended, always first and never parked.
+         *
+         * Losing the board the user is currently reading — to either mechanism — would leave a
+         * selection with no pill, so it falls back to the front page.
          */
         combine(
             categoryRepository.boards,
-            settingsRepository.settings.map { it.hiddenHomeBoards }.distinctUntilChanged(),
-        ) { boards, hiddenBoards ->
+            settingsRepository.settings
+                .map { Triple(it.hiddenHomeBoards, it.homeBoardOrder, it.disabledHomeBoards) }
+                .distinctUntilChanged(),
+        ) { boards, (hiddenBoards, order, parkedSlugs) ->
             val (frontPage, real) = boards.partition { it.slug == null }
-            frontPage + visibleHomeBoards(real, hiddenBoards)
-        }.onEach { visible ->
+            homeBoardArrangement(visibleHomeBoards(real, hiddenBoards), order, parkedSlugs)
+                .let { it.copy(enabled = frontPage + it.enabled) }
+        }.onEach { arrangement ->
             _uiState.update { state ->
-                val stillVisible = visible.any { it.slug == state.categorySlug }
+                val stillSelectable = arrangement.enabled.any { it.slug == state.categorySlug }
                 state.copy(
-                    boards = visible,
-                    categorySlug = if (stillVisible) state.categorySlug else null,
+                    boards = arrangement.enabled,
+                    parkedBoards = arrangement.parked,
+                    categorySlug = if (stillSelectable) state.categorySlug else null,
                 )
             }
         }.launchIn(viewModelScope)
@@ -151,6 +164,24 @@ class PostListViewModel(
         _uiState.update { it.copy(sort = sort) }
     }
 
+    /**
+     * Commits an edit made on the strip itself: the new left-to-right order, and which boards are
+     * parked at the tail.
+     *
+     * The strip sends whole lists rather than "moved X to 3" or "parked Y" because a drag is already
+     * a whole-list operation by the time the finger lifts, and a parked board is also a move. One
+     * write per gesture, and the flow above turns it back into two halves.
+     *
+     * 综合 is filtered out on the way in. It is not a board, so it has no slug to rank, and the strip
+     * pins it in front regardless.
+     */
+    fun saveBoardArrangement(
+        order: List<String>,
+        parked: Set<String>,
+    ) {
+        viewModelScope.launch { settingsRepository.setHomeBoardArrangement(order, parked) }
+    }
+
     /** The URL a WebView should open to clear the current error. */
     fun challengeUrl(): String =
         NodeSeekSite.BASE_URL +
@@ -191,6 +222,13 @@ private data class FeedKey(
  */
 data class PostListUiState(
     val boards: List<Board> = listOf(CategoryRepository.FRONT_PAGE),
+    /**
+     * Boards the user parked at the tail of the strip.
+     *
+     * Separate from [boards] rather than a flag on them: nothing outside the strip may treat these as
+     * selectable, and a list the feed can page through is exactly what [boards] is.
+     */
+    val parkedBoards: List<Board> = emptyList(),
     val categorySlug: String? = null,
     val sort: FeedSort = FeedSort.LAST_REPLY,
 ) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,13 @@
     <!-- Screen-reader description for the lock on a board only admins can open -->
     <string name="board_admin_only">仅管理员可见</string>
 
+    <!-- Rearranging the home strip: long-press it open, drag to reorder, park what you never read -->
+    <string name="action_finish_editing_boards">完成排序</string>
+    <string name="board_edit_hint">拖动排序，点角标移出或加回</string>
+    <string name="board_park">移出首页</string>
+    <string name="board_restore">加回首页</string>
+    <string name="board_parked">已移出首页</string>
+
     <!-- The four kinds every board falls into; the tag colour and the picker's headings share them -->
     <string name="board_family_everyday">日常类</string>
     <string name="board_family_technical">技术类</string>

--- a/app/src/test/java/io/github/nodyssey/data/HomeBoardArrangementTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/HomeBoardArrangementTest.kt
@@ -1,0 +1,76 @@
+package io.github.nodyssey.data
+
+import io.github.nodyssey.data.settings.homeBoardArrangement
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The strip's saved arrangement, applied to whatever boards the site currently has.
+ *
+ * The interesting cases are all disagreements between the two: a ranking written months ago against
+ * a board list the API has since changed. None of them may lose a board or invent one.
+ */
+class HomeBoardArrangementTest {
+
+    private val daily = Board("daily", "日常", null)
+    private val tech = Board("tech", "技术", null)
+    private val trade = Board("trade", "交易", null)
+    private val boards = listOf(daily, tech, trade)
+
+    @Test
+    fun `no saved arrangement leaves the api order alone`() {
+        val arrangement = homeBoardArrangement(boards, emptyList(), emptySet())
+        assertEquals(boards, arrangement.enabled)
+        assertEquals(emptyList<Board>(), arrangement.parked)
+    }
+
+    @Test
+    fun `the saved order is the order`() {
+        val arrangement = homeBoardArrangement(boards, listOf("trade", "daily", "tech"), emptySet())
+        assertEquals(listOf(trade, daily, tech), arrangement.enabled)
+    }
+
+    @Test
+    fun `a parked board leaves the enabled half and keeps its rank in the tail`() {
+        val arrangement =
+            homeBoardArrangement(boards, listOf("trade", "daily", "tech"), setOf("trade", "tech"))
+        assertEquals(listOf(daily), arrangement.enabled)
+        assertEquals(listOf(trade, tech), arrangement.parked)
+    }
+
+    /**
+     * A board added to the site after the user last rearranged the strip has no rank. Dropping it
+     * would be a board silently going missing, so it is appended and enabled.
+     */
+    @Test
+    fun `a board the ranking has never seen is appended and enabled`() {
+        val added = Board("photo-share", "贴图", null)
+        val arrangement =
+            homeBoardArrangement(
+                boards + added,
+                order = listOf("trade", "daily", "tech"),
+                parked = setOf("trade"),
+            )
+        assertEquals(listOf(daily, tech, added), arrangement.enabled)
+        assertEquals(listOf(trade), arrangement.parked)
+    }
+
+    /** The mirror image: a rank for a board the API stopped returning is simply not a board. */
+    @Test
+    fun `a rank for a board that no longer exists is dropped`() {
+        val arrangement =
+            homeBoardArrangement(boards, listOf("meaningless", "trade", "daily", "tech"), emptySet())
+        assertEquals(listOf(trade, daily, tech), arrangement.enabled)
+    }
+
+    /**
+     * Parking is stored as a set beside the ranking, so a slug can in principle be parked without
+     * being ranked — a half-written store, or a downgrade. It must still park rather than reappear.
+     */
+    @Test
+    fun `a parked board with no rank still parks`() {
+        val arrangement = homeBoardArrangement(boards, emptyList(), setOf("tech"))
+        assertEquals(listOf(daily, trade), arrangement.enabled)
+        assertEquals(listOf(tech), arrangement.parked)
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/ui/postlist/BoardReorderTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/postlist/BoardReorderTest.kt
@@ -1,0 +1,89 @@
+package io.github.nodyssey.ui.postlist
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import io.github.nodyssey.data.Board
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Where a dragged pill lands, decided without a Compose tree.
+ *
+ * The strip lays its pills out in a wrapped grid, so this works off settled slot rectangles and a hit
+ * test rather than a scroll axis. The fixture below is that grid flattened to one row of 100dp slots,
+ * which is all the geometry the decision actually needs.
+ */
+class BoardReorderTest {
+
+    private val front = BoardSlot(Board(null, "综合", null), parked = false)
+    private val daily = BoardSlot(Board("daily", "日常", null), parked = false)
+    private val tech = BoardSlot(Board("tech", "技术", null), parked = false)
+    private val trade = BoardSlot(Board("trade", "交易", null), parked = true)
+
+    private val slots = listOf(front, daily, tech, trade)
+
+    private val bounds =
+        mapOf(
+            FRONT_PAGE_KEY to Rect(0f, 0f, 100f, 40f),
+            "daily" to Rect(100f, 0f, 200f, 40f),
+            "tech" to Rect(200f, 0f, 300f, 40f),
+            "trade" to Rect(300f, 0f, 400f, 40f),
+        )
+
+    private fun over(key: String) = bounds.getValue(key).center
+
+    @Test
+    fun `dragging a pill onto another takes that slot`() {
+        val moved = slots.reorderedFor("tech", over("daily"), bounds)
+        assertEquals(listOf(front, tech, daily, trade), moved)
+    }
+
+    @Test
+    fun `hovering over its own slot changes nothing`() {
+        assertNull(slots.reorderedFor("tech", over("tech"), bounds))
+    }
+
+    /** Between two pills, or off the end of the last row: nowhere to land, so nothing moves. */
+    @Test
+    fun `a pointer over no pill at all changes nothing`() {
+        assertNull(slots.reorderedFor("tech", Offset(600f, 20f), bounds))
+    }
+
+    /** 综合 is the front page, not a board. Nothing may be dropped into its slot. */
+    @Test
+    fun `the locked front page slot refuses a drop`() {
+        assertNull(slots.reorderedFor("tech", over(FRONT_PAGE_KEY), bounds))
+    }
+
+    /**
+     * Parking is what the corner badge does, deliberately and reversibly. A pill dragged over the
+     * parked tail must not park itself as a side effect of where the finger happened to stop.
+     */
+    @Test
+    fun `the parked tail refuses a drop`() {
+        assertNull(slots.reorderedFor("tech", over("trade"), bounds))
+    }
+
+    @Test
+    fun `a drag with no pill held changes nothing`() {
+        assertNull(slots.reorderedFor(null, over("daily"), bounds))
+    }
+
+    /**
+     * A move lands the held pill in the slot the finger is already in. Once the strip has laid itself
+     * out again the pointer is therefore over the held pill, and the next drag event finds nothing to
+     * swap with — without that the two pills would trade places for as long as the finger sat still.
+     *
+     * The relaid-out bounds are the point, so the test swaps them the way a layout pass would.
+     */
+    @Test
+    fun `a move settles once the strip has laid out again`() {
+        // The finger does not move between the two calls; the pills move under it.
+        val finger = over("daily")
+        val moved = slots.reorderedFor("tech", finger, bounds)!!
+        val relaidOut =
+            bounds + mapOf("tech" to bounds.getValue("daily"), "daily" to bounds.getValue("tech"))
+        assertNull(moved.reorderedFor("tech", finger, relaidOut))
+    }
+}


### PR DESCRIPTION
## 这个 PR 做了什么

首页顶部的板块选择栏从「只能选」变成「能自己排」。展开后长按任意 pill 进入编辑态：

- **拖动重排** —— 所有可用板块都能拖，跨行也行
- **移出/加回** —— 每个 pill 右上角挂 ✕，点了就飞到队尾并变灰，角标随即变成 ＋；再点一下捡回来
- **持久化** —— 顺序和「已移出」集合都存 DataStore，冷启动即生效
- **退出** —— 右上角展开按钮在编辑态变成 ✓，返回键也能退

顺带修了展开按钮**贴着屏幕右边缘**的问题（它此前是这一行唯一没有内边距的元素）。

## 几个需要 reviewer 知道的决定

**「综合」锁死在第一位，不可拖不可删。** 它是首页本身而不是板块（没有 slug，API 也不返回它）。允许删掉就得再发明一套「首个可见板块」的冷启动回退规则，不值得。

**和账号设置里那三个「首页版块」开关是两套独立机制。** 那三个（交易/生活/贴图）同步服务器，是站点自己的偏好；这个是纯本地、覆盖全部板块。行为差异是刻意的：

| | 账号设置关掉 | app 内移出 |
|---|---|---|
| 在 strip 里 | 彻底消失，编辑态也看不到 | 留在队尾灰显 |
| 怎么恢复 | 只能回账号设置 | 点 ＋ |

这是和产品方向确认过的选择，不是遗漏。`PostListViewModel` 里两者按顺序收窄，注释写明了为什么是这个顺序。

**布局换掉了 `FlowRow`。** 原来是 \`Row { 板块流 ; 展开按钮 }\`，按钮的宽度成了**每一行**都要让出的一整列，展开后右边挂着一条从上到下的空白。改成按钮浮在右上角，下面用自写的 `BoardFlow` 只让第一行退让、其余行跑满全宽——`FlowRow` 表达不了「只缩第一行」，所以这里是个自定义 `Layout`（约 40 行，无对齐/无 maxLines，刻意最小）。

**动效全部走 \`MaterialTheme.motionScheme\`，没有硬编码 duration。** 换位用 `animateBounds` 滑行；松手用 `Animatable` 把指尖偏移收敛回**新**格子而不是瞬移；抓起放下是弹簧缩放加阴影；移出时飞向队尾与褪色共用一条时间线；✕/＋ 和展开按钮图标交叉缩放切换。

## 两个不太显眼但重要的实现细节

1. **命中判定读外层 `Box` 的坐标，位移和 `animateBounds` 挂在内层。** 否则正在飞的 pill 会把自己的动画偏移喂回落点判定里，拖动会抖。
2. **每个 pill 带 `key(slot.key)`。** 没有它 Compose 会按下标复用节点——换位时内容直接跳变，`animateBounds` 根本没东西可动。

长按检测是手写的（`awaitEachGesture` + `PointerEventPass.Initial`），因为它挂在 chip **上层**：chip 自己的 `clickable` 会消费 pointer down，主 pass 上的检测器永远收不到手势起点。

## 验证

- 单元测试：`homeBoardArrangement` 6 例（新板块追加保持启用、废弃 slug 丢弃、移出保序、有 rank 无 rank 两种）；`reorderedFor` 7 例（综合槽位拒收、灰区拒收、重排后收敛不来回抖）
- `spotlessCheck` + 全量 `testDebugUnitTest` 通过
- 真机（SM-S9310 / Android 16）走查：展开、长按进编辑、点 ✕ 移出、拖动换位均符合预期；动效与布局修复由作者本人在真机复验

🤖 Generated with [Claude Code](https://claude.com/claude-code)