### PR TITLE
修三个通知相关的 bug：未读数不掉、头像错位、私信输入栏

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,11 +23,17 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:windowSoftInputMode="adjustResize"
         android:theme="@style/Theme.Nodyssey">
+        <!--
+            adjustResize belongs on the activity; on <application> the platform never reads it, so
+            the window fell back to the default pan. Panning slides the whole window out of the top
+            of the screen and reports the keyboard as an inset anyway, which is what made every
+            `imePadding` in the app subtract a second keyboard.
+        -->
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/io/github/nodyssey/core/net/NodeSeekJsonClient.kt
+++ b/app/src/main/java/io/github/nodyssey/core/net/NodeSeekJsonClient.kt
@@ -302,8 +302,14 @@ class NodeSeekJsonClient(
 
         const val STARDUST_PAGE_SIZE = 20
 
-        /** `?all=true` with an empty body; the per-item form takes a JSON array we do not need. */
+        /** `?all=true` with an empty body. */
         fun markAllViewedPath(type: String) = "/api/notification/$type/markViewed?all=true"
+
+        /**
+         * The per-row form of the same endpoint: no query, and a JSON body whose one field is named
+         * after the group — see [io.github.nodyssey.data.NotificationCategory.viewedField].
+         */
+        fun markViewedPath(type: String) = "/api/notification/$type/markViewed"
 
         /*
          * Direct messages.
@@ -322,6 +328,7 @@ class NodeSeekJsonClient(
 
         const val PATH_MESSAGE_SEND = "/api/notification/message/send"
         const val PATH_MESSAGE_MARK_VIEWED_ALL = "/api/notification/message/markViewed?all=true"
+        const val PATH_MESSAGE_MARK_VIEWED = "/api/notification/message/markViewed"
 
         /*
          * 关注 / 粉丝, read out of the site's own `fans` bundle on 2026-08-02.

--- a/app/src/main/java/io/github/nodyssey/data/MessageRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/MessageRepository.kt
@@ -58,12 +58,23 @@ data class MessageThread(
     val level: Int?,
     /** Oldest first, which is the order the conversation reads in. */
     val messages: List<DirectMessage>,
+    /**
+     * The ids of the messages this load found still unread, for [MessageRepository.markRead].
+     *
+     * Reading a conversation is not what clears it on NodeSeek — fetching the history leaves every
+     * row unread until the client posts these back, which is why the site's own thread view collects
+     * them the moment it renders.
+     */
+    val unreadIds: List<Long> = emptyList(),
 )
 
 interface MessageRepository {
     suspend fun conversations(): List<MessageConversation>
 
     suspend fun thread(uid: Long): MessageThread
+
+    /** Clears the given messages, which is what opening a conversation is supposed to do. */
+    suspend fun markRead(messageIds: List<Long>)
 
     /** Returns the accepted message so the optimistic bubble can be replaced by the real one. */
     suspend fun send(
@@ -141,6 +152,22 @@ class NetworkMessageRepository(
             avatarUrl = NodeSeekSite.avatarUrl(uid),
             level = header?.get("rank")?.jsonPrimitive?.intOrNull,
             messages = messages.mapIndexed { index, raw -> raw.toDirectMessage(uid, index) },
+            // Theirs and unread. The site tests `receiver_id === me`, which needs our own uid; from
+            // inside one thread "sent by the person we are talking to" says the same thing without
+            // a second round trip to find out who we are.
+            unreadIds =
+            messages.mapNotNull { raw ->
+                raw.id?.toLongOrNull()?.takeIf { !raw.viewed && raw.senderId == uid }
+            },
+        )
+    }
+
+    override suspend fun markRead(messageIds: List<Long>) {
+        if (messageIds.isEmpty()) return
+        jsonApi.postJson(
+            path = NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED,
+            body = markViewedBody(NotificationCategory.MESSAGES, messageIds),
+            referer = REFERER,
         )
     }
 

--- a/app/src/main/java/io/github/nodyssey/data/NotificationRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/NotificationRepository.kt
@@ -4,9 +4,16 @@ import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.TimeFormat
 import io.github.nodyssey.core.net.JsonApi
 import io.github.nodyssey.core.net.NodeSeekJsonClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 
 /**
  * The site's three notification groups, in the order `/notification` shows them.
@@ -15,11 +22,15 @@ import kotlinx.serialization.json.JsonObject
  * 系统通知 inside [MESSAGES] — see `docs/design-requirements-remaining.md` §0.1. [MESSAGES] has no
  * notification rows of its own either; selecting it shows the conversation list (board 7e), which is
  * why its endpoint lives in [MessageRepository] rather than here.
+ *
+ * [viewedField] is the name `markViewed` wants its id array under. It is a different word per group
+ * — `atMe`, `replys`, `messages` — read off the site's own `notification.js` (2026-08-02); there is
+ * no shared `ids` spelling to fall back on.
  */
-enum class NotificationCategory(val endpoint: String?) {
-    MENTIONS("at-me"),
-    REPLIES("reply-to-me"),
-    MESSAGES(null),
+enum class NotificationCategory(val endpoint: String?, val viewedField: String) {
+    MENTIONS("at-me", "atMe"),
+    REPLIES("reply-to-me", "replys"),
+    MESSAGES(null, "messages"),
 }
 
 data class NotificationCounts(
@@ -47,6 +58,13 @@ data class NotificationCounts(
  */
 data class ForumNotification(
     val id: String,
+    /**
+     * The row id `markViewed` takes, when the endpoint sent one.
+     *
+     * Separate from [id] because [id] is a display key that falls back to a synthesised string, and
+     * posting a synthesised key would clear whatever row happens to own that number server-side.
+     */
+    val viewedId: Long?,
     val category: NotificationCategory,
     val postId: Long?,
     val floor: String?,
@@ -65,13 +83,78 @@ class NotificationRepository(
 ) {
     private val json = Json { ignoreUnknownKeys = true }
 
-    suspend fun unreadCounts(): NotificationCounts {
+    /**
+     * The unread badges, as one value the whole app reads.
+     *
+     * The tab badge and the group chips used to be a field copied into one screen's UiState, which
+     * meant the only thing that could change them was that screen re-running its own load — so
+     * opening the item you were being badged about left the badge exactly where it was. Keeping the
+     * counts here instead lets a read anywhere (a notification opened, a conversation opened, the
+     * poll worker) settle them for everyone.
+     */
+    private val _counts = MutableStateFlow(NotificationCounts())
+    val counts: StateFlow<NotificationCounts> = _counts.asStateFlow()
+
+    suspend fun refreshCounts(): NotificationCounts {
         val root = json.parseToJsonElement(jsonSource.getJson(NodeSeekJsonClient.PATH_UNREAD_COUNT))
         return NotificationCounts(
             replies = root.count("reply", "replyCount"),
             mentions = root.count("atMe", "at_me", "mention"),
             messages = root.count("message", "messages", "msg"),
+        ).also { _counts.value = it }
+    }
+
+    /** Signing out: the next account's badge must not start at the last one's. */
+    fun clearCounts() {
+        _counts.value = NotificationCounts()
+    }
+
+    /**
+     * Takes [count] off a group's badge before the server has been asked anything.
+     *
+     * Opening an item has to move the badge in the same frame as the row greys out, or the two
+     * disagree for as long as the round trip takes and the badge reads as stuck. Whatever the
+     * server says next — from [markViewed], or the next [refreshCounts] — replaces this.
+     */
+    fun noteRead(
+        category: NotificationCategory,
+        count: Int = 1,
+    ) {
+        if (count <= 0) return
+        _counts.update { current ->
+            when (category) {
+                NotificationCategory.MENTIONS ->
+                    current.copy(mentions = (current.mentions - count).coerceAtLeast(0))
+
+                NotificationCategory.REPLIES ->
+                    current.copy(replies = (current.replies - count).coerceAtLeast(0))
+
+                NotificationCategory.MESSAGES ->
+                    current.copy(messages = (current.messages - count).coerceAtLeast(0))
+            }
+        }
+    }
+
+    /**
+     * Clears single rows server-side, the way clicking one on the site does.
+     *
+     * `notification.js` posts the row ids to the group's own `markViewed` and then re-reads
+     * `unread-count`; both halves matter here, because the endpoint answers with a bare ack and the
+     * badge is only ever as right as the last count we were given.
+     */
+    suspend fun markViewed(
+        category: NotificationCategory,
+        ids: List<Long>,
+    ) {
+        val endpoint = category.endpoint ?: return
+        if (ids.isEmpty()) return
+        noteRead(category, ids.size)
+        jsonSource.postJson(
+            path = NodeSeekJsonClient.markViewedPath(endpoint),
+            body = markViewedBody(category, ids),
+            referer = NodeSeekSite.BASE_URL + NodeSeekSite.NOTIFICATION_PATH,
         )
+        refreshCounts()
     }
 
     /**
@@ -87,6 +170,7 @@ class NotificationRepository(
             body = "",
             referer = NodeSeekSite.BASE_URL + NodeSeekSite.NOTIFICATION_PATH,
         )
+        refreshCounts()
     }
 
     suspend fun notifications(category: NotificationCategory): List<ForumNotification> {
@@ -100,6 +184,15 @@ class NotificationRepository(
         return rows.orEmpty().mapIndexed { index, item -> item.toNotification(category, index) }
     }
 }
+
+/** `{"atMe":[1,2]}` / `{"replys":[…]}` / `{"messages":[…]}` — numbers, as the site sends them. */
+internal fun markViewedBody(
+    category: NotificationCategory,
+    ids: List<Long>,
+): String =
+    buildJsonObject {
+        put(category.viewedField, JsonArray(ids.map(::JsonPrimitive)))
+    }.toString()
 
 /** The counts endpoint sometimes nests its numbers one level down; zero is the honest default. */
 private fun JsonElement.count(vararg names: String): Int {
@@ -123,6 +216,9 @@ private fun JsonObject.toNotification(
     val viewed = bool("viewed") ?: false
     return ForumNotification(
         id = text("comment_id", "id", "message_id") ?: "${category.name}-$postId-$index",
+        // `id`, not `comment_id`: the site's own 标为已读 posts the row's `id`, and on the reply
+        // endpoint those two are different numbers.
+        viewedId = long("id"),
         category = category,
         postId = postId,
         floor = floorValue?.let { if (it.startsWith('#')) it else "#$it" },

--- a/app/src/main/java/io/github/nodyssey/notifications/NotificationPollWorker.kt
+++ b/app/src/main/java/io/github/nodyssey/notifications/NotificationPollWorker.kt
@@ -44,7 +44,7 @@ class NotificationPollWorker(
 
         val counts =
             try {
-                container.notificationRepository.unreadCounts()
+                container.notificationRepository.refreshCounts()
             } catch (e: NodeSeekException) {
                 return if (e.error is NodeSeekError.Network) Result.retry() else Result.success()
             }

--- a/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadScreen.kt
@@ -7,20 +7,21 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.selection.toggleable
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
@@ -37,9 +38,10 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
@@ -51,9 +53,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -90,13 +91,13 @@ fun MessageThreadRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     MessageThreadScreen(
         state = state,
+        draftState = viewModel.draftState,
         onBack = onBack,
         onSignIn = onSignIn,
         onVerify = onVerify,
         onOpenBrowser = onOpenBrowser,
         onLinkClick = onLinkClick,
         onRetryLoad = viewModel::refresh,
-        onDraftChange = viewModel::updateDraft,
         onToggleMarkdown = viewModel::toggleMarkdown,
         onSend = viewModel::send,
         onRetrySend = viewModel::retry,
@@ -109,12 +110,12 @@ fun MessageThreadRoute(
 @Composable
 fun MessageThreadScreen(
     state: MessageThreadUiState,
+    draftState: TextFieldState,
     onBack: () -> Unit,
     onSignIn: () -> Unit,
     onVerify: () -> Unit,
     onOpenBrowser: (String) -> Unit,
     onRetryLoad: () -> Unit,
-    onDraftChange: (String) -> Unit,
     onToggleMarkdown: () -> Unit,
     onSend: () -> Unit,
     onRetrySend: (String) -> Unit,
@@ -163,7 +164,7 @@ fun MessageThreadScreen(
             )
         },
     ) { padding ->
-        Column(Modifier.padding(padding).fillMaxSize().imePadding()) {
+        Column(Modifier.padding(padding).consumeWindowInsets(padding).fillMaxSize().imePadding()) {
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             Box(Modifier.weight(1f)) {
                 when {
@@ -189,12 +190,10 @@ fun MessageThreadScreen(
                     else -> MessageBubbles(state, onLinkClick, onRetrySend)
                 }
             }
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
             MessageInputBar(
-                draft = state.draft,
+                draftState = draftState,
                 isMarkdown = state.isMarkdown,
                 canSend = state.canSend,
-                onDraftChange = onDraftChange,
                 onToggleMarkdown = onToggleMarkdown,
                 onSend = onSend,
             )
@@ -216,15 +215,28 @@ private fun MessageBubbles(
      * must always land.
      */
     val rows = remember(state.messages, state.nowMillis) { threadRows(state.messages, state.nowMillis) }
+    /*
+     * Anchored at the bottom rather than scrolled there.
+     *
+     * `reverseLayout` measures from the last row up, so the newest message stays against the message
+     * bar whatever happens to the viewport — which is the answer to the keyboard as much as to a new
+     * message. Scrolling to the end in an effect could not be: the keyboard shrinks the list over
+     * several frames, and a scroll that finished on the first of them left the thread short.
+     *
+     * `asReversed()` is a view, not a copy, and it puts row 0 at the bottom — so the day separators
+     * still read in the order they were built.
+     */
+    val newestFirst = remember(rows) { rows.asReversed() }
     LaunchedEffect(rows.size) {
-        if (rows.isNotEmpty()) listState.animateScrollToItem(rows.lastIndex)
+        if (rows.isNotEmpty()) listState.animateScrollToItem(0)
     }
     LazyColumn(
         state = listState,
+        reverseLayout = true,
         contentPadding = PaddingValues(horizontal = Spacing.lg, vertical = 14.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        items(rows, key = ThreadRow::key) { row ->
+        items(newestFirst, key = ThreadRow::key) { row ->
             when (row) {
                 is ThreadRow.Day -> DayDivider(row.label)
 
@@ -421,123 +433,131 @@ private fun MessageStatusLine(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * The message bar: one pill for the text, a toggle and a send key sitting on its bottom line.
+ *
+ * Built out of a `BasicTextField` and a `Surface` rather than a filled `TextField`, because a filled
+ * field reserves the room a floating label would need and is 56dp tall before it holds anything —
+ * next to a 44dp send key that read as three mismatched blocks. The field grows with the draft up to
+ * [MAX_INPUT_LINES] and the two keys stay on the last line, which is what makes the row settle.
+ */
 @Composable
 private fun MessageInputBar(
-    draft: String,
+    draftState: TextFieldState,
     isMarkdown: Boolean,
     canSend: Boolean,
-    onDraftChange: (String) -> Unit,
     onToggleMarkdown: () -> Unit,
     onSend: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(start = 10.dp, end = 10.dp, top = Spacing.sm, bottom = 14.dp),
-        verticalAlignment = Alignment.Bottom,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        MarkdownToggle(isMarkdown = isMarkdown, onToggle = onToggleMarkdown)
-        TextField(
-            value = draft,
-            onValueChange = onDraftChange,
-            placeholder = {
-                Text(
-                    stringResource(
-                        if (isMarkdown) {
-                            R.string.message_input_hint_markdown
-                        } else {
-                            R.string.message_input_hint_plain
-                        },
-                    ),
-                )
-            },
-            maxLines = MAX_INPUT_LINES,
-            shape = RoundedCornerShape(22.dp),
-            colors =
-            TextFieldDefaults.colors(
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent,
-                disabledIndicatorColor = Color.Transparent,
-            ),
-            modifier = Modifier.weight(1f),
-        )
-        FilledIconButton(
-            onClick = onSend,
-            enabled = canSend,
-            shape = RoundedCornerShape(14.dp),
-            colors =
-            IconButtonDefaults.filledIconButtonColors(
-                disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            ),
-            modifier = Modifier.size(44.dp),
+    Surface(color = MaterialTheme.colorScheme.surfaceContainerLowest) {
+        Row(
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
         ) {
-            Icon(
-                Icons.AutoMirrored.Filled.Send,
-                contentDescription = stringResource(R.string.message_send),
-                modifier = Modifier.size(20.dp),
+            MarkdownToggle(isMarkdown = isMarkdown, onToggle = onToggleMarkdown)
+            MessageDraftField(
+                draftState = draftState,
+                isMarkdown = isMarkdown,
+                modifier = Modifier.weight(1f),
             )
+            FilledIconButton(
+                onClick = onSend,
+                enabled = canSend,
+                colors =
+                IconButtonDefaults.filledIconButtonColors(
+                    disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+                modifier = Modifier.size(INPUT_CONTROL_SIZE),
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.Send,
+                    contentDescription = stringResource(R.string.message_send),
+                    modifier = Modifier.size(20.dp),
+                )
+            }
         }
     }
 }
 
+@Composable
+private fun MessageDraftField(
+    draftState: TextFieldState,
+    isMarkdown: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val hint =
+        stringResource(
+            if (isMarkdown) R.string.message_input_hint_markdown else R.string.message_input_hint_plain,
+        )
+    val textStyle =
+        MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface)
+    BasicTextField(
+        state = draftState,
+        lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = MAX_INPUT_LINES),
+        textStyle = textStyle,
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        modifier = modifier,
+        decorator = { inner ->
+            Surface(
+                shape = RoundedCornerShape(INPUT_CONTROL_SIZE / 2),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ) {
+                Box(
+                    modifier =
+                    Modifier
+                        .heightIn(min = INPUT_CONTROL_SIZE)
+                        .padding(horizontal = 14.dp, vertical = 10.dp),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    if (draftState.text.isEmpty()) {
+                        Text(
+                            text = hint,
+                            style = textStyle,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    inner()
+                }
+            }
+        },
+    )
+}
+
 /**
- * The site's MD On/Off switch, drawn small enough to sit in a message bar.
+ * The site's MD On/Off switch, as a Material toggle button rather than a hand-drawn switch.
  *
- * A Material `Switch` is 52×32 before its touch target, which would take the width of two buttons in
- * a row that also has to hold a growing text field.
+ * The previous one was a 48×44 slab holding a 30×16 track and the letters MD — two controls' worth
+ * of furniture for one bit. `ToggleButton` says the same thing in the same square as the send key,
+ * and brings the checked-state shape change and colours with it. "MD" alone tells a screen reader
+ * nothing, so the button still carries the full name.
  */
 @Composable
 private fun MarkdownToggle(
     isMarkdown: Boolean,
     onToggle: () -> Unit,
 ) {
-    val trackColor =
-        if (isMarkdown) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
-    // "MD" alone tells a screen reader nothing, so the switch carries the full name.
     val label = stringResource(R.string.message_markdown_toggle)
-    Column(
+    ToggleButton(
+        checked = isMarkdown,
+        onCheckedChange = { onToggle() },
+        shapes = ToggleButtonDefaults.shapes(),
+        contentPadding = PaddingValues(0.dp),
         modifier =
         Modifier
-            .minimumInteractiveComponentSize()
-            .width(48.dp)
-            .height(44.dp)
-            .clip(RoundedCornerShape(14.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-            .toggleable(
-                value = isMarkdown,
-                role = Role.Switch,
-                onValueChange = { onToggle() },
-            ).semantics(mergeDescendants = true) { contentDescription = label },
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(3.dp, Alignment.CenterVertically),
+            .size(INPUT_CONTROL_SIZE)
+            .semantics { contentDescription = label },
     ) {
-        Box(
-            Modifier
-                .width(30.dp)
-                .height(16.dp)
-                .clip(CircleShape)
-                .background(trackColor)
-                .padding(2.dp),
-            contentAlignment = if (isMarkdown) Alignment.CenterEnd else Alignment.CenterStart,
-        ) {
-            Box(
-                Modifier
-                    .size(12.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surface),
-            )
-        }
         Text(
             text = stringResource(R.string.message_markdown_label),
-            style = MaterialTheme.typography.labelSmall,
+            style = MaterialTheme.typography.labelLarge,
             fontWeight = FontWeight.Bold,
-            color =
-            if (isMarkdown) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.onSurfaceVariant
-            },
         )
     }
 }
@@ -570,6 +590,9 @@ private fun Modifier.wrapContentWidthTo(isMine: Boolean): Modifier =
 
 private const val BUBBLE_MAX_WIDTH = 0.78f
 private const val MAX_INPUT_LINES = 5
+
+/** One height for the MD toggle, the send key and the empty draft pill, so the bar reads as a row. */
+private val INPUT_CONTROL_SIZE = 44.dp
 
 @Preview(showBackground = true, widthDp = 360, heightDp = 800)
 @Composable
@@ -632,12 +655,12 @@ private fun MessageThreadPreview() {
                     ),
                 ),
             ),
+            draftState = remember { TextFieldState() },
             onBack = {},
             onSignIn = {},
             onVerify = {},
             onOpenBrowser = {},
             onRetryLoad = {},
-            onDraftChange = {},
             onToggleMarkdown = {},
             onSend = {},
             onRetrySend = {},

--- a/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadViewModel.kt
@@ -1,5 +1,8 @@
 package io.github.nodyssey.ui.messages
 
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -11,6 +14,8 @@ import io.github.nodyssey.core.net.NodeSeekException
 import io.github.nodyssey.core.runCatchingExceptCancellation
 import io.github.nodyssey.data.DirectMessage
 import io.github.nodyssey.data.MessageRepository
+import io.github.nodyssey.data.NotificationCategory
+import io.github.nodyssey.data.NotificationRepository
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.nodyssey.di.AppContainer
 import io.github.nodyssey.ui.postlist.toNodeSeekError
@@ -18,6 +23,8 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -31,6 +38,7 @@ import kotlinx.coroutines.launch
  */
 class MessageThreadViewModel(
     private val repository: MessageRepository,
+    private val notifications: NotificationRepository,
     private val session: SessionRepository,
     private val clock: AppClock,
     uid: Long,
@@ -38,11 +46,19 @@ class MessageThreadViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(MessageThreadUiState(uid = uid, userName = userName))
     val uiState: StateFlow<MessageThreadUiState> = _uiState.asStateFlow()
+
+    /** The composer's text and selection, held here for the same reason the post editor's is. */
+    val draftState = TextFieldState()
     private var loadJob: Job? = null
     private var pendingSeed = 0L
 
     init {
         refresh()
+        // `canSend` is a property of the text, and the text lives in a state object the ViewModel
+        // cannot make a StateFlow out of — so the one derived bit it needs is mirrored across.
+        snapshotFlow { draftState.text.isNotBlank() }
+            .onEach { canSend -> _uiState.update { it.copy(canSend = canSend) } }
+            .launchIn(viewModelScope)
     }
 
     fun refresh() {
@@ -71,6 +87,7 @@ class MessageThreadViewModel(
                                 nowMillis = clock.nowMillis(),
                             )
                         }
+                        markRead(thread.unreadIds)
                     }.onFailure { throwable ->
                         _uiState.update {
                             it.copy(isLoading = false, error = throwable.toNodeSeekError())
@@ -79,8 +96,21 @@ class MessageThreadViewModel(
             }
     }
 
-    fun updateDraft(value: String) {
-        _uiState.update { it.copy(draft = value) }
+    /**
+     * Tells the server the conversation has been read, then re-reads the badge.
+     *
+     * Fetching the history is not what clears it — the site posts the ids back and only then does
+     * `unread-count` drop, which is why the 私信 badge used to outlive reading the message.
+     */
+    private fun markRead(ids: List<Long>) {
+        if (ids.isEmpty()) return
+        notifications.noteRead(NotificationCategory.MESSAGES, ids.size)
+        viewModelScope.launch {
+            runCatchingExceptCancellation {
+                repository.markRead(ids)
+                notifications.refreshCounts()
+            }
+        }
     }
 
     fun toggleMarkdown() {
@@ -88,7 +118,7 @@ class MessageThreadViewModel(
     }
 
     fun send() {
-        val content = _uiState.value.draft.trim()
+        val content = draftState.text.toString().trim()
         if (content.isEmpty()) return
         val bubble =
             MessageBubble(
@@ -100,8 +130,9 @@ class MessageThreadViewModel(
                 sentAtText = null,
                 status = SendStatus.SENDING,
             )
+        draftState.clearText()
         _uiState.update {
-            it.copy(draft = "", messages = it.messages + bubble, nowMillis = clock.nowMillis())
+            it.copy(messages = it.messages + bubble, nowMillis = clock.nowMillis())
         }
         deliver(bubble)
     }
@@ -174,6 +205,7 @@ class MessageThreadViewModel(
                 initializer {
                     MessageThreadViewModel(
                         repository = container.messageRepository,
+                        notifications = container.notificationRepository,
                         session = container.sessionRepository,
                         clock = container.clock,
                         uid = uid,
@@ -211,10 +243,9 @@ data class MessageThreadUiState(
     val messages: List<MessageBubble> = emptyList(),
     val isLoading: Boolean = false,
     val error: NodeSeekError? = null,
-    val draft: String = "",
+    /** Mirrored out of [MessageThreadViewModel.draftState]; the text itself is not UiState. */
+    val canSend: Boolean = false,
     /** The site's own MD On/Off switch; off sends the text verbatim. */
     val isMarkdown: Boolean = true,
     val nowMillis: Long = 0L,
-) {
-    val canSend: Boolean get() = draft.isNotBlank()
-}
+)

--- a/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -39,6 +40,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -244,8 +246,10 @@ private fun NotificationRow(
             .padding(start = 10.dp, end = Spacing.lg, top = 14.dp, bottom = 14.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        // Aligned with the first line of the sentence rather than the top of the row.
-        Box(Modifier.padding(top = 7.dp).size(6.dp)) {
+        // Both markers hang off the sentence's first line, not off the top of the row — see
+        // [AvatarCapOffset]. The dot is smaller than the avatar, so it drops further to centre on
+        // the same line rather than sitting on top of it.
+        Box(Modifier.offset(y = AvatarCapOffset + 2.dp).size(6.dp)) {
             if (item.isUnread) {
                 Box(
                     Modifier
@@ -255,11 +259,25 @@ private fun NotificationRow(
                 )
             }
         }
-        UserAvatar(url = item.avatarUrl, name = item.actorName, size = Sizes.avatarList)
+        UserAvatar(
+            url = item.avatarUrl,
+            name = item.actorName,
+            size = Sizes.avatarList,
+            modifier = Modifier.offset(y = AvatarCapOffset),
+        )
         Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(5.dp)) {
             Text(
                 text = notificationSentence(item),
-                style = MaterialTheme.typography.bodyMedium,
+                // Trimmed at the top so the sentence starts at the row's edge instead of a few
+                // pixels below it, the same pairing the feed's title and avatar use.
+                style =
+                MaterialTheme.typography.bodyMedium.copy(
+                    lineHeightStyle =
+                    LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Proportional,
+                        trim = LineHeightStyle.Trim.FirstLineTop,
+                    ),
+                ),
                 color =
                 if (item.isUnread) {
                     MaterialTheme.colorScheme.onSurface
@@ -363,6 +381,15 @@ private fun NotificationCategory.label(): String =
 private val PLACEHOLDER = Regex("""%(\d)[$]s""")
 private const val MAX_BADGE = 99
 
+/**
+ * Drops the avatar onto the sentence's cap line.
+ *
+ * The twin of the feed's own offset — even with the first line's leading trimmed, the line box still
+ * starts at the ascent rather than at the tallest glyph, and a top-aligned avatar next to it reads
+ * as floating. Measured at bodyMedium on the row as built, which is why it is not the feed's number.
+ */
+private val AvatarCapOffset = 3.dp
+
 @Preview(showBackground = true, widthDp = 360, heightDp = 800)
 @Composable
 private fun NotificationsPreview() {
@@ -377,6 +404,7 @@ private fun NotificationsPreview() {
                 listOf(
                     ForumNotification(
                         id = "1",
+                        viewedId = 1L,
                         category = NotificationCategory.MENTIONS,
                         postId = 1,
                         floor = "#3",
@@ -391,6 +419,7 @@ private fun NotificationsPreview() {
                     ),
                     ForumNotification(
                         id = "2",
+                        viewedId = 2L,
                         category = NotificationCategory.MENTIONS,
                         postId = 2,
                         floor = null,

--- a/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsViewModel.kt
@@ -49,8 +49,15 @@ class NotificationsViewModel(
                 _uiState.update {
                     if (value.isSignedIn) it.copy(isSignedIn = true) else NotificationsUiState()
                 }
-                if (value.isSignedIn) refresh()
+                // Signing out has to empty the badge at the source too, or the counts the previous
+                // account was carrying stay in the repository waiting to be re-emitted.
+                if (value.isSignedIn) refresh() else repository.clearCounts()
             }.launchIn(viewModelScope)
+        // The badges are the repository's, not this screen's: a conversation read on board 7f has to
+        // move them too, and that happens while this view model is doing nothing at all.
+        repository.counts
+            .onEach { counts -> _uiState.update { it.copy(counts = counts) } }
+            .launchIn(viewModelScope)
     }
 
     fun selectCategory(category: NotificationCategory) {
@@ -76,7 +83,7 @@ class NotificationsViewModel(
             viewModelScope.launch {
                 _uiState.update { it.copy(isLoading = true, error = null) }
                 runCatchingExceptCancellation {
-                    val counts = repository.unreadCounts()
+                    val counts = repository.refreshCounts()
                     if (category == NotificationCategory.MESSAGES) {
                         Loaded(counts, conversations = messages.conversations())
                     } else {
@@ -108,17 +115,24 @@ class NotificationsViewModel(
      */
     fun markAllRead() {
         val category = _uiState.value.selectedCategory
-        _uiState.update { state ->
-            state.copy(
-                items = state.items.map { it.copy(isUnread = false) },
-                conversations = state.conversations.map { it.copy(unreadCount = 0) },
-                counts = NotificationCounts(),
+        val state = _uiState.value
+        // Only the group the button belongs to. Zeroing the whole `NotificationCounts` used to wipe
+        // all three badges, so 全部已读 on @我 also claimed the unread 私信 had been read.
+        repository.noteRead(
+            category = category,
+            count = state.counts.forCategory(category),
+        )
+        _uiState.update {
+            it.copy(
+                items = it.items.map { item -> item.copy(isUnread = false) },
+                conversations = it.conversations.map { row -> row.copy(unreadCount = 0) },
             )
         }
         viewModelScope.launch {
             runCatchingExceptCancellation {
                 if (category == NotificationCategory.MESSAGES) {
                     messages.markAllRead()
+                    repository.refreshCounts()
                 } else {
                     repository.markAllRead(category)
                 }
@@ -126,13 +140,35 @@ class NotificationsViewModel(
         }
     }
 
+    /**
+     * Opening a row is a read, on the server as well as on screen.
+     *
+     * Only greying the row out locally was the whole of bug 1: the badge is the count endpoint's
+     * answer, the count endpoint had never been told, and so the number that sent the user here
+     * survived being acted on — through a refresh, and through a restart.
+     */
     fun markOpened(id: String) {
+        val item = _uiState.value.items.firstOrNull { it.id == id } ?: return
         _uiState.update { state ->
             state.copy(items = state.items.map { if (it.id == id) it.copy(isUnread = false) else it })
         }
+        if (!item.isUnread) return
+        val viewedId = item.viewedId ?: return
+        viewModelScope.launch {
+            runCatchingExceptCancellation { repository.markViewed(item.category, listOf(viewedId)) }
+        }
     }
 
+    /**
+     * The badge half of opening a conversation; board 7f posts the message ids once it has them.
+     *
+     * The list row knows how many are unread but not which, because `message/list` carries one row
+     * per conversation — so this moves the badge now and the thread settles it against the server a
+     * moment later.
+     */
     fun markConversationOpened(uid: Long) {
+        val conversation = _uiState.value.conversations.firstOrNull { it.uid == uid } ?: return
+        repository.noteRead(NotificationCategory.MESSAGES, conversation.unreadCount)
         _uiState.update { state ->
             state.copy(
                 conversations =

--- a/app/src/test/java/io/github/nodyssey/data/MessageRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/MessageRepositoryTest.kt
@@ -194,6 +194,49 @@ class MessageRepositoryTest {
             assertFalse(thread.messages.last().isMarkdown)
         }
 
+    /**
+     * Reading a thread does not clear it — the ids have to be posted back — so the load has to hand
+     * them over. Only theirs count: our own unread rows are the ones *they* have not read.
+     */
+    @Test
+    fun `thread reports the counterparty's unread messages`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    mapOf(
+                        threadPath to
+                            """
+                            {"success":true,
+                             "talkTo":{"member_id":5230,"member_name":"nssk"},
+                             "msgArray":[
+                               {"id":1,"receiver_id":52425,"sender_id":5230,"viewed":0,
+                                "content":"在吗","created_at":"2026-07-24T18:15:47.000Z"},
+                               {"id":2,"receiver_id":52425,"sender_id":5230,"viewed":1,
+                                "content":"读过的","created_at":"2026-07-24T18:16:47.000Z"},
+                               {"id":3,"receiver_id":5230,"sender_id":52425,"viewed":0,
+                                "content":"我发的","created_at":"2026-07-26T14:31:28.000Z"}
+                             ]}
+                            """.trimIndent(),
+                    ),
+                )
+
+            assertEquals(listOf(1L), repository(api).thread(5230).unreadIds)
+        }
+
+    @Test
+    fun `mark read posts the message ids the site's own thread view posts`() =
+        runTest {
+            val api =
+                FakeJsonApi(
+                    posts = mapOf(NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED to """{"success":true}"""),
+                )
+
+            repository(api).markRead(listOf(11L, 12L))
+
+            assertEquals(listOf(NodeSeekJsonClient.PATH_MESSAGE_MARK_VIEWED), api.postedPaths)
+            assertEquals(listOf("""{"messages":[11,12]}"""), api.postedBodies)
+        }
+
     /** The recipient field is camel-cased here and nowhere else on this API. */
     @Test
     fun `send posts receiverUid`() =

--- a/app/src/test/java/io/github/nodyssey/data/NotificationRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/NotificationRepositoryTest.kt
@@ -11,13 +11,16 @@ class NotificationRepositoryTest {
     @Test
     fun `parses unread counts`() =
         runTest {
-            val source = FakeJsonSource(mapOf("/api/notification/unread-count" to """{"reply":2,"atMe":1,"all":3}"""))
+            val source = FakeJsonSource(mapOf(UNREAD_COUNT to """{"reply":2,"atMe":1,"all":3}"""))
+            val repository = NotificationRepository(source)
 
-            val counts = NotificationRepository(source).unreadCounts()
+            val counts = repository.refreshCounts()
 
             assertEquals(2, counts.replies)
             assertEquals(1, counts.mentions)
             assertEquals(3, counts.all)
+            // The badge everyone else reads is the same value, not a copy the caller has to pass on.
+            assertEquals(counts, repository.counts.value)
         }
 
     @Test
@@ -91,11 +94,66 @@ class NotificationRepositoryTest {
     @Test
     fun `mark all read posts to the group's own endpoint`() =
         runTest {
-            val source = FakeJsonSource(emptyMap())
+            val source = FakeJsonSource(mapOf(UNREAD_COUNT to """{"reply":0,"atMe":0}"""))
 
             NotificationRepository(source).markAllRead(NotificationCategory.MENTIONS)
 
             assertEquals(listOf("/api/notification/at-me/markViewed?all=true"), source.postedPaths)
+        }
+
+    /**
+     * Bug: opening a notification greyed the row out and left the badge alone, so the number that
+     * sent the user there outlived being acted on.
+     */
+    @Test
+    fun `opening one notification clears it server-side and re-reads the badge`() =
+        runTest {
+            val source = FakeJsonSource(mapOf(UNREAD_COUNT to """{"reply":0,"atMe":1}"""))
+            val repository = NotificationRepository(source)
+
+            repository.markViewed(NotificationCategory.MENTIONS, listOf(42L))
+
+            assertEquals(listOf("/api/notification/at-me/markViewed"), source.postedPaths)
+            assertEquals(listOf("""{"atMe":[42]}"""), source.postedBodies)
+            // …and the answer to `unread-count` is what the badge ends up showing.
+            assertEquals(1, repository.counts.value.mentions)
+        }
+
+    /** Each group names its id array differently; there is no shared `ids` spelling. */
+    @Test
+    fun `each group posts its own field name`() =
+        runTest {
+            assertEquals("""{"atMe":[1]}""", markViewedBody(NotificationCategory.MENTIONS, listOf(1L)))
+            assertEquals("""{"replys":[1]}""", markViewedBody(NotificationCategory.REPLIES, listOf(1L)))
+            assertEquals("""{"messages":[1]}""", markViewedBody(NotificationCategory.MESSAGES, listOf(1L)))
+        }
+
+    /** The row id `markViewed` wants is `id`, which on the reply endpoint is not `comment_id`. */
+    @Test
+    fun `keeps the row id the mark-viewed call needs`() =
+        runTest {
+            val path = "/api/notification/reply-to-me/list?page=1"
+            val source =
+                FakeJsonSource(mapOf(path to """{"replyList":[{"id":7,"comment_id":42,"post_id":1}]}"""))
+
+            val item = NotificationRepository(source).notifications(NotificationCategory.REPLIES).single()
+
+            assertEquals("42", item.id)
+            assertEquals(7L, item.viewedId)
+        }
+
+    /** The badge has to move in the same frame as the row, not a round trip later. */
+    @Test
+    fun `noting a read drops the badge before the network answers`() =
+        runTest {
+            val source = FakeJsonSource(mapOf(UNREAD_COUNT to """{"reply":0,"atMe":3,"message":2}"""))
+            val repository = NotificationRepository(source)
+            repository.refreshCounts()
+
+            repository.noteRead(NotificationCategory.MESSAGES, 2)
+
+            assertEquals(0, repository.counts.value.messages)
+            assertEquals(3, repository.counts.value.mentions)
         }
 
     @Test
@@ -110,16 +168,20 @@ class NotificationRepositoryTest {
         }
 }
 
+private const val UNREAD_COUNT = "/api/notification/unread-count"
+
 private class FakeJsonSource(
     private val responses: Map<String, String>,
 ) : JsonApi {
     val postedPaths = mutableListOf<String>()
+    val postedBodies = mutableListOf<String>()
 
     override suspend fun getJson(path: String, referer: String): String =
         requireNotNull(responses[path]) { "No response for $path" }
 
     override suspend fun postJson(path: String, body: String, referer: String): String {
         postedPaths += path
+        postedBodies += body
         return """{"success":true}"""
     }
 }

--- a/app/src/test/java/io/github/nodyssey/ui/messages/MessageThreadViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/messages/MessageThreadViewModelTest.kt
@@ -1,14 +1,17 @@
 package io.github.nodyssey.ui.messages
 
 import android.webkit.CookieManager
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import io.github.nodyssey.core.AppClock
 import io.github.nodyssey.core.NodeSeekSite
+import io.github.nodyssey.core.net.JsonApi
 import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.core.net.NodeSeekException
 import io.github.nodyssey.core.net.WebViewCookieJar
 import io.github.nodyssey.data.DirectMessage
 import io.github.nodyssey.data.MessageRepository
 import io.github.nodyssey.data.MessageThread
+import io.github.nodyssey.data.NotificationRepository
 import io.github.nodyssey.data.session.SessionRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -51,12 +54,12 @@ class MessageThreadViewModelTest {
             val viewModel = viewModel(repository)
             advanceUntilIdle()
 
-            viewModel.updateDraft("行，我发个投票试试")
+            viewModel.draftState.setTextAndPlaceCursorAtEnd("行，我发个投票试试")
             viewModel.send()
 
             // The bubble is on screen before the network answers, and the field is already clear.
             assertEquals(SendStatus.SENDING, viewModel.uiState.value.messages.last().status)
-            assertEquals("", viewModel.uiState.value.draft)
+            assertEquals("", viewModel.draftState.text.toString())
 
             advanceUntilIdle()
             assertEquals(SendStatus.SENT, viewModel.uiState.value.messages.last().status)
@@ -69,7 +72,7 @@ class MessageThreadViewModelTest {
             val viewModel = viewModel(repository)
             advanceUntilIdle()
 
-            viewModel.updateDraft("顺便问下星辰能转账吗")
+            viewModel.draftState.setTextAndPlaceCursorAtEnd("顺便问下星辰能转账吗")
             viewModel.send()
             advanceUntilIdle()
 
@@ -93,7 +96,7 @@ class MessageThreadViewModelTest {
             val viewModel = viewModel(repository)
             advanceUntilIdle()
 
-            viewModel.updateDraft("在吗")
+            viewModel.draftState.setTextAndPlaceCursorAtEnd("在吗")
             viewModel.send()
             advanceUntilIdle()
 
@@ -113,36 +116,74 @@ class MessageThreadViewModelTest {
             advanceUntilIdle()
 
             viewModel.toggleMarkdown()
-            viewModel.updateDraft("**不要加粗**")
+            viewModel.draftState.setTextAndPlaceCursorAtEnd("**不要加粗**")
             viewModel.send()
             advanceUntilIdle()
 
             assertEquals(false, repository.lastMarkdown)
         }
 
-    private fun viewModel(repository: MessageRepository) =
-        MessageThreadViewModel(
-            repository = repository,
-            session = SessionRepository(WebViewCookieJar(cookieManager)),
-            clock = AppClock { NOW },
-            uid = 4471,
-            userName = "iwil",
-        )
+    /**
+     * Bug: fetching a conversation is not what clears it — the ids have to go back — so the 私信
+     * badge survived reading the message that put it there.
+     */
+    @Test
+    fun `opening a conversation clears its unread messages and the badge`() =
+        runTest(dispatcher) {
+            val repository = FakeMessageRepository(unreadIds = listOf(11L, 12L))
+            val counts = FakeCountsApi(unread = """{"message":0}""")
+            val notifications = NotificationRepository(counts)
+            notifications.refreshCounts()
+            advanceUntilIdle()
+
+            viewModel(repository, notifications)
+            advanceUntilIdle()
+
+            assertEquals(listOf(11L, 12L), repository.markedRead)
+            assertEquals(0, notifications.counts.value.messages)
+        }
+
+    private fun viewModel(
+        repository: MessageRepository,
+        notifications: NotificationRepository = NotificationRepository(FakeCountsApi()),
+    ) = MessageThreadViewModel(
+        repository = repository,
+        notifications = notifications,
+        session = SessionRepository(WebViewCookieJar(cookieManager)),
+        clock = AppClock { NOW },
+        uid = 4471,
+        userName = "iwil",
+    )
 
     private companion object {
         const val NOW = 1_785_000_000_000L
     }
 }
 
+private class FakeCountsApi(
+    private val unread: String = """{"message":0}""",
+) : JsonApi {
+    override suspend fun getJson(path: String, referer: String): String = unread
+
+    override suspend fun postJson(path: String, body: String, referer: String): String =
+        """{"success":true}"""
+}
+
 private class FakeMessageRepository(
     var sendError: Throwable? = null,
+    private val unreadIds: List<Long> = emptyList(),
 ) : MessageRepository {
     var sendCount = 0
     var lastMarkdown: Boolean? = null
+    val markedRead = mutableListOf<Long>()
 
     override suspend fun conversations() = emptyList<io.github.nodyssey.data.MessageConversation>()
 
     override suspend fun markAllRead() = Unit
+
+    override suspend fun markRead(messageIds: List<Long>) {
+        markedRead += messageIds
+    }
 
     override suspend fun thread(uid: Long) =
         MessageThread(
@@ -161,6 +202,7 @@ private class FakeMessageRepository(
                     sentAtText = null,
                 ),
             ),
+            unreadIds = unreadIds,
         )
 
     override suspend fun send(

--- a/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsScreenTest.kt
@@ -156,6 +156,7 @@ class NotificationsScreenTest {
     private fun mention() =
         ForumNotification(
             id = "1",
+            viewedId = 1L,
             category = NotificationCategory.MENTIONS,
             postId = 1,
             floor = null,

--- a/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsViewModelTest.kt
@@ -1,0 +1,162 @@
+package io.github.nodyssey.ui.notifications
+
+import android.webkit.CookieManager
+import io.github.nodyssey.core.AppClock
+import io.github.nodyssey.core.NodeSeekSite
+import io.github.nodyssey.core.net.JsonApi
+import io.github.nodyssey.core.net.WebViewCookieJar
+import io.github.nodyssey.data.MessageConversation
+import io.github.nodyssey.data.MessageRepository
+import io.github.nodyssey.data.MessageThread
+import io.github.nodyssey.data.NotificationRepository
+import io.github.nodyssey.data.SearchRepository
+import io.github.nodyssey.data.UserSearchResult
+import io.github.nodyssey.data.session.SessionRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The badge half of board 7d.
+ *
+ * Every case here is the same bug seen from a different side: acting on a notification used to move
+ * the row and leave the number that pointed at it exactly where it was.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class NotificationsViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val cookieManager = CookieManager.getInstance()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        cookieManager.removeAllCookies(null)
+        cookieManager.setCookie(NodeSeekSite.BASE_URL, "session=test")
+    }
+
+    @After
+    fun tearDown() {
+        cookieManager.removeAllCookies(null)
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `opening a notification tells the server and drops the badge`() =
+        runTest(dispatcher) {
+            val api = FakeApi(counts = """{"atMe":2}""")
+            val viewModel = viewModel(api)
+            advanceUntilIdle()
+            assertEquals(2, viewModel.uiState.value.counts.mentions)
+
+            api.counts = """{"atMe":1}"""
+            viewModel.markOpened("1")
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.items.single().isUnread)
+            assertEquals(listOf("/api/notification/at-me/markViewed"), api.postedPaths)
+            assertEquals(listOf("""{"atMe":[1]}"""), api.postedBodies)
+            assertEquals(1, viewModel.uiState.value.counts.mentions)
+        }
+
+    /** Opening the same row twice must not post it twice, nor take the badge down twice. */
+    @Test
+    fun `opening a row that is already read posts nothing`() =
+        runTest(dispatcher) {
+            val api = FakeApi(counts = """{"atMe":2}""")
+            val viewModel = viewModel(api, unread = false)
+            advanceUntilIdle()
+
+            viewModel.markOpened("1")
+            advanceUntilIdle()
+
+            assertEquals(emptyList<String>(), api.postedPaths)
+            assertEquals(2, viewModel.uiState.value.counts.mentions)
+        }
+
+    /** 全部已读 on @我 used to zero all three badges, 私信 included. */
+    @Test
+    fun `mark all read only clears the group the button belongs to`() =
+        runTest(dispatcher) {
+            val api = FakeApi(counts = """{"atMe":2,"message":3}""")
+            val viewModel = viewModel(api)
+            advanceUntilIdle()
+
+            api.counts = """{"atMe":0,"message":3}"""
+            viewModel.markAllRead()
+            advanceUntilIdle()
+
+            assertEquals(0, viewModel.uiState.value.counts.mentions)
+            assertEquals(3, viewModel.uiState.value.counts.messages)
+        }
+
+    private fun viewModel(
+        api: FakeApi,
+        unread: Boolean = true,
+    ): NotificationsViewModel {
+        val notifications = NotificationRepository(api)
+        api.mentionUnread = unread
+        return NotificationsViewModel(
+            repository = notifications,
+            messages = NoMessages,
+            search = NoSearch,
+            session = SessionRepository(WebViewCookieJar(cookieManager)),
+            clock = AppClock { 1_785_000_000_000L },
+        )
+    }
+}
+
+private object NoSearch : SearchRepository {
+    override suspend fun searchUsers(query: String) = emptyList<UserSearchResult>()
+}
+
+private object NoMessages : MessageRepository {
+    override suspend fun conversations() = emptyList<MessageConversation>()
+
+    override suspend fun thread(uid: Long) =
+        MessageThread(uid = uid, userName = "", avatarUrl = null, level = null, messages = emptyList())
+
+    override suspend fun send(
+        uid: Long,
+        content: String,
+        markdown: Boolean,
+    ) = null
+
+    override suspend fun markRead(messageIds: List<Long>) = Unit
+
+    override suspend fun markAllRead() = Unit
+}
+
+private class FakeApi(
+    var counts: String,
+) : JsonApi {
+    var mentionUnread = true
+    val postedPaths = mutableListOf<String>()
+    val postedBodies = mutableListOf<String>()
+
+    override suspend fun getJson(path: String, referer: String): String =
+        when {
+            path.startsWith("/api/notification/unread-count") -> counts
+
+            else ->
+                """{"atList":[{"id":1,"member_id":12,"username":"nssk","post_title":"求教如何改用户名",
+                   "viewed":${if (mentionUnread) 0 else 1}}]}"""
+        }
+
+    override suspend fun postJson(path: String, body: String, referer: String): String {
+        postedPaths += path
+        postedBodies += body
+        return """{"success":true}"""
+    }
+}


### PR DESCRIPTION
## 1. 未读红点点不掉

**问题**：点开新消息看过之后，通知 tab 上的角标和分组 chip 上的数字都不减少。刷新、重启都回来。

**原因**：角标的数字是 `/api/notification/unread-count` 的答案，而 App 从来没告诉过服务器"我看过了"——`markOpened` / `markConversationOpened` 只把本地那行改成已读。私信这条更直接：**拉取会话内容本身不算已读**，站点是在渲染完会话后把未读消息的 id 回传的，我们缺了这一步。

**改法**：从站点自己的 `notification.js` 里读到每行形式的接口（原注释里"per-item form takes a JSON array we do not need"判断错了）。三组的 id 字段名各不相同，没有统一的 `ids` 拼写：

| 分组 | 端点 | 请求体 |
| --- | --- | --- |
| @我 | `POST /api/notification/at-me/markViewed` | `{"atMe":[id]}` |
| 回复主题 | `POST /api/notification/reply-to-me/markViewed` | `{"replys":[id]}` |
| 私信 | `POST /api/notification/message/markViewed` | `{"messages":[id,…]}` |

配套的结构改动：

- 未读数变成 `NotificationRepository` 里的一份 `StateFlow`，而不是某个界面 UiState 里的副本。私信会话在 board 7f 已读时，通知页的角标才有办法跟着动。
- 点开时先本地减一（角标当帧就动），再发请求，再重读 `unread-count` 定案——站点自己也是这个顺序。
- `ForumNotification` 新增 `viewedId`：`markViewed` 要的是行的 `id`，而现有的 `id` 是个会退化成合成字符串的展示 key，回复接口上这两个还是不同的数字。
- `全部已读` 只清它自己那一组。原来它把 `NotificationCounts()` 整个清零，在 @我 里点一下连未读私信也一并宣称读过了。
- 登出时清空 repository 里的计数，下一个账号不会从上一个的数字开始。

## 2. 通知界面头像和右边文字错位

首页早有这个处理（`AvatarCapOffset` + 首行 `Trim.FirstLineTop`），通知列表漏了：句子首行的 leading 没裁，头像顶到行框顶而不是字顶，看着像浮起来。补齐后真机上量下来和首页一致。

## 3. 私信输入栏

**样子**：填充式 `TextField` 天生 56dp 高（给浮动标签留的位置），和 44dp 的发送键并排就是三块高低不齐；左边的 MD 开关是手搓的 48×44 灰方块套一个迷你滑轨。换成官方 `ToggleButton`（M3 1.5 的表现力组件，自带选中态形变）和 `BasicTextField` + decorator 的胶囊，三个控件统一 44dp。

**位置**：真正的原因不在这个界面——`android:windowSoftInputMode="adjustResize"` 写在了 `<application>` 上，系统只在 `<activity>` 上读这个属性，所以 Activity 一直退回默认的 **adjustPan**：键盘一弹系统把整个窗口往上推，界面里的 `imePadding()` 再减一遍，输入栏就飞到了顶部。挪到 `<activity>` 之后，发帖器和回复编辑器那几个原本也在双减的界面一起正常了。消息列表另外改成 `reverseLayout`，最新一条天然贴着输入栏，不再靠"键盘弹起后补一次滚动"去追（那个补救在 IME 逐帧动画里必然追不上）。

## 验证

- `./gradlew :app:testDebugUnitTest :app:lintDebug spotlessCheck` 全过。
- 新增回归测试：`NotificationsViewModelTest`（点开→发请求→角标下降；已读行不重复发；全部已读只清一组）、`NotificationRepositoryTest`（三组各自的 body、`viewedId` 取 `id` 而非 `comment_id`、乐观减一）、`MessageRepositoryTest`（只上报对方发来的未读、markRead 的 body）、`MessageThreadViewModelTest`（打开会话即清）。
- 真机（SM-S9310 / Android 16）逐项看过：通知行对齐比对首页、私信输入栏在键盘开合两态、回复编辑器未回归。

## Reviewer 需要知道的

**第 1 条的端到端效果没能在真机上确认。** 当前账号三组未读都是 0，造不出一条真实未读来观察角标下降。接口路径和字段名是从站点脚本里逐字抄的，单测覆盖了 body 形状和调用时机，但没有跑通过一次真实的"数字掉下去"。风险点是 id 取错（现在取行的 `id`）。

改动涉及抓站接口（新增三个 `markViewed` 端点）和 `AndroidManifest` 的软键盘模式——后者影响 App 里**每一个**输入框，不只是私信。

🤖 Generated with [Claude Code](https://claude.com/claude-code)