### PR TITLE
工具栏能自己排了：扳手拉出面板加删拖，键从蚂蚁大小长回 48dp

### DIFF
--- a/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
@@ -60,6 +60,9 @@ class SettingsRepository(
                     .toSet(),
                 homeBoardOrder = decodeValues(preferences[KEY_HOME_BOARD_ORDER]),
                 disabledHomeBoards = decodeValues(preferences[KEY_DISABLED_HOME_BOARDS]).toSet(),
+                postToolbarActions = decodeValues(preferences[KEY_POST_TOOLBAR]),
+                replyToolbarActions = decodeValues(preferences[KEY_REPLY_TOOLBAR]),
+                messageToolbarActions = decodeValues(preferences[KEY_MESSAGE_TOOLBAR]),
                 notificationsEnabled = preferences[KEY_NOTIFICATIONS_ENABLED] ?: false,
                 notificationPollMinutes =
                 (preferences[KEY_NOTIFICATION_POLL_MINUTES] ?: DEFAULT_POLL_MINUTES)
@@ -212,6 +215,28 @@ class SettingsRepository(
         }
     }
 
+    /**
+     * Stores one composer's strip. An empty list clears the preference rather than writing one, so
+     * "I put it back the way it was" and "I never touched it" stay the same stored state.
+     */
+    suspend fun setComposerToolbar(
+        surface: ComposerSurface,
+        actions: List<String>,
+    ) {
+        val key = when (surface) {
+            ComposerSurface.POST -> KEY_POST_TOOLBAR
+            ComposerSurface.REPLY -> KEY_REPLY_TOOLBAR
+            ComposerSurface.MESSAGE -> KEY_MESSAGE_TOOLBAR
+        }
+        edit { preferences ->
+            if (actions.isEmpty()) {
+                preferences.remove(key)
+            } else {
+                preferences[key] = encodeValues(actions, MAX_TOOLBAR_ACTIONS)
+            }
+        }
+    }
+
     /** Local mirror of the site's Remote 启用节日主题 switch; the sync authority is the account. */
     suspend fun setHolidayTheme(enabled: Boolean) = edit { it[KEY_HOLIDAY_THEME] = enabled }
 
@@ -274,6 +299,9 @@ class SettingsRepository(
         private val KEY_HIDDEN_HOME_BOARDS = stringPreferencesKey("hidden_home_boards")
         private val KEY_HOME_BOARD_ORDER = stringPreferencesKey("home_board_order")
         private val KEY_DISABLED_HOME_BOARDS = stringPreferencesKey("disabled_home_boards")
+        private val KEY_POST_TOOLBAR = stringPreferencesKey("post_toolbar_actions")
+        private val KEY_REPLY_TOOLBAR = stringPreferencesKey("reply_toolbar_actions")
+        private val KEY_MESSAGE_TOOLBAR = stringPreferencesKey("message_toolbar_actions")
         private val KEY_HOLIDAY_THEME = booleanPreferencesKey("holiday_theme")
         private val KEY_NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
         private val KEY_NOTIFICATION_POLL_MINUTES = intPreferencesKey("notification_poll_minutes")
@@ -292,6 +320,9 @@ class SettingsRepository(
 
         /** The site has fifteen boards. The cap is only here so a corrupt write cannot grow forever. */
         private const val MAX_HOME_BOARDS = 64
+
+        /** Comfortably above `EditorAction.entries.size`; a stored strip can never need more. */
+        private const val MAX_TOOLBAR_ACTIONS = 32
 
         private fun decodeRecentSearches(value: String?): List<String> =
             value.orEmpty().split(RECENT_SEARCH_SEPARATOR).filter(String::isNotBlank)
@@ -334,6 +365,9 @@ class SettingsRepository(
     }
 }
 
+/** Which composer's formatting strip a stored arrangement belongs to. */
+enum class ComposerSurface { POST, REPLY, MESSAGE }
+
 data class UserSettings(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val dynamicColor: Boolean = false,
@@ -353,6 +387,16 @@ data class UserSettings(
     val homeBoardOrder: List<String> = emptyList(),
     /** Boards parked at the tail of the strip. A subset of [homeBoardOrder]; see `setHomeBoardArrangement`. */
     val disabledHomeBoards: Set<String> = emptySet(),
+    /*
+     * The three formatting strips, as laid out through the wrench on the toolbar. Stored as
+     * `EditorAction` names in the order they appear; empty means "never customised" and the surface
+     * falls back to its own default set. Separate per surface on purpose — a topic wants a list and a
+     * link where a reply wants a quote and an @, and one shared arrangement would have to drop one of
+     * those from somebody's defaults to exist at all.
+     */
+    val postToolbarActions: List<String> = emptyList(),
+    val replyToolbarActions: List<String> = emptyList(),
+    val messageToolbarActions: List<String> = emptyList(),
     /*
      * App notification polling (board f4). Off by default: polling costs battery and needs the
      * POST_NOTIFICATIONS runtime permission, so it starts only when the user asks for it.

--- a/app/src/main/java/io/github/nodyssey/ui/account/ProfileFieldsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/account/ProfileFieldsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -55,12 +54,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nodyssey.R
 import io.github.nodyssey.ui.common.AvatarShape
-import io.github.nodyssey.ui.common.MARKDOWN_LINK_CARET
-import io.github.nodyssey.ui.common.MARKDOWN_LINK_SUFFIX
-import io.github.nodyssey.ui.common.MarkdownInsertion
 import io.github.nodyssey.ui.common.NodysseyIcons
 import io.github.nodyssey.ui.common.UserAvatar
-import io.github.nodyssey.ui.common.applyMarkdown
+import io.github.nodyssey.ui.composer.EditorActions
+import io.github.nodyssey.ui.composer.EditorToolbar
+import io.github.nodyssey.ui.composer.applyMarkdown
 import io.github.nodyssey.ui.theme.NodysseyTheme
 import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.readableWidth
@@ -288,10 +286,10 @@ private fun AvatarEditor(
 /**
  * A Markdown field with the five formatting actions a signature is allowed.
  *
- * The glyph labels rather than icons match the post composer's toolbar, which made the same call for
- * the same reason: `material-icons-core` ships none of `format_bold`, `format_italic` or
- * `strikethrough_s`, and hand-drawing three vectors to say what "B" and "I" already say is a poor
- * trade. Each button still carries a spoken description.
+ * The toolbar is the post composer's, not a second one that happens to insert the same characters:
+ * the keys, their spoken labels, the caret arithmetic and the 32dp grid all come from
+ * [EditorToolbar]. Only [EditorActions.Signature] and the container's colour are local, the latter
+ * because this is the one strip that sits inside a settings form rather than against the keyboard.
  */
 @Composable
 private fun MarkdownField(
@@ -323,51 +321,14 @@ private fun MarkdownField(
             textStyle = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.fillMaxWidth(),
         )
-        Surface(
-            shape = RoundedCornerShape(12.dp),
+        EditorToolbar(
+            actions = EditorActions.Signature,
+            onAction = { action -> fieldState.edit { applyMarkdown(action) } },
+            showDivider = false,
             color = MaterialTheme.colorScheme.surfaceContainerLow,
-        ) {
-            Row(Modifier.padding(2.dp)) {
-                SignatureFormat.entries.forEach { format ->
-                    val description = stringResource(format.descriptionRes)
-                    IconButton(
-                        onClick = { fieldState.edit { applyMarkdown(format.insertion) } },
-                        modifier = Modifier.semantics { contentDescription = description },
-                    ) {
-                        Text(format.glyph, style = MaterialTheme.typography.labelLarge)
-                    }
-                }
-            }
-        }
+            shape = RoundedCornerShape(12.dp),
+        )
     }
-}
-
-/**
- * Bold, italic, strikethrough, link, inline code — and deliberately nothing else.
- *
- * The absent actions are the point: NodeSeek's own helper text says a signature supports neither
- * images nor quotes. The insertion mechanics come from [applyMarkdown], shared with the post
- * composer, so only the *set* differs between the two editors.
- */
-private enum class SignatureFormat(
-    val glyph: String,
-    val descriptionRes: Int,
-    val insertion: MarkdownInsertion,
-) {
-    Bold("B", R.string.account_format_bold, MarkdownInsertion("**", "**", "加粗文字")),
-    Italic("I", R.string.account_format_italic, MarkdownInsertion("*", "*", "斜体文字")),
-    Strikethrough("S", R.string.account_format_strikethrough, MarkdownInsertion("~~", "~~", "删除线")),
-    Link(
-        "↗",
-        R.string.account_format_link,
-        MarkdownInsertion(
-            prefix = "[",
-            suffix = MARKDOWN_LINK_SUFFIX,
-            placeholder = "链接文字",
-            caretInSuffix = MARKDOWN_LINK_CARET,
-        ),
-    ),
-    Code("</>", R.string.account_format_code, MarkdownInsertion("`", "`", "code")),
 }
 
 private val AVATAR_SIZE = 84.dp

--- a/app/src/main/java/io/github/nodyssey/ui/common/EditorTextField.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/EditorTextField.kt
@@ -1,0 +1,67 @@
+package io.github.nodyssey.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * The text field every editor in the app is built on.
+ *
+ * A `BasicTextField` rather than Material's filled one, for the reason the message bar found first: a
+ * filled field reserves the room a floating label would need and stands 56dp tall before it holds
+ * anything. What the four editors actually shared was smaller and more error-prone than that — a
+ * placeholder drawn behind the field whenever the text is empty, which has to sit inside the decorator
+ * and therefore got rewritten at every call site.
+ *
+ * [container] is what the four still differ in, and the only thing they should: the post body wants a
+ * box that fills the screen, the reply sheet one that fills the width, the message bar a rounded pill,
+ * the title a row with a counter and a rule under it. It receives the placeholder and the field
+ * together and is responsible for stacking them — a `Box`, or something that ends in one.
+ */
+@Composable
+fun EditorTextField(
+    state: TextFieldState,
+    hint: String,
+    textStyle: TextStyle,
+    modifier: Modifier = Modifier,
+    hintStyle: TextStyle = textStyle,
+    hintMaxLines: Int = Int.MAX_VALUE,
+    lineLimits: TextFieldLineLimits = TextFieldLineLimits.MultiLine(),
+    inputTransformation: InputTransformation? = null,
+    container: @Composable (content: @Composable () -> Unit) -> Unit = { content ->
+        Box(Modifier.fillMaxWidth()) { content() }
+    },
+) {
+    BasicTextField(
+        state = state,
+        lineLimits = lineLimits,
+        inputTransformation = inputTransformation,
+        textStyle = textStyle,
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        modifier = modifier,
+        decorator = { inner ->
+            container {
+                if (state.text.isEmpty()) {
+                    Text(
+                        text = hint,
+                        style = hintStyle,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = hintMaxLines,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                inner()
+            }
+        },
+    )
+}

--- a/app/src/main/java/io/github/nodyssey/ui/common/MarkdownFormatting.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/MarkdownFormatting.kt
@@ -12,9 +12,9 @@ import java.text.BreakIterator
  * One Markdown formatting action, described rather than implemented.
  *
  * Every editor in the app offers a different *set* of actions — the post composer has images and
- * quotes, a signature is not allowed either — but they all insert text the same way, and the caret
- * arithmetic is the part that silently rots when it is copied. Editors declare their own actions and
- * share [applyMarkdown].
+ * quotes, a signature is allowed neither — but they all insert text the same way, and the caret
+ * arithmetic is the part that silently rots when it is copied. Surfaces declare their actions in
+ * `EditorActions` and share [applyMarkdown].
  */
 internal data class MarkdownInsertion(
     val prefix: String,
@@ -34,18 +34,19 @@ internal data class MarkdownInsertion(
 /**
  * Where an insertion leaves the caret.
  *
- * The two editors answer this differently and always have: the post composer selects what it just
- * wrapped, the signature editor places a caret. Unifying the *arithmetic* is the point of this file;
- * unifying the *behaviour* would be a silent UX change, so the difference is named here instead.
+ * Wrapping actions all select what they just wrapped, so the placeholder is gone the moment typing
+ * resumes. The signature editor used to place a bare caret instead, which left the caret *before*
+ * `加粗文字` and the placeholder behind in the text — a difference that was recorded here as
+ * deliberate long after it had stopped being defensible.
  */
 internal enum class MarkdownCaret {
-    /** Selects the wrapped content, so the next keystroke replaces it. The post composer's choice. */
+    /** Selects the wrapped content, so the next keystroke replaces it. Every wrapping action's choice. */
     SELECT_CONTENT,
 
     /** Just past the prefix when nothing was selected, at [MarkdownInsertion.caretInSuffix] otherwise. */
     AFTER_INSERTION,
 
-    /** Always at [MarkdownInsertion.caretInSuffix], selection or not. Used by the composer's link. */
+    /** Always at [MarkdownInsertion.caretInSuffix], selection or not. Used by the link action. */
     IN_SUFFIX,
 }
 

--- a/app/src/main/java/io/github/nodyssey/ui/common/NodysseyIcons.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/NodysseyIcons.kt
@@ -14,8 +14,7 @@ import androidx.compose.ui.unit.dp
  * strict lockfile makes a separate, deliberate operation.
  *
  * The bar for adding one: the icon has to carry meaning a core icon cannot. 账号设置's `tune` became
- * `Icons.Default.Settings` and `logout` became `ExitToApp` for exactly that reason, and the signature
- * editor's format toolbar uses the same text glyphs the post composer already does.
+ * `Icons.Default.Settings` and `logout` became `ExitToApp` for exactly that reason.
  */
 object NodysseyIcons {
     /** Decorative welcome glyph used by the signed-out profile illustration (board c7). */
@@ -351,6 +350,17 @@ object NodysseyIcons {
         )
     }
 
+    val FormatItalic: ImageVector by lazy {
+        materialIcon(name = "FormatItalic", pathData = "M10,4v3h2.21l-3.42,8H6v3h8v-3h-2.21l3.42,-8H18V4z")
+    }
+
+    val StrikethroughS: ImageVector by lazy {
+        materialIcon(
+            name = "StrikethroughS",
+            pathData = "M10,19h4v-3h-4v3zM5,4v3h5v3h4V7h5V4H5zM3,14h18v-2H3v2z",
+        )
+    }
+
     /** Heading. Material's `title` glyph rather than `format_h2`, which is text rendered as a path. */
     val Title: ImageVector by lazy {
         materialIcon(name = "Title", pathData = "M5,4v3h5.5v12h3V7H19V4z")
@@ -401,6 +411,28 @@ object NodysseyIcons {
             "M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2z" +
                 "M8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z",
         )
+    }
+
+    /**
+     * The key that opens the toolbar's own settings, at the end of the strip.
+     *
+     * A wrench rather than Material's `tune` sliders: `tune` sits in a row of formatting glyphs and
+     * reads as one of them — three horizontal bars is very nearly the list key. A wrench cannot be
+     * mistaken for something that edits the text.
+     */
+    val Build: ImageVector by lazy {
+        materialIcon(
+            name = "Build",
+            pathData =
+            "M22.7,19l-9.1,-9.1c0.9,-2.3 0.4,-5 -1.5,-6.9 -2,-2 -5,-2.4 -7.4,-1.3L9,6 6,9 1.6,4.7" +
+                "C0.4,7.1 0.9,10.1 2.9,12.1c1.9,1.9 4.6,2.4 6.9,1.5l9.1,9.1c0.4,0.4 1,0.4 1.4,0" +
+                "l2.3,-2.3c0.5,-0.4 0.5,-1.1 0.1,-1.4z",
+        )
+    }
+
+    /** The grab handle on a reorderable row. */
+    val DragHandle: ImageVector by lazy {
+        materialIcon(name = "DragHandle", pathData = "M20,9H4v2h16V9zM4,15h16v-2H4V15z")
     }
 
     /** The emoji panel's entry point. */

--- a/app/src/main/java/io/github/nodyssey/ui/composer/EditorToolbar.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/EditorToolbar.kt
@@ -20,8 +20,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.nodyssey.R
@@ -31,16 +35,29 @@ import io.github.nodyssey.ui.theme.Spacing
 /**
  * The formatting strip that sits on the keyboard's top edge.
  *
- * Shared by the post editor (7a/C5) and the reply sheet (6d/C6) — same component, different action
- * list and different trailing control.
+ * Shared by the post editor (7a/C5), the reply sheet (6d/C6), the message bar and the signature field
+ * — same component, different action list and different trailing control.
  *
- * The trailing control is pinned and the keys scroll under it. Measured on a 360dp phone, seven
- * 32dp keys and a 发布 button fit with a few dp to spare — which means they stop fitting the moment
- * the system font scale goes up, and of the two, a key you have to scroll to is far less costly
- * than a publish button you cannot see.
+ * Nothing but text-mutating keys goes in here. 预览 and 内容/预览/对照 used to, and they were the
+ * reason the keys were 32dp: every slot a view switch took was a slot the keys had to shrink to fit
+ * around. Those live in each surface's own chrome now, which is what bought the size below.
+ *
+ * [keySize] is 48dp — Material's minimum touch target — for every caller with room for it. The reply
+ * sheet is the one that has not: it keeps 发布 pinned at the end of the strip, and six 48dp keys plus
+ * that button want 392dp on a 360dp screen. It passes 42dp and stays scroll-free, which was the
+ * deliberate trade over the alternative, a strip that scrolls its last key under the publish button.
  *
  * [active] is what marks the toggled-open panels — the image and emoji keys stay lit while their
  * sheet is showing, which is the only cue that tapping again closes it.
+ *
+ * [color] and [shape] exist for the signature field, which is the one caller not sitting against the
+ * keyboard: inside a settings form the strip has to read as a grouped control rather than as the
+ * bottom edge of the screen, and it gets there by being a rounded container instead of a flat one.
+ *
+ * [onCustomize] adds the wrench that opens the strip's own settings — only the two composers whose
+ * strip is user-arranged pass it. It rides at the end of the *scrolling* keys rather than pinned
+ * beside [trailing]: it is the one key nobody reaches for mid-sentence, so it is the right thing to
+ * put behind a swipe, and the reply sheet has exactly one pinned slot and 发布 has it.
  */
 @Composable
 fun EditorToolbar(
@@ -49,9 +66,13 @@ fun EditorToolbar(
     modifier: Modifier = Modifier,
     active: Set<EditorAction> = emptySet(),
     showDivider: Boolean = true,
+    keySize: Dp = EditorToolbarDefaults.KeySize,
+    color: Color = MaterialTheme.colorScheme.surface,
+    shape: Shape = RectangleShape,
+    onCustomize: (() -> Unit)? = null,
     trailing: @Composable RowScope.() -> Unit = {},
 ) {
-    Surface(color = MaterialTheme.colorScheme.surface, modifier = modifier) {
+    Surface(color = color, shape = shape, modifier = modifier) {
         Box {
             if (showDivider) {
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -69,10 +90,25 @@ fun EditorToolbar(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     actions.forEach { action ->
-                        ToolbarButton(
-                            action = action,
+                        ToolbarKey(
+                            icon = action.icon,
+                            contentDescription = stringResource(action.labelRes),
+                            size = keySize,
+                            // An unlit 表情 key is still a checkbox in the "off" position, while 加粗
+                            // is never a checkbox at all — see [EditorAction.opensPanel].
+                            checkable = action.opensPanel,
                             selected = action in active,
                             onClick = { onAction(action) },
+                        )
+                    }
+                    onCustomize?.let { customize ->
+                        ToolbarKey(
+                            icon = NodysseyIcons.Build,
+                            contentDescription = stringResource(R.string.composer_toolbar_customize),
+                            size = keySize,
+                            checkable = false,
+                            selected = false,
+                            onClick = customize,
                         )
                     }
                 }
@@ -83,33 +119,37 @@ fun EditorToolbar(
 }
 
 /**
- * One key. A panel key is a checkbox; a formatting key is a button.
+ * One key. A panel key is a checkbox; every other key is a button.
  *
- * Both branches draw identically — 32dp box, `shapes.medium`, lit state in `surfaceContainer` +
- * `primary`. The split is about semantics: [EditorAction.opensPanel] keys have an on/off state that
- * colour alone conveys, so they go through `IconToggleButton` and TalkBack announces 表情 as
- * "已选中"/"未选中". The formatting keys fire and forget, and dressing them as checkboxes would be a
+ * Both branches draw identically — same box, `shapes.medium`, lit state in `surfaceContainer` +
+ * `primary`. The split is about semantics: a [checkable] key has an on/off state that colour alone
+ * conveys, so it goes through `IconToggleButton` and TalkBack announces 表情 as "已选中"/"未选中".
+ * The formatting keys and the wrench fire and forget, and dressing them as checkboxes would be a
  * regression, not a fix.
  */
 @Composable
-private fun ToolbarButton(
-    action: EditorAction,
+private fun ToolbarKey(
+    icon: ImageVector,
+    contentDescription: String,
+    size: Dp,
+    checkable: Boolean,
     selected: Boolean,
     onClick: () -> Unit,
 ) {
-    // 32dp box, matching the board's density. Both branches take the identical modifier, so the two
-    // key flavours measure the same and the strip stays on one grid.
-    val modifier = Modifier.size(32.dp)
+    // Both branches take the identical modifier, so the two key flavours measure the same and the
+    // strip stays on one grid. The glyph is half the box: 24dp inside 48dp is the Material ratio, and
+    // scaling it with the box is what keeps the tighter reply strip from looking like a different set.
+    val modifier = Modifier.size(size)
     val shape = MaterialTheme.shapes.medium
-    val icon: @Composable () -> Unit = {
+    val content: @Composable () -> Unit = {
         Icon(
-            imageVector = action.icon,
-            contentDescription = stringResource(action.labelRes),
-            modifier = Modifier.size(20.dp),
+            imageVector = icon,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(size / 2),
         )
     }
 
-    if (action.opensPanel) {
+    if (checkable) {
         IconToggleButton(
             checked = selected,
             onCheckedChange = { onClick() },
@@ -120,7 +160,7 @@ private fun ToolbarButton(
                 checkedContentColor = MaterialTheme.colorScheme.primary,
             ),
             shape = shape,
-            content = icon,
+            content = content,
         )
     } else {
         IconButton(
@@ -130,14 +170,30 @@ private fun ToolbarButton(
                 contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
             ),
             shape = shape,
-            content = icon,
+            content = content,
         )
     }
 }
 
-private val EditorAction.icon: ImageVector
+object EditorToolbarDefaults {
+    /** Material's minimum touch target. Every strip with the room for it uses this. */
+    val KeySize = 48.dp
+
+    /**
+     * What the reply sheet passes: six keys and a pinned 发布 in 360dp, without a scroll.
+     *
+     * Below the 48dp minimum on purpose, and the only place in the app that is. The alternative was a
+     * strip that scrolls, and a scrolling strip always hides its *last* key under the publish button —
+     * so the cost lands on one specific key rather than being spread as 6dp across all six.
+     */
+    val CompactKeySize = 42.dp
+}
+
+internal val EditorAction.icon: ImageVector
     get() = when (this) {
         EditorAction.BOLD -> NodysseyIcons.FormatBold
+        EditorAction.ITALIC -> NodysseyIcons.FormatItalic
+        EditorAction.STRIKETHROUGH -> NodysseyIcons.StrikethroughS
         EditorAction.HEADING -> NodysseyIcons.Title
         EditorAction.CODE -> NodysseyIcons.Code
         EditorAction.QUOTE -> NodysseyIcons.FormatQuote
@@ -146,12 +202,13 @@ private val EditorAction.icon: ImageVector
         EditorAction.MENTION -> NodysseyIcons.AlternateEmail
         EditorAction.IMAGE -> NodysseyIcons.Image
         EditorAction.EMOJI -> NodysseyIcons.Mood
-        EditorAction.PREVIEW -> NodysseyIcons.Visibility
     }
 
-private val EditorAction.labelRes: Int
+internal val EditorAction.labelRes: Int
     get() = when (this) {
         EditorAction.BOLD -> R.string.composer_format_bold
+        EditorAction.ITALIC -> R.string.composer_format_italic
+        EditorAction.STRIKETHROUGH -> R.string.composer_format_strikethrough
         EditorAction.HEADING -> R.string.composer_format_heading
         EditorAction.CODE -> R.string.composer_format_code
         EditorAction.QUOTE -> R.string.composer_format_quote
@@ -160,7 +217,6 @@ private val EditorAction.labelRes: Int
         EditorAction.MENTION -> R.string.composer_format_mention
         EditorAction.IMAGE -> R.string.composer_format_image
         EditorAction.EMOJI -> R.string.composer_format_emoji
-        EditorAction.PREVIEW -> R.string.action_preview
     }
 
 /**

--- a/app/src/main/java/io/github/nodyssey/ui/composer/MarkdownEditing.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/MarkdownEditing.kt
@@ -13,10 +13,82 @@ import io.github.nodyssey.ui.common.toggleLinePrefix
  *
  * The site's own editor carries fifteen keys (§1.6). A phone toolbar that tried to match it would
  * either scroll — hiding the actions people actually use behind a swipe — or shrink below the 48dp
- * target, so the boards pick six or seven per surface and this enum is the union of those picks.
- * [IMAGE], [EMOJI] and [PREVIEW] open something rather than rewriting text; the screen handles them.
+ * target, so the boards pick four to six per surface and this enum is the union of those picks.
+ *
+ * Everything here mutates text at the caret. Preview does not — it changes what the whole screen
+ * shows — and it is deliberately absent: it lives in each surface's own chrome, alongside 发布 and
+ * the close button, rather than competing with 加粗 for a slot.
+ *
+ * [IMAGE] and [EMOJI] open something rather than rewriting text; the screen handles them.
  */
-enum class EditorAction { BOLD, HEADING, CODE, QUOTE, LIST, LINK, MENTION, IMAGE, EMOJI, PREVIEW }
+enum class EditorAction {
+    BOLD,
+    ITALIC,
+    STRIKETHROUGH,
+    HEADING,
+    CODE,
+    QUOTE,
+    LIST,
+    LINK,
+    MENTION,
+    IMAGE,
+    EMOJI,
+}
+
+/**
+ * Which keys each surface picks, side by side.
+ *
+ * Kept together rather than one list per screen file, because the interesting thing about them is the
+ * comparison — every entry is an argument about what that surface is for, and those arguments are only
+ * checkable next to each other:
+ *
+ * - [Post] leads with a list and a link; a topic is written, not spoken.
+ * - [Reply] trades those for a quote and an @, the two things a reply does that a topic does not.
+ * - [Message] is the shortest, and only that: every key is available through its wrench, images
+ *   included — `message/send` carries `content` as Markdown and the thread renders images in it.
+ *   No preview, because a message renders into a bubble the moment it is sent; getting it wrong
+ *   costs a second message, not a deleted topic.
+ * - [Signature] omits images and quotes because NodeSeek's own helper text says signatures support
+ *   neither. Offering keys the server will strip is the failure the reduced set exists to avoid.
+ */
+object EditorActions {
+    val Post =
+        listOf(
+            EditorAction.BOLD,
+            EditorAction.CODE,
+            EditorAction.LIST,
+            EditorAction.LINK,
+            EditorAction.IMAGE,
+            EditorAction.EMOJI,
+        )
+
+    val Reply =
+        listOf(
+            EditorAction.BOLD,
+            EditorAction.CODE,
+            EditorAction.QUOTE,
+            EditorAction.MENTION,
+            EditorAction.IMAGE,
+            EditorAction.EMOJI,
+        )
+
+    val Message =
+        listOf(
+            EditorAction.BOLD,
+            EditorAction.CODE,
+            EditorAction.LINK,
+            EditorAction.EMOJI,
+        )
+
+    val Signature =
+        listOf(
+            EditorAction.BOLD,
+            EditorAction.ITALIC,
+            EditorAction.STRIKETHROUGH,
+            EditorAction.LINK,
+            EditorAction.CODE,
+        )
+}
 
 /**
  * True when the key opens a panel that stays open, rather than performing a one-shot edit.
@@ -26,7 +98,7 @@ enum class EditorAction { BOLD, HEADING, CODE, QUOTE, LIST, LINK, MENTION, IMAGE
  * the latter a toggled role would tell a screen reader something untrue.
  */
 internal val EditorAction.opensPanel: Boolean
-    get() = this in setOf(EditorAction.IMAGE, EditorAction.EMOJI, EditorAction.PREVIEW)
+    get() = this in setOf(EditorAction.IMAGE, EditorAction.EMOJI)
 
 /**
  * Applies one toolbar action to the current selection.
@@ -39,19 +111,20 @@ internal val EditorAction.opensPanel: Boolean
  * - **Line prefixes** (heading, quote, list) toggle at the start of the caret's line, so tapping
  *   the same key twice undoes it instead of stacking `>> `.
  *
- * The mechanics live in `ui/common`, shared with the signature editor; this file only says which
- * insertion each key stands for.
+ * The mechanics live in `ui/common`; this file only says which insertion each key stands for.
  */
 internal fun TextFieldBuffer.applyMarkdown(action: EditorAction) {
     when (action) {
         EditorAction.BOLD -> applyMarkdown(BOLD)
+        EditorAction.ITALIC -> applyMarkdown(ITALIC)
+        EditorAction.STRIKETHROUGH -> applyMarkdown(STRIKETHROUGH)
         EditorAction.CODE -> applyMarkdown(CODE)
         EditorAction.LINK -> applyMarkdown(LINK)
         EditorAction.MENTION -> applyMarkdown(MENTION)
         EditorAction.HEADING -> toggleLinePrefix("## ")
         EditorAction.QUOTE -> toggleLinePrefix("> ")
         EditorAction.LIST -> toggleLinePrefix("- ")
-        EditorAction.IMAGE, EditorAction.EMOJI, EditorAction.PREVIEW -> Unit
+        EditorAction.IMAGE, EditorAction.EMOJI -> Unit
     }
 }
 
@@ -63,6 +136,22 @@ private val BOLD =
         caret = MarkdownCaret.SELECT_CONTENT,
     )
 
+private val ITALIC =
+    MarkdownInsertion(
+        prefix = "*",
+        suffix = "*",
+        placeholder = "斜体文字",
+        caret = MarkdownCaret.SELECT_CONTENT,
+    )
+
+private val STRIKETHROUGH =
+    MarkdownInsertion(
+        prefix = "~~",
+        suffix = "~~",
+        placeholder = "删除线",
+        caret = MarkdownCaret.SELECT_CONTENT,
+    )
+
 private val CODE =
     MarkdownInsertion(
         prefix = "`",
@@ -71,12 +160,7 @@ private val CODE =
         caret = MarkdownCaret.SELECT_CONTENT,
     )
 
-/**
- * The caret goes into the empty address, never onto the label.
- *
- * Unlike the signature editor's link, which stops just past `](`: here the scheme is already typed,
- * so landing after it is one fewer thing to do.
- */
+/** The caret goes into the empty address, never onto the label: the scheme is already typed. */
 private val LINK =
     MarkdownInsertion(
         prefix = "[",

--- a/app/src/main/java/io/github/nodyssey/ui/composer/MarkdownEditorBar.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/MarkdownEditorBar.kt
@@ -1,0 +1,140 @@
+package io.github.nodyssey.ui.composer
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.Dp
+import io.github.nodyssey.ui.common.deleteBackwards
+import io.github.nodyssey.ui.common.insertText
+
+/**
+ * What the formatting strip remembers between frames — and, for the emoji recents, between screens.
+ *
+ * Hoisted out of the strip because both halves outlive it: the panel leaves the composition every time
+ * it closes, taking any recents it held with it, and the reply sheet's whole toolbar leaves whenever
+ * the sheet is dismissed. Whoever owns the editor owns this, and it is saved rather than remembered so
+ * a rotation does not lose the emoji someone just picked.
+ */
+@Stable
+class MarkdownEditorState(
+    emojiOpen: Boolean = false,
+    recentEmoji: List<String> = emptyList(),
+) {
+    /** The emoji panel replaces the keyboard rather than stacking on it, so only one is ever true. */
+    var emojiOpen by mutableStateOf(emojiOpen)
+        private set
+
+    /** Most recently inserted emoji, newest first. */
+    var recentEmoji by mutableStateOf(recentEmoji)
+        internal set
+
+    internal fun toggleEmoji() {
+        emojiOpen = !emojiOpen
+    }
+
+    fun closeEmoji() {
+        emojiOpen = false
+    }
+
+    companion object {
+        val Saver: Saver<MarkdownEditorState, Any> =
+            listSaver(
+                // An ArrayList, not whatever `List` the recents happen to be: the saved-state bundle
+                // takes Serializable, and the empty-list singleton is not a reliable one to bet on.
+                save = { listOf(it.emojiOpen, ArrayList(it.recentEmoji)) },
+                restore = {
+                    @Suppress("UNCHECKED_CAST")
+                    MarkdownEditorState(it[0] as Boolean, it[1] as List<String>)
+                },
+            )
+    }
+}
+
+@Composable
+fun rememberMarkdownEditorState(): MarkdownEditorState =
+    rememberSaveable(saver = MarkdownEditorState.Saver) { MarkdownEditorState() }
+
+/**
+ * The formatting strip, its emoji panel, and the wiring between them and a [TextFieldState].
+ *
+ * Every editor in the app has the same three-part shape — keys on the keyboard's top edge, the panel
+ * they open below, and a text field somewhere above — and used to spell out the same dispatch by hand:
+ * toggle the panel, hide the IME, close the panel again on the next formatting key, apply the markup.
+ * That is the part worth having once. What each surface still declares for itself is its [actions],
+ * whatever [trailing] control sits at the end of the strip, and where [onPickImages] takes the one
+ * key that opens something the host owns rather than rewriting text.
+ *
+ * [content] is emitted between the strip and the panel — the message bar's own input row goes there,
+ * so the panel takes the keyboard's place under it rather than pushing it off the screen. The post and
+ * reply editors leave it empty, and the two sit flush.
+ */
+@Composable
+fun MarkdownEditorBar(
+    actions: List<EditorAction>,
+    bodyState: TextFieldState,
+    editorState: MarkdownEditorState,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
+    keySize: Dp = EditorToolbarDefaults.KeySize,
+    /** The host owns the photo picker, so [EditorAction.IMAGE] comes back out rather than acting. */
+    onPickImages: () -> Unit = {},
+    /** Runs after markup is applied — the post editor puts focus back in the body with it. */
+    onFormatted: () -> Unit = {},
+    /** Adds the wrench at the end of the keys. Only the two surfaces with an arranged strip pass it. */
+    onCustomize: (() -> Unit)? = null,
+    trailing: @Composable RowScope.() -> Unit = {},
+    content: @Composable ColumnScope.() -> Unit = {},
+) {
+    val keyboard = LocalSoftwareKeyboardController.current
+    // The panel stands in for the keyboard, and a keyboard is the one thing back is always expected to
+    // dismiss before it leaves the screen.
+    BackHandler(enabled = editorState.emojiOpen) { editorState.closeEmoji() }
+
+    Column(modifier) {
+        EditorToolbar(
+            actions = actions,
+            active = if (editorState.emojiOpen) setOf(EditorAction.EMOJI) else emptySet(),
+            showDivider = showDivider,
+            keySize = keySize,
+            onCustomize = onCustomize,
+            onAction = { action ->
+                when (action) {
+                    EditorAction.EMOJI -> {
+                        editorState.toggleEmoji()
+                        if (editorState.emojiOpen) keyboard?.hide()
+                    }
+
+                    EditorAction.IMAGE -> onPickImages()
+
+                    else -> {
+                        editorState.closeEmoji()
+                        bodyState.edit { applyMarkdown(action) }
+                        onFormatted()
+                    }
+                }
+            },
+            trailing = trailing,
+        )
+        content()
+        if (editorState.emojiOpen) {
+            EmojiPanel(
+                onInsert = { text -> bodyState.edit { insertText(text) } },
+                onBackspace = { bodyState.edit { deleteBackwards() } },
+                recent = editorState.recentEmoji,
+                onRecentChange = { editorState.recentEmoji = it },
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerScreen.kt
@@ -18,14 +18,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.AlertDialog
@@ -60,10 +58,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -76,9 +72,8 @@ import io.github.nodyssey.data.composer.ImageAttachment
 import io.github.nodyssey.data.composer.PostDraft
 import io.github.nodyssey.data.composer.PostPermission
 import io.github.nodyssey.data.composer.UploadFailure
+import io.github.nodyssey.ui.common.EditorTextField
 import io.github.nodyssey.ui.common.NodysseyIcons
-import io.github.nodyssey.ui.common.deleteBackwards
-import io.github.nodyssey.ui.common.insertText
 import io.github.nodyssey.ui.theme.PostBody
 import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.readableWidth
@@ -135,6 +130,8 @@ fun PostComposerRoute(
         onPublish = { if (state.isSignedIn) viewModel.publish(onPublished) else onSignIn() },
         onContinueDraft = viewModel::continueDraft,
         onDiscardDraft = viewModel::discardDraft,
+        onToolbarChange = viewModel::setToolbar,
+        onToolbarReset = viewModel::resetToolbar,
         modifier = modifier,
     )
 }
@@ -213,6 +210,8 @@ fun PostComposerScreen(
     onPublish: () -> Unit,
     onContinueDraft: () -> Unit,
     onDiscardDraft: () -> Unit,
+    onToolbarChange: (List<EditorAction>) -> Unit,
+    onToolbarReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // While a publish is in flight the request may already have created the topic; leaving now would
@@ -226,11 +225,11 @@ fun PostComposerScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             ComposerTopBar(
-                preview = state.viewMode == ComposerViewMode.PREVIEW,
+                viewMode = state.viewMode,
                 isPublishing = state.isPublishing,
                 canPublish = state.canPublish,
                 onClose = onClose,
-                onBack = { onViewModeChange(ComposerViewMode.CONTENT) },
+                onViewModeChange = onViewModeChange,
                 onPublish = onPublish,
             )
         },
@@ -244,10 +243,11 @@ fun PostComposerScreen(
                 bodyState = bodyState,
                 onBoardSelect = onBoardSelect,
                 onPermissionSelect = onPermissionSelect,
-                onViewModeChange = onViewModeChange,
                 onPickImages = onPickImages,
                 onRemoveAttachment = onRemoveAttachment,
                 onRetryAttachment = onRetryAttachment,
+                onToolbarChange = onToolbarChange,
+                onToolbarReset = onToolbarReset,
                 modifier = Modifier.padding(padding),
             )
         }
@@ -258,29 +258,43 @@ fun PostComposerScreen(
     }
 }
 
+/**
+ * Close, the view switch, publish.
+ *
+ * The switch is here rather than in the formatting strip because 内容/预览/对照 is not a formatting
+ * action — it changes what the whole screen shows, the way the close and publish buttons beside it do.
+ * It sat in the toolbar's trailing slot until users called the keys "蚂蚁一样": three of the strip's
+ * seven slots went to a view switch, which is what forced the remaining keys down to 32dp.
+ *
+ * It also replaces the title. "发布帖子" told you where you were on a screen that could not be
+ * anywhere else, and the switch says the same thing better by showing which of the three views is
+ * live. With the switch always reachable there is no back arrow either — tapping 内容 is the way out
+ * of a preview, and 关闭 stays 关闭 in every mode instead of turning into something else.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ComposerTopBar(
-    preview: Boolean,
+    viewMode: ComposerViewMode,
     isPublishing: Boolean,
     canPublish: Boolean,
     onClose: () -> Unit,
-    onBack: () -> Unit,
+    onViewModeChange: (ComposerViewMode) -> Unit,
     onPublish: () -> Unit,
 ) {
     TopAppBar(
         title = {
-            Text(
-                text = stringResource(if (preview) R.string.composer_preview_title else R.string.composer_title),
-                style = MaterialTheme.typography.titleSmall,
-                fontSize = 16.sp,
+            ViewModeSwitch(
+                options = ComposerViewMode.entries,
+                selected = viewMode,
+                label = { mode -> stringResource(mode.labelRes) },
+                onSelect = onViewModeChange,
             )
         },
         navigationIcon = {
-            IconButton(onClick = if (preview) onBack else onClose, enabled = !isPublishing) {
+            IconButton(onClick = onClose, enabled = !isPublishing) {
                 Icon(
-                    imageVector = if (preview) Icons.AutoMirrored.Filled.ArrowBack else Icons.Default.Close,
-                    contentDescription = stringResource(if (preview) R.string.action_back else R.string.action_cancel),
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.action_cancel),
                 )
             }
         },
@@ -340,17 +354,16 @@ private fun EditorContent(
     bodyState: TextFieldState,
     onBoardSelect: (Board) -> Unit,
     onPermissionSelect: (PostPermission) -> Unit,
-    onViewModeChange: (ComposerViewMode) -> Unit,
     onPickImages: () -> Unit,
     onRemoveAttachment: (ImageAttachment) -> Unit,
     onRetryAttachment: (ImageAttachment) -> Unit,
+    onToolbarChange: (List<EditorAction>) -> Unit,
+    onToolbarReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var emojiOpen by rememberSaveable { mutableStateOf(false) }
-    // Held here, not in the panel: the panel leaves the composition whenever it closes.
-    var recentEmoji by rememberSaveable { mutableStateOf(listOf<String>()) }
+    val editorState = rememberMarkdownEditorState()
     val focusRequester = remember { FocusRequester() }
-    val keyboard = LocalSoftwareKeyboardController.current
+    var customizing by rememberSaveable { mutableStateOf(false) }
 
     Column(modifier = modifier.fillMaxSize().imePadding()) {
         ComposerOptions(state = state, onBoardSelect = onBoardSelect, onPermissionSelect = onPermissionSelect)
@@ -366,42 +379,25 @@ private fun EditorContent(
             onRemove = onRemoveAttachment,
             onRetry = onRetryAttachment,
         )
-        EditorToolbar(
-            actions = POST_ACTIONS,
-            active = if (emojiOpen) setOf(EditorAction.EMOJI) else emptySet(),
-            onAction = { action ->
-                when (action) {
-                    EditorAction.IMAGE -> onPickImages()
-
-                    EditorAction.EMOJI -> {
-                        emojiOpen = !emojiOpen
-                        if (emojiOpen) keyboard?.hide()
-                    }
-
-                    else -> {
-                        emojiOpen = false
-                        bodyState.edit { applyMarkdown(action) }
-                        focusRequester.requestFocus()
-                    }
-                }
-            },
-            trailing = {
-                ViewModeSwitch(
-                    options = ComposerViewMode.entries,
-                    selected = state.viewMode,
-                    label = { mode -> stringResource(mode.labelRes) },
-                    onSelect = onViewModeChange,
-                )
-            },
+        MarkdownEditorBar(
+            actions = state.toolbar.enabled,
+            bodyState = bodyState,
+            editorState = editorState,
+            onPickImages = onPickImages,
+            onCustomize = { customizing = true },
+            // The toolbar takes focus when it is tapped, and a caret the user cannot see is a caret
+            // they have lost track of.
+            onFormatted = { focusRequester.requestFocus() },
         )
-        if (emojiOpen) {
-            EmojiPanel(
-                onInsert = { text -> bodyState.edit { insertText(text) } },
-                onBackspace = { bodyState.edit { deleteBackwards() } },
-                recent = recentEmoji,
-                onRecentChange = { recentEmoji = it },
-            )
-        }
+    }
+
+    if (customizing) {
+        ToolbarCustomizeSheet(
+            layout = state.toolbar,
+            onChange = onToolbarChange,
+            onReset = onToolbarReset,
+            onDismiss = { customizing = false },
+        )
     }
 }
 
@@ -438,27 +434,18 @@ private fun BodyField(
     focusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
-    BasicTextField(
+    EditorTextField(
         state = bodyState,
+        hint = stringResource(R.string.composer_body_hint),
         textStyle = PostBody.copy(color = MaterialTheme.colorScheme.onSurface),
-        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-        lineLimits = TextFieldLineLimits.MultiLine(),
+        hintStyle = PostBody,
         modifier = modifier
             .readableWidth()
             .focusRequester(focusRequester)
             .padding(horizontal = Spacing.lg, vertical = Spacing.md),
-        decorator = { inner ->
-            Box(Modifier.fillMaxSize()) {
-                if (bodyState.text.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.composer_body_hint),
-                        style = PostBody,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                inner()
-            }
-        },
+        // The body owns the rest of the screen, so the placeholder is drawn against all of it rather
+        // than against one line's worth.
+        container = { content -> Box(Modifier.fillMaxSize()) { content() } },
     )
 }
 
@@ -467,33 +454,26 @@ private fun TitleField(
     titleState: TextFieldState,
     length: Int,
 ) {
-    BasicTextField(
+    EditorTextField(
         state = titleState,
-        lineLimits = TextFieldLineLimits.SingleLine,
-        // Enforced at the input layer rather than trimmed afterwards: truncating in the ViewModel
-        // cut composing text out from under the IME, which made the field stutter mid-word.
-        inputTransformation = InputTransformation.maxLength(PostComposerViewModel.MAX_TITLE_LENGTH),
+        hint = stringResource(R.string.composer_title_hint),
         textStyle = MaterialTheme.typography.titleMedium.copy(
             fontSize = 19.sp,
             lineHeight = 26.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onSurface,
         ),
-        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        // The placeholder is not bold: the weight belongs to a title that exists.
+        hintStyle = MaterialTheme.typography.titleMedium.copy(fontSize = 19.sp),
+        lineLimits = TextFieldLineLimits.SingleLine,
+        // Enforced at the input layer rather than trimmed afterwards: truncating in the ViewModel
+        // cut composing text out from under the IME, which made the field stutter mid-word.
+        inputTransformation = InputTransformation.maxLength(PostComposerViewModel.MAX_TITLE_LENGTH),
         modifier = Modifier.readableWidth().padding(horizontal = Spacing.lg),
-        decorator = { inner ->
+        container = { content ->
             Column {
                 Row(verticalAlignment = Alignment.Bottom) {
-                    Box(Modifier.weight(1f).padding(bottom = Spacing.sm)) {
-                        if (length == 0) {
-                            Text(
-                                text = stringResource(R.string.composer_title_hint),
-                                style = MaterialTheme.typography.titleMedium.copy(fontSize = 19.sp),
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        inner()
-                    }
+                    Box(Modifier.weight(1f).padding(bottom = Spacing.sm)) { content() }
                     Text(
                         text = stringResource(
                             R.string.composer_title_count,
@@ -732,14 +712,5 @@ private fun formatTime(timestamp: Long): String =
     DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(timestamp))
 
 private val IMAGE_MARKDOWN = Regex("""!\[[^]]*]\([^)]+\)""")
-
-private val POST_ACTIONS = listOf(
-    EditorAction.BOLD,
-    EditorAction.CODE,
-    EditorAction.LIST,
-    EditorAction.LINK,
-    EditorAction.IMAGE,
-    EditorAction.EMOJI,
-)
 
 private const val MAX_IMAGES_PER_PICK = 9

--- a/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/PostComposerViewModel.kt
@@ -25,6 +25,8 @@ import io.github.nodyssey.data.composer.PostSubmission
 import io.github.nodyssey.data.composer.UploadFailure
 import io.github.nodyssey.data.composer.UploadStatus
 import io.github.nodyssey.data.session.SessionState
+import io.github.nodyssey.data.settings.ComposerSurface
+import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.di.AppContainer
 import io.github.nodyssey.ui.common.appendBlock
 import io.github.nodyssey.ui.common.editFromViewModel
@@ -35,8 +37,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -48,6 +52,11 @@ class PostComposerViewModel(
     private val clock: AppClock,
     uploader: ImageUploader,
     private val profileRepository: ProfileRepository? = null,
+    /**
+     * Null in tests and wherever the strip is not editable; the editor then shows
+     * [EditorActions.Post] and the wrench does nothing worth opening, so it is not offered.
+     */
+    private val settings: SettingsRepository? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(PostComposerUiState())
     val uiState: StateFlow<PostComposerUiState> = _uiState.asStateFlow()
@@ -82,6 +91,12 @@ class PostComposerViewModel(
         uploads.attachments
             .onEach { attachments -> _uiState.update { it.copy(attachments = attachments) } }
             .launchIn(viewModelScope)
+        settings?.settings
+            ?.map { it.postToolbarActions }
+            ?.distinctUntilChanged()
+            ?.onEach { stored ->
+                _uiState.update { it.copy(toolbar = toolbarLayout(stored, EditorActions.Post)) }
+            }?.launchIn(viewModelScope)
         // An upload lands while typing continues, so its Markdown goes to the end of the body
         // rather than wherever the caret happens to be sitting — and, because this edits the buffer
         // instead of replacing the whole string, the caret stays wherever the user left it.
@@ -241,6 +256,20 @@ class PostComposerViewModel(
         }
     }
 
+    /** Writes the strip through on every edit in the wrench panel; see `ToolbarCustomizeSheet`. */
+    fun setToolbar(actions: List<EditorAction>) {
+        val repository = settings ?: return
+        viewModelScope.launch {
+            repository.setComposerToolbar(ComposerSurface.POST, actions.map(EditorAction::name))
+        }
+    }
+
+    /** Clears the stored arrangement, which is what makes the defaults come back. */
+    fun resetToolbar() {
+        val repository = settings ?: return
+        viewModelScope.launch { repository.setComposerToolbar(ComposerSurface.POST, emptyList()) }
+    }
+
     companion object {
         const val MAX_TITLE_LENGTH = 60
         private const val AUTOSAVE_DELAY_MILLIS = 750L
@@ -254,6 +283,7 @@ class PostComposerViewModel(
                     clock = container.clock,
                     uploader = container.imageUploader,
                     profileRepository = container.profileRepository,
+                    settings = container.settingsRepository,
                 )
             }
         }
@@ -272,6 +302,8 @@ data class PostComposerUiState(
     val boardTitle: String? = null,
     val permission: PostPermission = PostPermission.PUBLIC,
     val viewMode: ComposerViewMode = ComposerViewMode.CONTENT,
+    /** The formatting strip's keys and the wrench panel's pool. Defaults until settings arrive. */
+    val toolbar: ToolbarLayout = toolbarLayout(emptyList(), EditorActions.Post),
     val isPublishing: Boolean = false,
     val publishError: NodeSeekError? = null,
     val publishErrorDetail: String? = null,

--- a/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposer.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposer.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.ui.composer
 
-import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -26,8 +25,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -52,17 +49,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -72,9 +66,8 @@ import io.github.nodyssey.core.net.NodeSeekError
 import io.github.nodyssey.data.composer.ImageAttachment
 import io.github.nodyssey.data.composer.PickedImage
 import io.github.nodyssey.data.composer.UploadFailure
+import io.github.nodyssey.ui.common.EditorTextField
 import io.github.nodyssey.ui.common.NodysseyIcons
-import io.github.nodyssey.ui.common.deleteBackwards
-import io.github.nodyssey.ui.common.insertText
 import io.github.nodyssey.ui.theme.CommentBody
 import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.readableWidth
@@ -102,12 +95,21 @@ fun ReplyComposerHost(
     onRetryFailedUploads: () -> Unit,
     onPublish: () -> Unit,
     onClearError: () -> Unit,
+    onToolbarChange: (List<EditorAction>) -> Unit,
+    onToolbarReset: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Above the early return on purpose: the host stays composed while the sheet is closed, so
     // this is the one place the recents survive both the emoji panel and the sheet being dismissed.
-    var recentEmoji by rememberSaveable { mutableStateOf(listOf<String>()) }
+    val editorState = rememberMarkdownEditorState()
+    // The panel is part of the sheet even though its state is not, so it goes down with it — the
+    // recents are what outlive the dismissal, not a half-open drawer.
+    LaunchedEffect(state.visible) { if (!state.visible) editorState.closeEmoji() }
     if (!state.visible) return
+    // Hosted here rather than inside the editor sheet: it is a sheet too, and a sheet opened from
+    // inside another sheet's content stacks two dialog windows for no reason. As siblings the wrench
+    // panel simply covers the editor, which is what it should look like anyway.
+    var customizing by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
     val picker = rememberLauncherForActivityResult(
         ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_PICK),
@@ -149,8 +151,17 @@ fun ReplyComposerHost(
             onRetryFailedUploads = onRetryFailedUploads,
             onPublish = onPublish,
             onClearError = onClearError,
-            recentEmoji = recentEmoji,
-            onRecentEmojiChange = { recentEmoji = it },
+            editorState = editorState,
+            onCustomize = { customizing = true },
+        )
+    }
+
+    if (customizing) {
+        ToolbarCustomizeSheet(
+            layout = state.toolbar,
+            onChange = onToolbarChange,
+            onReset = onToolbarReset,
+            onDismiss = { customizing = false },
         )
     }
 }
@@ -169,10 +180,9 @@ private fun ReplyEditorSheet(
     onRetryFailedUploads: () -> Unit,
     onPublish: () -> Unit,
     onClearError: () -> Unit,
-    recentEmoji: List<String>,
-    onRecentEmojiChange: (List<String>) -> Unit,
+    editorState: MarkdownEditorState,
+    onCustomize: () -> Unit,
 ) {
-    var emojiOpen by rememberSaveable { mutableStateOf(false) }
     val keyboard = LocalSoftwareKeyboardController.current
 
     ModalBottomSheet(
@@ -208,6 +218,23 @@ private fun ReplyEditorSheet(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
+                // The sheet's own chrome is where a view switch belongs — this row is what the post
+                // editor's top bar is, and it is the only bar the sheet has.
+                IconButton(
+                    onClick = {
+                        // The preview covers the sheet, so the IME has to be gone before it rises —
+                        // otherwise it comes back to a keyboard over a screen that has no field.
+                        keyboard?.hide()
+                        onPreview()
+                    },
+                    enabled = !state.isPublishing,
+                ) {
+                    Icon(
+                        imageVector = NodysseyIcons.Visibility,
+                        contentDescription = stringResource(R.string.action_preview),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 IconButton(onClick = onDismiss, enabled = !state.isPublishing) {
                     Icon(
                         imageVector = Icons.Default.Close,
@@ -223,33 +250,22 @@ private fun ReplyEditorSheet(
                     modifier = Modifier.padding(start = Spacing.xl, end = Spacing.xl, top = Spacing.xs),
                 )
             }
-            BasicTextField(
+            // The default container fills the width it was given, which is what this field needs:
+            // `readableWidth` centres what it wraps, so a decoration that measured to its content
+            // would centre a half-typed reply.
+            EditorTextField(
                 state = bodyState,
-                lineLimits = TextFieldLineLimits.MultiLine(),
+                hint = stringResource(R.string.post_reply_editor_hint),
                 textStyle = CommentBody.copy(
                     fontSize = 16.sp,
                     lineHeight = 26.sp,
                     color = MaterialTheme.colorScheme.onSurface,
                 ),
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                hintStyle = CommentBody.copy(fontSize = 16.sp, lineHeight = 26.sp),
                 modifier = Modifier
                     .readableWidth()
                     .heightIn(min = MIN_EDITOR_HEIGHT, max = MAX_EDITOR_HEIGHT)
                     .padding(horizontal = Spacing.xl, vertical = Spacing.sm),
-                decorator = { inner ->
-                    // Fills the width it was given: `readableWidth` centres what it wraps, so a
-                    // decoration that measures to its content would centre a half-typed reply.
-                    Box(Modifier.fillMaxWidth()) {
-                        if (bodyState.text.isEmpty()) {
-                            Text(
-                                text = stringResource(R.string.post_reply_editor_hint),
-                                style = CommentBody.copy(fontSize = 16.sp, lineHeight = 26.sp),
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        inner()
-                    }
-                },
             )
             AttachmentTray(
                 attachments = state.attachments,
@@ -267,30 +283,16 @@ private fun ReplyEditorSheet(
                 onDismiss = onClearError,
                 modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.xs),
             )
-            EditorToolbar(
-                actions = REPLY_ACTIONS,
-                active = if (emojiOpen) setOf(EditorAction.EMOJI) else emptySet(),
+            MarkdownEditorBar(
+                actions = state.toolbar.enabled,
+                bodyState = bodyState,
+                editorState = editorState,
                 showDivider = false,
-                onAction = { action ->
-                    when (action) {
-                        EditorAction.IMAGE -> onPickImages()
-
-                        EditorAction.PREVIEW -> {
-                            keyboard?.hide()
-                            onPreview()
-                        }
-
-                        EditorAction.EMOJI -> {
-                            emojiOpen = !emojiOpen
-                            if (emojiOpen) keyboard?.hide()
-                        }
-
-                        else -> {
-                            emojiOpen = false
-                            bodyState.edit { applyMarkdown(action) }
-                        }
-                    }
-                },
+                // The one strip in the app under 48dp: it keeps 发布 pinned at its end, and six full
+                // keys plus that button want 392dp on a 360dp screen.
+                keySize = EditorToolbarDefaults.CompactKeySize,
+                onPickImages = onPickImages,
+                onCustomize = onCustomize,
                 trailing = {
                     PublishReplyButton(
                         isPublishing = state.isPublishing,
@@ -299,14 +301,6 @@ private fun ReplyEditorSheet(
                     )
                 },
             )
-            if (emojiOpen) {
-                EmojiPanel(
-                    onInsert = { text -> bodyState.edit { insertText(text) } },
-                    onBackspace = { bodyState.edit { deleteBackwards() } },
-                    recent = recentEmoji,
-                    onRecentChange = onRecentEmojiChange,
-                )
-            }
         }
     }
 }
@@ -556,16 +550,6 @@ private fun replyErrorReason(error: NodeSeekError, detail: String?): String = wh
 
 private fun formatTime(timestamp: Long): String =
     DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(timestamp))
-
-private val REPLY_ACTIONS = listOf(
-    EditorAction.BOLD,
-    EditorAction.CODE,
-    EditorAction.QUOTE,
-    EditorAction.MENTION,
-    EditorAction.IMAGE,
-    EditorAction.EMOJI,
-    EditorAction.PREVIEW,
-)
 
 private val MIN_EDITOR_HEIGHT = 96.dp
 private val MAX_EDITOR_HEIGHT = 260.dp

--- a/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposerViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/ReplyComposerViewModel.kt
@@ -22,6 +22,8 @@ import io.github.nodyssey.data.composer.ImageUploader
 import io.github.nodyssey.data.composer.PickedImage
 import io.github.nodyssey.data.composer.UploadFailure
 import io.github.nodyssey.data.composer.UploadStatus
+import io.github.nodyssey.data.settings.ComposerSurface
+import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.di.AppContainer
 import io.github.nodyssey.ui.common.appendBlock
 import io.github.nodyssey.ui.common.editFromViewModel
@@ -31,8 +33,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -58,6 +62,8 @@ class ReplyComposerViewModel(
     private val repository: CommentComposerRepository,
     private val clock: AppClock,
     uploader: ImageUploader,
+    /** Null in tests; the sheet then shows [EditorActions.Reply] and offers no wrench. */
+    private val settings: SettingsRepository? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ReplyComposerUiState(postId = postId))
     val uiState: StateFlow<ReplyComposerUiState> = _uiState.asStateFlow()
@@ -71,6 +77,12 @@ class ReplyComposerViewModel(
     private var publishJob: Job? = null
 
     init {
+        settings?.settings
+            ?.map { it.replyToolbarActions }
+            ?.distinctUntilChanged()
+            ?.onEach { stored ->
+                _uiState.update { it.copy(toolbar = toolbarLayout(stored, EditorActions.Reply)) }
+            }?.launchIn(viewModelScope)
         uploads.attachments
             .onEach { attachments -> _uiState.update { it.copy(attachments = attachments) } }
             .launchIn(viewModelScope)
@@ -189,6 +201,20 @@ class ReplyComposerViewModel(
         }
     }
 
+    /** Writes the strip through on every edit in the wrench panel; see `ToolbarCustomizeSheet`. */
+    fun setToolbar(actions: List<EditorAction>) {
+        val repository = settings ?: return
+        viewModelScope.launch {
+            repository.setComposerToolbar(ComposerSurface.REPLY, actions.map(EditorAction::name))
+        }
+    }
+
+    /** Clears the stored arrangement, which is what makes the defaults come back. */
+    fun resetToolbar() {
+        val repository = settings ?: return
+        viewModelScope.launch { repository.setComposerToolbar(ComposerSurface.REPLY, emptyList()) }
+    }
+
     companion object {
         private const val AUTOSAVE_DELAY_MILLIS = 750L
 
@@ -199,6 +225,7 @@ class ReplyComposerViewModel(
                     repository = container.commentComposerRepository,
                     clock = container.clock,
                     uploader = container.imageUploader,
+                    settings = container.settingsRepository,
                 )
             }
         }
@@ -217,6 +244,8 @@ data class ReplyComposerUiState(
     val publishError: NodeSeekError? = null,
     val publishErrorDetail: String? = null,
     val attachments: List<ImageAttachment> = emptyList(),
+    /** The formatting strip's keys and the wrench panel's pool. Defaults until settings arrive. */
+    val toolbar: ToolbarLayout = toolbarLayout(emptyList(), EditorActions.Reply),
 ) {
     val failedUploadCount: Int get() = attachments.count { it.status == UploadStatus.FAILED }
 

--- a/app/src/main/java/io/github/nodyssey/ui/composer/ToolbarCustomizeSheet.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/ToolbarCustomizeSheet.kt
@@ -1,0 +1,327 @@
+package io.github.nodyssey.ui.composer
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import io.github.nodyssey.R
+import io.github.nodyssey.ui.common.NodysseyIcons
+import io.github.nodyssey.ui.theme.Spacing
+import kotlin.math.roundToInt
+
+/**
+ * What the wrench opens: the strip's own contents, as a list you can rearrange.
+ *
+ * A sheet rather than a settings page, because it is reached mid-sentence. The post editor would
+ * survive a navigation — its draft autosaves — but the reply sheet would not: it *is* a sheet, and
+ * navigating away dismisses it along with whatever was half-typed.
+ *
+ * Every change writes through immediately, so there is no 保存 button and nothing to lose by
+ * swiping the sheet away. The strip underneath is already rearranged by the time it reappears.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ToolbarCustomizeSheet(
+    layout: ToolbarLayout,
+    onChange: (List<EditorAction>) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = Spacing.lg)
+                .padding(bottom = Spacing.xl),
+            // No blanket arrangement: the gap between two rows and the gap between a heading and the
+            // list under it are different distances, and one `spacedBy` for the whole sheet can only
+            // ever be right for one of them.
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(R.string.composer_toolbar_customize),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onReset) {
+                    Text(stringResource(R.string.composer_toolbar_reset))
+                }
+            }
+
+            SectionLabel(stringResource(R.string.composer_toolbar_enabled), top = Spacing.sm)
+            EnabledKeys(enabled = layout.enabled, onChange = onChange)
+
+            if (layout.available.isNotEmpty()) {
+                SectionLabel(stringResource(R.string.composer_toolbar_available), top = Spacing.xl)
+                Column(verticalArrangement = Arrangement.spacedBy(ROW_GAP)) {
+                    layout.available.forEach { action ->
+                        AvailableRow(
+                            action = action,
+                            onAdd = { onChange(layout.enabled + action) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(
+    text: String,
+    top: Dp,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = top, bottom = Spacing.sm),
+    )
+}
+
+/**
+ * The enabled keys, in strip order, draggable by the handle.
+ *
+ * A plain `Column` rather than a `LazyColumn`: there are at most as many rows as [EditorAction] has
+ * entries, they are all the same height, and that uniformity is what makes the drag arithmetic one
+ * division instead of a bounds lookup. The list also sits inside a scrolling sheet, where a lazy list
+ * would need a fixed height to measure at all.
+ */
+@Composable
+private fun EnabledKeys(
+    enabled: List<EditorAction>,
+    onChange: (List<EditorAction>) -> Unit,
+) {
+    val haptics = LocalHapticFeedback.current
+    // The slot, not the row: with a gap between them, one row of travel is one row plus one gap, and
+    // stepping by the row alone would make the list run ahead of the finger by a gap per swap.
+    val slotHeightPx = with(LocalDensity.current) { (ROW_HEIGHT + ROW_GAP).toPx() }
+    var draggedIndex by remember { mutableStateOf<Int?>(null) }
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+    val apply by rememberUpdatedState(onChange)
+    /*
+     * The order the gesture works on, and the order the rows draw from.
+     *
+     * A snapshot list rather than the caller's `enabled`, because a drag outruns composition. Several
+     * move events can arrive inside one frame, and each has to see the swap the one before it made —
+     * `rememberUpdatedState` would not, since it only refreshes when a recomposition happens to land
+     * between them, and closing over `enabled` or keying `pointerInput` on it is worse still: the
+     * first restarts the block and cancels the drag, the second rearranges the pre-drag order forever.
+     *
+     * Between gestures the caller is the authority again, which is what the effect below restores.
+     */
+    val order = remember { mutableStateListOf<EditorAction>().apply { addAll(enabled) } }
+    LaunchedEffect(enabled) {
+        if (order.toList() != enabled) {
+            order.clear()
+            order.addAll(enabled)
+        }
+    }
+
+    fun release() {
+        draggedIndex = null
+        dragOffset = 0f
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(ROW_GAP)) {
+        order.forEachIndexed { index, action ->
+            val dragging = index == draggedIndex
+            EnabledRow(
+                action = action,
+                // The last key never leaves: an empty strip reads back as "never customised" and
+                // would hand the defaults straight back on the next open. See `toolbarLayout`.
+                canRemove = order.size > MIN_TOOLBAR_KEYS,
+                dragging = dragging,
+                onRemove = {
+                    order.remove(action)
+                    apply(order.toList())
+                },
+                modifier = Modifier
+                    .zIndex(if (dragging) 1f else 0f)
+                    .offset { IntOffset(0, if (dragging) dragOffset.roundToInt() else 0) },
+                handle = {
+                    DragHandle(
+                        modifier = Modifier.pointerInput(Unit) {
+                            detectDragGestures(
+                                onDragStart = {
+                                    draggedIndex = index
+                                    dragOffset = 0f
+                                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                },
+                                onDragEnd = ::release,
+                                onDragCancel = ::release,
+                            ) { change, amount ->
+                                change.consume()
+                                val from = draggedIndex ?: return@detectDragGestures
+                                dragOffset += amount.y
+                                // One row of travel is one swap, and the offset gives that row back
+                                // so the dragged item stays under the finger rather than racing it.
+                                val steps = (dragOffset / slotHeightPx).roundToInt()
+                                if (steps == 0) return@detectDragGestures
+                                val to = (from + steps).coerceIn(0, order.lastIndex)
+                                if (to == from) return@detectDragGestures
+                                dragOffset -= (to - from) * slotHeightPx
+                                draggedIndex = to
+                                order.add(to, order.removeAt(from))
+                                apply(order.toList())
+                            }
+                        },
+                    )
+                },
+            )
+        }
+    }
+}
+
+/** The grab target. A slot rather than a modifier parameter, so the row stays a plain composable. */
+@Composable
+private fun DragHandle(modifier: Modifier = Modifier) {
+    val label = stringResource(R.string.composer_toolbar_reorder)
+    Icon(
+        imageVector = NodysseyIcons.DragHandle,
+        contentDescription = label,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.size(HANDLE_SIZE),
+    )
+}
+
+@Composable
+private fun EnabledRow(
+    action: EditorAction,
+    canRemove: Boolean,
+    dragging: Boolean,
+    onRemove: () -> Unit,
+    handle: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth().height(ROW_HEIGHT),
+        // `surface` was the bug behind "挤在一起": it is all but the sheet's own background, so with
+        // no gap either the rows fused into one slab. A container tone makes each one an object.
+        color = if (dragging) {
+            MaterialTheme.colorScheme.surfaceContainerHighest
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHigh
+        },
+        shape = MaterialTheme.shapes.medium,
+        shadowElevation = if (dragging) DRAG_ELEVATION else 0.dp,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+            modifier = Modifier.padding(start = Spacing.md, end = Spacing.sm),
+        ) {
+            handle()
+            Icon(
+                imageVector = action.icon,
+                contentDescription = null,
+                modifier = Modifier.size(KEY_ICON_SIZE),
+            )
+            Text(
+                text = stringResource(action.labelRes),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(
+                onClick = onRemove,
+                enabled = canRemove,
+                // Kept in place rather than hidden when it is the last key: a control that vanishes
+                // is a control the user goes looking for.
+                modifier = Modifier.alpha(if (canRemove) 1f else DISABLED_ALPHA),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.composer_toolbar_remove),
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AvailableRow(
+    action: EditorAction,
+    onAdd: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ROW_HEIGHT)
+            // Aligned with the enabled rows' icons, which sit past a 24dp handle and its gap.
+            // Aligned with the enabled rows' key icons, which sit past a handle and its gap — the two
+            // halves are the same list, so their glyphs have to share a column.
+            .padding(start = Spacing.md + HANDLE_SIZE + Spacing.md, end = Spacing.sm),
+    ) {
+        Icon(
+            imageVector = action.icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(KEY_ICON_SIZE),
+        )
+        Text(
+            text = stringResource(action.labelRes),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onAdd) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = stringResource(R.string.composer_toolbar_add),
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+private val ROW_HEIGHT = 56.dp
+
+/** Between rows, and therefore part of one drag step. See `slotHeightPx`. */
+private val ROW_GAP = Spacing.sm
+private val DRAG_ELEVATION = 6.dp
+private val HANDLE_SIZE = 24.dp
+private val KEY_ICON_SIZE = 22.dp
+private const val DISABLED_ALPHA = 0.38f

--- a/app/src/main/java/io/github/nodyssey/ui/composer/ToolbarLayout.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/composer/ToolbarLayout.kt
@@ -1,0 +1,49 @@
+package io.github.nodyssey.ui.composer
+
+/**
+ * The keys on the strip, and the keys the wrench panel offers to add.
+ *
+ * Two lists rather than one list plus a predicate, because that is what the panel draws: the enabled
+ * half in the order it will appear, the rest as a pool underneath.
+ */
+data class ToolbarLayout(
+    val enabled: List<EditorAction>,
+    val available: List<EditorAction>,
+)
+
+/**
+ * Reads a stored arrangement back into keys.
+ *
+ * Deliberately *not* the home strip's ranking model, despite the family resemblance. That one
+ * reconciles a saved order against a board list the server can change under it, so it has to carry
+ * ranks for boards that no longer exist and adopt boards it has never seen. Nothing here comes from a
+ * server: [EditorAction] is a closed set this app ships, so the stored value is simply the enabled
+ * keys in order and everything else is available.
+ *
+ * The two rules that remain are the ones any stored enum name needs:
+ *
+ * - A name that no longer parses is dropped. An action removed in a later version leaves behind
+ *   arrangements that mention it, and one of those must not empty somebody's toolbar.
+ * - An action the arrangement has never heard of lands in [ToolbarLayout.available], not on the
+ *   strip. A key added in a later version is an offer, not a change to a toolbar someone laid out.
+ *
+ * An empty [stored] means "never customised", so it yields [defaults] — which is safe only because
+ * the panel refuses to remove the last key. If emptying the strip were ever allowed, this would read
+ * it back as untouched and hand the defaults straight back.
+ */
+fun toolbarLayout(
+    stored: List<String>,
+    defaults: List<EditorAction>,
+): ToolbarLayout {
+    val byName = EditorAction.entries.associateBy(EditorAction::name)
+    val enabled = stored.mapNotNull(byName::get).distinct().ifEmpty { defaults }
+    return ToolbarLayout(
+        enabled = enabled,
+        // Enum order, not the order they were removed in: the pool is a catalogue, and a catalogue
+        // that reshuffles itself as you take things out of it is one you have to re-read every time.
+        available = EditorAction.entries.filterNot { it in enabled },
+    )
+}
+
+/** The strip always keeps one key. See [toolbarLayout] for what an empty arrangement would mean. */
+const val MIN_TOOLBAR_KEYS = 1

--- a/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadScreen.kt
@@ -1,5 +1,8 @@
 package io.github.nodyssey.ui.messages
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,7 +22,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
@@ -49,11 +51,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -68,11 +71,21 @@ import io.github.nodyssey.R
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.TimeFormat
 import io.github.nodyssey.core.net.NodeSeekError
+import io.github.nodyssey.data.composer.ImageAttachment
+import io.github.nodyssey.data.composer.PickedImage
+import io.github.nodyssey.ui.common.EditorTextField
 import io.github.nodyssey.ui.common.LoadingState
 import io.github.nodyssey.ui.common.NodeSeekErrorState
 import io.github.nodyssey.ui.common.NodysseyIcons
 import io.github.nodyssey.ui.common.UserAvatar
+import io.github.nodyssey.ui.composer.AttachmentTray
+import io.github.nodyssey.ui.composer.EditorAction
+import io.github.nodyssey.ui.composer.MarkdownEditorBar
+import io.github.nodyssey.ui.composer.MarkdownEditorState
+import io.github.nodyssey.ui.composer.ToolbarCustomizeSheet
 import io.github.nodyssey.ui.composer.parseMarkdown
+import io.github.nodyssey.ui.composer.rememberMarkdownEditorState
+import io.github.nodyssey.ui.composer.toPickedImages
 import io.github.nodyssey.ui.richtext.RichContent
 import io.github.nodyssey.ui.theme.NodysseyTheme
 import io.github.nodyssey.ui.theme.Spacing
@@ -101,6 +114,11 @@ fun MessageThreadRoute(
         onToggleMarkdown = viewModel::toggleMarkdown,
         onSend = viewModel::send,
         onRetrySend = viewModel::retry,
+        onPickImages = viewModel::addImages,
+        onRemoveAttachment = viewModel::removeAttachment,
+        onRetryAttachment = viewModel::retryUpload,
+        onToolbarChange = viewModel::setToolbar,
+        onToolbarReset = viewModel::resetToolbar,
         modifier = modifier,
     )
 }
@@ -119,11 +137,26 @@ fun MessageThreadScreen(
     onToggleMarkdown: () -> Unit,
     onSend: () -> Unit,
     onRetrySend: (String) -> Unit,
+    onPickImages: (List<PickedImage>) -> Unit,
+    onRemoveAttachment: (ImageAttachment) -> Unit,
+    onRetryAttachment: (ImageAttachment) -> Unit,
+    onToolbarChange: (List<EditorAction>) -> Unit,
+    onToolbarReset: () -> Unit,
     modifier: Modifier = Modifier,
     /** Bubble-content links. Separate from [onOpenBrowser] so our own URLs can stay in the app. */
     onLinkClick: (String) -> Unit = onOpenBrowser,
 ) {
     val webUrl = NodeSeekSite.BASE_URL + NodeSeekSite.messageThreadWebPath(state.uid)
+    val editorState = rememberMarkdownEditorState()
+    var customizing by rememberSaveable { mutableStateOf(false) }
+    // Turning MD off takes the strip away, and neither the panel nor the sheet it opened may be left
+    // behind on a bar that no longer has a key to close them.
+    LaunchedEffect(state.isMarkdown) {
+        if (!state.isMarkdown) {
+            editorState.closeEmoji()
+            customizing = false
+        }
+    }
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -190,14 +223,27 @@ fun MessageThreadScreen(
                     else -> MessageBubbles(state, onLinkClick, onRetrySend)
                 }
             }
-            MessageInputBar(
+            MessageComposer(
                 draftState = draftState,
-                isMarkdown = state.isMarkdown,
-                canSend = state.canSend,
+                state = state,
+                editorState = editorState,
                 onToggleMarkdown = onToggleMarkdown,
                 onSend = onSend,
+                onPickImages = onPickImages,
+                onRemoveAttachment = onRemoveAttachment,
+                onRetryAttachment = onRetryAttachment,
+                onCustomize = { customizing = true },
             )
         }
+    }
+
+    if (customizing) {
+        ToolbarCustomizeSheet(
+            layout = state.toolbar,
+            onChange = onToolbarChange,
+            onReset = onToolbarReset,
+            onDismiss = { customizing = false },
+        )
     }
 }
 
@@ -490,19 +536,19 @@ private fun MessageDraftField(
     isMarkdown: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val hint =
+    EditorTextField(
+        state = draftState,
+        hint =
         stringResource(
             if (isMarkdown) R.string.message_input_hint_markdown else R.string.message_input_hint_plain,
-        )
-    val textStyle =
-        MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface)
-    BasicTextField(
-        state = draftState,
+        ),
+        textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+        // One line of placeholder, elided: the pill is 44dp tall when empty and a wrapping hint
+        // would grow it before anything has been typed.
+        hintMaxLines = 1,
         lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = MAX_INPUT_LINES),
-        textStyle = textStyle,
-        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
         modifier = modifier,
-        decorator = { inner ->
+        container = { content ->
             Surface(
                 shape = RoundedCornerShape(INPUT_CONTROL_SIZE / 2),
                 color = MaterialTheme.colorScheme.surfaceContainerHigh,
@@ -514,20 +560,74 @@ private fun MessageDraftField(
                         .padding(horizontal = 14.dp, vertical = 10.dp),
                     contentAlignment = Alignment.CenterStart,
                 ) {
-                    if (draftState.text.isEmpty()) {
-                        Text(
-                            text = hint,
-                            style = textStyle,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    inner()
+                    content()
                 }
             }
         },
     )
+}
+
+/**
+ * The formatting strip, shown only while MD is on (7f + C6).
+ *
+ * Off, the server takes the text verbatim, and a toolbar that inserted `**` would be offering syntax
+ * that arrives as literal asterisks — so the strip is not disabled, it is absent, and the toggle is
+ * the one control that decides.
+ *
+ * The strip sits above the message bar rather than below it, and the emoji panel below: the panel
+ * stands in for the keyboard and belongs where the keyboard was, while the keys belong next to the
+ * text they format. [MarkdownEditorBar] emits them in that order around its content slot.
+ */
+@Composable
+private fun MessageComposer(
+    draftState: TextFieldState,
+    state: MessageThreadUiState,
+    editorState: MarkdownEditorState,
+    onToggleMarkdown: () -> Unit,
+    onSend: () -> Unit,
+    onPickImages: (List<PickedImage>) -> Unit,
+    onRemoveAttachment: (ImageAttachment) -> Unit,
+    onRetryAttachment: (ImageAttachment) -> Unit,
+    onCustomize: () -> Unit,
+) {
+    val context = LocalContext.current
+    val picker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickMultipleVisualMedia(MAX_IMAGES_PER_PICK),
+    ) { uris -> onPickImages(uris.toPickedImages(context)) }
+
+    val inputBar: @Composable () -> Unit = {
+        MessageInputBar(
+            draftState = draftState,
+            isMarkdown = state.isMarkdown,
+            canSend = state.canSend,
+            onToggleMarkdown = onToggleMarkdown,
+            onSend = onSend,
+        )
+    }
+
+    Column {
+        // Outside the MD branch: an upload started before the toggle was flipped is still running,
+        // and its cell is the only place the user can see that, or cancel it.
+        AttachmentTray(
+            attachments = state.attachments,
+            onRemove = onRemoveAttachment,
+            onRetry = onRetryAttachment,
+        )
+        if (state.isMarkdown) {
+            MarkdownEditorBar(
+                actions = state.toolbar.enabled,
+                bodyState = draftState,
+                editorState = editorState,
+                onPickImages = {
+                    picker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                },
+                onCustomize = onCustomize,
+                content = { inputBar() },
+            )
+        } else {
+            inputBar()
+        }
+    }
 }
 
 /**
@@ -590,6 +690,7 @@ private fun Modifier.wrapContentWidthTo(isMine: Boolean): Modifier =
 
 private const val BUBBLE_MAX_WIDTH = 0.78f
 private const val MAX_INPUT_LINES = 5
+private const val MAX_IMAGES_PER_PICK = 9
 
 /** One height for the MD toggle, the send key and the empty draft pill, so the bar reads as a row. */
 private val INPUT_CONTROL_SIZE = 44.dp
@@ -664,6 +765,11 @@ private fun MessageThreadPreview() {
             onToggleMarkdown = {},
             onSend = {},
             onRetrySend = {},
+            onPickImages = {},
+            onRemoveAttachment = {},
+            onRetryAttachment = {},
+            onToolbarChange = {},
+            onToolbarReset = {},
         )
     }
 }

--- a/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/messages/MessageThreadViewModel.kt
@@ -16,14 +16,30 @@ import io.github.nodyssey.data.DirectMessage
 import io.github.nodyssey.data.MessageRepository
 import io.github.nodyssey.data.NotificationCategory
 import io.github.nodyssey.data.NotificationRepository
+import io.github.nodyssey.data.composer.ImageAttachment
+import io.github.nodyssey.data.composer.ImageUploadQueue
+import io.github.nodyssey.data.composer.ImageUploader
+import io.github.nodyssey.data.composer.PickedImage
+import io.github.nodyssey.data.composer.UploadStatus
 import io.github.nodyssey.data.session.SessionRepository
+import io.github.nodyssey.data.settings.ComposerSurface
+import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.di.AppContainer
+import io.github.nodyssey.ui.common.appendBlock
+import io.github.nodyssey.ui.common.editFromViewModel
+import io.github.nodyssey.ui.common.removeBlock
+import io.github.nodyssey.ui.composer.EditorAction
+import io.github.nodyssey.ui.composer.EditorActions
+import io.github.nodyssey.ui.composer.ToolbarLayout
+import io.github.nodyssey.ui.composer.toolbarLayout
 import io.github.nodyssey.ui.postlist.toNodeSeekError
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -41,24 +57,80 @@ class MessageThreadViewModel(
     private val notifications: NotificationRepository,
     private val session: SessionRepository,
     private val clock: AppClock,
+    uploader: ImageUploader,
     uid: Long,
     userName: String,
+    /** Null in tests; the bar then shows [EditorActions.Message] and offers no wrench. */
+    private val settings: SettingsRepository? = null,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(MessageThreadUiState(uid = uid, userName = userName))
     val uiState: StateFlow<MessageThreadUiState> = _uiState.asStateFlow()
 
     /** The composer's text and selection, held here for the same reason the post editor's is. */
     val draftState = TextFieldState()
+
+    /**
+     * The same queue the two composers use, and the same NodeImage host behind it.
+     *
+     * There is nothing message-shaped about an image here: `message/send` carries one `content`
+     * string, so an image in a private message is `![](…)` spliced into that string exactly the way
+     * it is spliced into a topic's body.
+     */
+    private val uploads = ImageUploadQueue(viewModelScope, uploader)
     private var loadJob: Job? = null
     private var pendingSeed = 0L
 
     init {
         refresh()
-        // `canSend` is a property of the text, and the text lives in a state object the ViewModel
-        // cannot make a StateFlow out of — so the one derived bit it needs is mirrored across.
+        // The text lives in a state object the ViewModel cannot make a StateFlow out of, so the one
+        // derived bit it needs is mirrored across. Whether that is *enough* to send is the UiState's
+        // question, because an upload still in flight also has a say.
         snapshotFlow { draftState.text.isNotBlank() }
-            .onEach { canSend -> _uiState.update { it.copy(canSend = canSend) } }
+            .onEach { hasText -> _uiState.update { it.copy(hasDraftText = hasText) } }
             .launchIn(viewModelScope)
+        uploads.attachments
+            .onEach { attachments -> _uiState.update { it.copy(attachments = attachments) } }
+            .launchIn(viewModelScope)
+        // Appended rather than spliced at the caret: the upload lands while typing continues, and
+        // dropping `![](…)` mid-sentence is both surprising and hard to undo.
+        uploads.uploaded
+            .onEach { attachment ->
+                val markdown = attachment.markdown ?: return@onEach
+                draftState.editFromViewModel { appendBlock(markdown) }
+            }.launchIn(viewModelScope)
+        settings?.settings
+            ?.map { it.messageToolbarActions }
+            ?.distinctUntilChanged()
+            ?.onEach { stored ->
+                _uiState.update { it.copy(toolbar = toolbarLayout(stored, EditorActions.Message)) }
+            }?.launchIn(viewModelScope)
+    }
+
+    fun addImages(images: List<PickedImage>) = uploads.enqueue(images)
+
+    fun retryUpload(attachment: ImageAttachment) = uploads.retry(attachment.id)
+
+    fun retryFailedUploads() = uploads.retryFailed()
+
+    /** Dismissing a finished upload also takes its Markdown out of the draft it was written into. */
+    fun removeAttachment(attachment: ImageAttachment) {
+        val removed = uploads.remove(attachment.id) ?: return
+        val markdown = removed.markdown ?: return
+        draftState.editFromViewModel { removeBlock(markdown) }
+    }
+
+    /** Writes the strip through on every edit in the wrench panel; see `ToolbarCustomizeSheet`. */
+    fun setToolbar(actions: List<EditorAction>) {
+        val repository = settings ?: return
+        viewModelScope.launch {
+            repository.setComposerToolbar(ComposerSurface.MESSAGE, actions.map(EditorAction::name))
+        }
+    }
+
+    /** Clears the stored arrangement, which is what makes the defaults come back. */
+    fun resetToolbar() {
+        val repository = settings ?: return
+        viewModelScope.launch { repository.setComposerToolbar(ComposerSurface.MESSAGE, emptyList()) }
     }
 
     fun refresh() {
@@ -131,6 +203,9 @@ class MessageThreadViewModel(
                 status = SendStatus.SENDING,
             )
         draftState.clearText()
+        // The Markdown went out inside `content`; the queue's cells were only ever the progress
+        // report for getting it there, and leaving them up would attach them to the next message.
+        uploads.clear()
         _uiState.update {
             it.copy(messages = it.messages + bubble, nowMillis = clock.nowMillis())
         }
@@ -208,8 +283,10 @@ class MessageThreadViewModel(
                         notifications = container.notificationRepository,
                         session = container.sessionRepository,
                         clock = container.clock,
+                        uploader = container.imageUploader,
                         uid = uid,
                         userName = userName,
+                        settings = container.settingsRepository,
                     )
                 }
             }
@@ -244,8 +321,21 @@ data class MessageThreadUiState(
     val isLoading: Boolean = false,
     val error: NodeSeekError? = null,
     /** Mirrored out of [MessageThreadViewModel.draftState]; the text itself is not UiState. */
-    val canSend: Boolean = false,
+    val hasDraftText: Boolean = false,
+    val attachments: List<ImageAttachment> = emptyList(),
     /** The site's own MD On/Off switch; off sends the text verbatim. */
     val isMarkdown: Boolean = true,
+    /** The formatting strip's keys and the wrench panel's pool. Defaults until settings arrive. */
+    val toolbar: ToolbarLayout = toolbarLayout(emptyList(), EditorActions.Message),
     val nowMillis: Long = 0L,
-)
+) {
+    /**
+     * Sending an image that has not finished uploading would send its placeholder.
+     *
+     * The same guard the two composers put on 发布, for the same reason: the Markdown carries a URL
+     * the upload has not produced yet, and a message is gone the moment it is sent.
+     */
+    val canSend: Boolean
+        get() = hasDraftText &&
+            attachments.none { it.status == UploadStatus.UPLOADING || it.status == UploadStatus.WAITING }
+}

--- a/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
@@ -180,6 +180,8 @@ fun PostDetailRoute(
         onRetryFailedUploads = replyViewModel::retryFailedUploads,
         onPublish = { replyViewModel.publish { viewModel.refresh() } },
         onClearError = replyViewModel::clearPublishError,
+        onToolbarChange = replyViewModel::setToolbar,
+        onToolbarReset = replyViewModel::resetToolbar,
     )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,8 +61,6 @@
     <string name="post_edited">已编辑</string>
 
     <!-- Post composer -->
-    <string name="composer_title">新建帖子</string>
-    <string name="composer_preview_title">预览</string>
     <string name="composer_title_hint">一句话说清主题</string>
     <string name="composer_body_hint">写下正文，支持 Markdown…</string>
     <string name="composer_title_count">%1$d/%2$d</string>
@@ -88,6 +86,8 @@
     <string name="composer_publish_http">服务器返回 HTTP %1$d</string>
     <string name="composer_publish_unknown">请稍后重试</string>
     <string name="composer_format_bold">加粗</string>
+    <string name="composer_format_italic">斜体</string>
+    <string name="composer_format_strikethrough">删除线</string>
     <string name="composer_format_heading">二级标题</string>
     <string name="composer_format_code">行内代码</string>
     <string name="composer_format_quote">引用</string>
@@ -96,6 +96,14 @@
     <string name="composer_format_mention">提到某人</string>
     <string name="composer_format_image">图片</string>
     <string name="composer_format_emoji">表情</string>
+    <!-- The wrench at the end of the two composers' strips, and the panel it opens -->
+    <string name="composer_toolbar_customize">自定义工具栏</string>
+    <string name="composer_toolbar_enabled">工具栏上的按键</string>
+    <string name="composer_toolbar_available">可添加</string>
+    <string name="composer_toolbar_reorder">拖动排序</string>
+    <string name="composer_toolbar_remove">移出工具栏</string>
+    <string name="composer_toolbar_add">加入工具栏</string>
+    <string name="composer_toolbar_reset">恢复默认</string>
     <string name="composer_preview_empty">正文预览会显示在这里</string>
     <string name="composer_just_now">刚刚</string>
     <string name="composer_view_content">内容</string>
@@ -373,11 +381,6 @@
     <string name="account_bio_hint">请用一句话介绍自己</string>
     <string name="account_signature_helper">帖子内容下显示 · 支持 Markdown · 不支持图片和引用</string>
     <string name="account_readme_helper">用户主页中显示 · 支持 Markdown</string>
-    <string name="account_format_bold">加粗</string>
-    <string name="account_format_italic">斜体</string>
-    <string name="account_format_strikethrough">删除线</string>
-    <string name="account_format_link">链接</string>
-    <string name="account_format_code">行内代码</string>
 
     <!-- 安全 (d6 2/4) -->
     <string name="account_security_title">安全</string>

--- a/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerScreenTest.kt
@@ -48,6 +48,8 @@ class PostComposerScreenTest {
                     onPublish = {},
                     onContinueDraft = {},
                     onDiscardDraft = {},
+                    onToolbarChange = {},
+                    onToolbarReset = {},
                 )
             }
         }

--- a/app/src/test/java/io/github/nodyssey/ui/composer/ReplyComposerScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/ReplyComposerScreenTest.kt
@@ -1,0 +1,114 @@
+package io.github.nodyssey.ui.composer
+
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import io.github.nodyssey.ui.theme.NodysseyTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The reply sheet's editor chrome (6d / C6).
+ *
+ * This is the surface the toolbar geometry was decided on: it is the only one that keeps 发布 pinned
+ * inside the strip, so it is the only one where the keys and the trailing button compete for the same
+ * 360dp. The size and the no-scroll claim are asserted here rather than in a comment, because both
+ * silently stop being true the moment an action is added to the list.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class ReplyComposerScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun setSheet(state: ReplyComposerUiState) {
+        composeRule.setContent {
+            NodysseyTheme {
+                ReplyComposerHost(
+                    state = state,
+                    onDismiss = {},
+                    bodyState = rememberTextFieldState(state.body),
+                    onClearQuote = {},
+                    onPreviewChange = {},
+                    onPickImages = {},
+                    onRemoveAttachment = {},
+                    onRetryAttachment = {},
+                    onRetryFailedUploads = {},
+                    onPublish = {},
+                    onClearError = {},
+                    onToolbarChange = {},
+                    onToolbarReset = {},
+                )
+            }
+        }
+    }
+
+    private fun draft() =
+        ReplyComposerUiState(
+            postId = 1L,
+            visible = true,
+            body = "确实是学计算机的，不过这个项目只有架构是自己定的。",
+        )
+
+    @Test
+    fun `every formatting key fits beside the pinned publish button`() {
+        setSheet(draft())
+
+        listOf("加粗", "行内代码", "引用", "提到某人", "图片", "表情").forEach { key ->
+            composeRule.onNodeWithContentDescription(key).assertIsDisplayed()
+        }
+        composeRule.onNodeWithText("发布").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the keys are the compact size the sheet was measured for`() {
+        setSheet(draft())
+
+        // 42dp, not the 48dp every other strip gets: see EditorToolbarDefaults.CompactKeySize.
+        composeRule.onNodeWithContentDescription("加粗").assertWidthIsEqualTo(42.dp)
+        composeRule.onNodeWithContentDescription("表情").assertWidthIsEqualTo(42.dp)
+    }
+
+    @Test
+    fun `the wrench rides at the end of the keys, not in the pinned slot`() {
+        setSheet(draft())
+
+        // Reachable, but only by scrolling past the six formatting keys — 发布 keeps the one pinned
+        // slot, and the wrench is the key nobody reaches for mid-sentence.
+        composeRule.onNodeWithContentDescription("自定义工具栏").assertExists()
+    }
+
+    @Test
+    fun `the strip shows the stored arrangement rather than the defaults`() {
+        setSheet(
+            draft().copy(
+                toolbar = toolbarLayout(listOf("EMOJI", "BOLD"), EditorActions.Reply),
+            ),
+        )
+
+        composeRule.onNodeWithContentDescription("表情").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("加粗").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("引用").assertDoesNotExist()
+    }
+
+    @Test
+    fun `preview is chrome, not a formatting key`() {
+        setSheet(draft())
+
+        // In the sheet's own header row, beside 草稿已保存 and the close button, which makes it a
+        // plain `IconButton` — 40dp in Material 3 1.5, the same box the ✕ next to it gets — rather
+        // than one of the strip's 42dp keys. Header buttons are spaced, so their 48dp minimum touch
+        // targets have room to expand into; the strip's abutting keys do not.
+        composeRule.onNodeWithContentDescription("预览").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("预览").assertWidthIsEqualTo(40.dp)
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/ui/composer/ToolbarCustomizeSheetTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/ToolbarCustomizeSheetTest.kt
@@ -1,0 +1,108 @@
+package io.github.nodyssey.ui.composer
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import io.github.nodyssey.ui.theme.NodysseyTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/** The wrench panel: what it offers, and that a drag survives its own reordering. */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class ToolbarCustomizeSheetTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var enabled: List<EditorAction>
+    private var resets = 0
+
+    private fun setSheet(start: List<EditorAction>) {
+        enabled = start
+        composeRule.setContent {
+            var keys by remember { mutableStateOf(start) }
+            NodysseyTheme {
+                ToolbarCustomizeSheet(
+                    layout = ToolbarLayout(
+                        enabled = keys,
+                        available = EditorAction.entries.filterNot { it in keys },
+                    ),
+                    onChange = {
+                        keys = it
+                        enabled = it
+                    },
+                    onReset = { resets++ },
+                    onDismiss = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the pool holds everything the strip does not`() {
+        setSheet(listOf(EditorAction.BOLD, EditorAction.CODE))
+
+        composeRule.onNodeWithText("工具栏上的按键").assertIsDisplayed()
+        composeRule.onNodeWithText("可添加").assertIsDisplayed()
+        // 斜体 is in neither composer's defaults, so the pool is where it can be found at all.
+        composeRule.onNodeWithText("斜体").assertIsDisplayed()
+    }
+
+    @Test
+    fun `adding a key puts it at the end of the strip`() {
+        setSheet(listOf(EditorAction.BOLD, EditorAction.CODE))
+
+        composeRule.onAllNodesWithContentDescription("加入工具栏")[0].performClick()
+
+        assertEquals(3, enabled.size)
+        assertEquals(listOf(EditorAction.BOLD, EditorAction.CODE), enabled.take(2))
+    }
+
+    @Test
+    fun `the last key cannot be removed`() {
+        setSheet(listOf(EditorAction.BOLD))
+
+        composeRule.onNodeWithContentDescription("移出工具栏").performClick()
+
+        // An empty arrangement reads back as "never customised" and would restore the defaults.
+        assertEquals(listOf(EditorAction.BOLD), enabled)
+    }
+
+    @Test
+    fun `a drag keeps going after the swap that rewrites the list`() {
+        setSheet(listOf(EditorAction.BOLD, EditorAction.CODE, EditorAction.QUOTE, EditorAction.LINK))
+
+        // Two rows down in one gesture. The second step is the one that used to be lost: the first
+        // swap replaces the list the handler was given, and a handler bound to that list would
+        // either be cancelled or reorder the stale copy.
+        composeRule.onAllNodesWithContentDescription("拖动排序")[0].performTouchInput {
+            down(center)
+            moveBy(Offset(0f, ROW_SLOT_PX))
+            moveBy(Offset(0f, ROW_SLOT_PX))
+            up()
+        }
+
+        assertEquals(
+            listOf(EditorAction.CODE, EditorAction.QUOTE, EditorAction.BOLD, EditorAction.LINK),
+            enabled,
+        )
+    }
+}
+
+/** One slot — row plus gap — at the test's default density of 1, matching `ToolbarCustomizeSheet`. */
+private const val ROW_SLOT_PX = 64f

--- a/app/src/test/java/io/github/nodyssey/ui/composer/ToolbarLayoutTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/ToolbarLayoutTest.kt
@@ -1,0 +1,62 @@
+package io.github.nodyssey.ui.composer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The stored-arrangement rules from [toolbarLayout], which are the ones a version bump breaks. */
+class ToolbarLayoutTest {
+    @Test
+    fun `an untouched arrangement is the surface's own defaults`() {
+        val layout = toolbarLayout(emptyList(), EditorActions.Reply)
+
+        assertEquals(EditorActions.Reply, layout.enabled)
+        assertTrue(EditorAction.LIST in layout.available)
+    }
+
+    @Test
+    fun `a stored arrangement keeps the order it was saved in`() {
+        val stored = listOf("EMOJI", "BOLD", "LINK")
+
+        assertEquals(
+            listOf(EditorAction.EMOJI, EditorAction.BOLD, EditorAction.LINK),
+            toolbarLayout(stored, EditorActions.Post).enabled,
+        )
+    }
+
+    @Test
+    fun `a name this version no longer has is dropped, not fatal`() {
+        // What an action removed in a later release leaves behind in everyone's stored strip.
+        val layout = toolbarLayout(listOf("BOLD", "BLINK", "CODE"), EditorActions.Post)
+
+        assertEquals(listOf(EditorAction.BOLD, EditorAction.CODE), layout.enabled)
+    }
+
+    @Test
+    fun `an arrangement of nothing but junk falls back rather than emptying the strip`() {
+        assertEquals(EditorActions.Post, toolbarLayout(listOf("BLINK"), EditorActions.Post).enabled)
+    }
+
+    @Test
+    fun `a key this version has just added is offered, never silently enabled`() {
+        // Standing in for the next release's new action: a key the stored arrangement predates.
+        val layout = toolbarLayout(listOf("BOLD", "CODE"), EditorActions.Post)
+
+        assertTrue(EditorAction.STRIKETHROUGH in layout.available)
+        assertTrue(EditorAction.STRIKETHROUGH !in layout.enabled)
+    }
+
+    @Test
+    fun `the pool is the catalogue order, not the order things left the strip`() {
+        val layout = toolbarLayout(listOf("EMOJI"), EditorActions.Post)
+
+        assertEquals(EditorAction.entries.filterNot { it == EditorAction.EMOJI }, layout.available)
+    }
+
+    @Test
+    fun `a duplicated name cannot put the same key on the strip twice`() {
+        val layout = toolbarLayout(listOf("BOLD", "BOLD", "CODE"), EditorActions.Post)
+
+        assertEquals(listOf(EditorAction.BOLD, EditorAction.CODE), layout.enabled)
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/ui/messages/MessageComposerTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/messages/MessageComposerTest.kt
@@ -1,0 +1,181 @@
+package io.github.nodyssey.ui.messages
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import io.github.nodyssey.data.composer.ImageAttachment
+import io.github.nodyssey.data.composer.UploadStatus
+import io.github.nodyssey.ui.composer.EditorAction
+import io.github.nodyssey.ui.composer.EditorActions
+import io.github.nodyssey.ui.composer.toolbarLayout
+import io.github.nodyssey.ui.theme.NodysseyTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The message bar's half of the shared editor (7f).
+ *
+ * The MD toggle is the whole contract here: with it off the server takes the text verbatim, so a
+ * formatting key would insert syntax that arrives as literal asterisks. The strip is therefore absent
+ * rather than disabled, and these tests are what keep it that way.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class MessageComposerTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var draftState: TextFieldState
+
+    private fun setScreen(
+        draft: String = "",
+        markdown: Boolean = true,
+    ) {
+        composeRule.setContent {
+            var isMarkdown by remember { mutableStateOf(markdown) }
+            draftState = remember { TextFieldState(draft) }
+            NodysseyTheme {
+                MessageThreadScreen(
+                    state =
+                    MessageThreadUiState(
+                        uid = 4471,
+                        userName = "iwil",
+                        isMarkdown = isMarkdown,
+                        hasDraftText = draft.isNotBlank(),
+                        messages =
+                        listOf(
+                            MessageBubble(
+                                id = "1",
+                                isMine = false,
+                                content = "在的",
+                                isMarkdown = true,
+                                sentAtMillis = 1_785_000_000_000L,
+                                sentAtText = null,
+                                status = SendStatus.SENT,
+                            ),
+                        ),
+                    ),
+                    draftState = draftState,
+                    onBack = {},
+                    onSignIn = {},
+                    onVerify = {},
+                    onOpenBrowser = {},
+                    onRetryLoad = {},
+                    onToggleMarkdown = { isMarkdown = !isMarkdown },
+                    onSend = {},
+                    onRetrySend = {},
+                    onPickImages = {},
+                    onRemoveAttachment = {},
+                    onRetryAttachment = {},
+                    onToolbarChange = {},
+                    onToolbarReset = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the formatting strip is the same one the post editor uses`() {
+        setScreen()
+
+        composeRule.onNodeWithContentDescription("加粗").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("行内代码").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("链接").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("表情").assertIsDisplayed()
+    }
+
+    @Test
+    fun `four keys at the full 48dp, and no preview`() {
+        setScreen()
+
+        composeRule.onNodeWithContentDescription("加粗").assertWidthIsEqualTo(48.dp)
+        // A message renders into a bubble the moment it is sent; getting it wrong costs a second
+        // message, not a deleted topic. The thread's top bar belongs to the conversation, not to
+        // this draft, so there is nowhere for a preview to live and nothing much for it to do.
+        composeRule.onNodeWithContentDescription("预览").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the strip is arrangeable here too`() {
+        setScreen()
+
+        composeRule.onNodeWithContentDescription("自定义工具栏").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the image key is on offer, because private messages carry images`() {
+        setScreen()
+
+        // `message/send` takes `content` as Markdown and the thread renders images out of it, so an
+        // image here is the same NodeImage upload spliced into the same kind of string as a topic's.
+        assertTrue(EditorAction.IMAGE in defaultLayout().available)
+    }
+
+    @Test
+    fun `an upload still in flight holds the send key`() {
+        setScreen(draft = "看这个")
+        composeRule.waitForIdle()
+
+        // Sending now would send `![](…)` with a URL the upload has not produced yet.
+        assertFalse(
+            MessageThreadUiState(
+                uid = 1,
+                userName = "iwil",
+                hasDraftText = true,
+                attachments = listOf(
+                    ImageAttachment("1", "content://a", "a.png", UploadStatus.UPLOADING),
+                ),
+            ).canSend,
+        )
+    }
+
+    private fun defaultLayout() = toolbarLayout(emptyList(), EditorActions.Message)
+
+    @Test
+    fun `turning MD off takes the strip away rather than disabling it`() {
+        setScreen()
+
+        composeRule.onNodeWithContentDescription("Markdown 开关").performClick()
+
+        composeRule.onNodeWithContentDescription("加粗").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("表情").assertDoesNotExist()
+    }
+
+    @Test
+    fun `a formatting key wraps the draft and selects what it wrapped`() {
+        setScreen()
+
+        composeRule.onNodeWithContentDescription("加粗").performClick()
+
+        assertEquals("**加粗文字**", draftState.text.toString())
+        // Selected, not merely inserted: the next keystroke has to replace the placeholder.
+        assertEquals("加粗文字", draftState.text.substring(draftState.selection.min, draftState.selection.max))
+    }
+
+    @Test
+    fun `the emoji panel opens on the message bar too`() {
+        setScreen()
+
+        composeRule.onNodeWithContentDescription("表情").performClick()
+
+        composeRule.onNodeWithText("AC娘").assertIsDisplayed()
+        composeRule.onNodeWithText("最近使用").assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/ui/messages/MessageThreadViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/messages/MessageThreadViewModelTest.kt
@@ -12,6 +12,7 @@ import io.github.nodyssey.data.DirectMessage
 import io.github.nodyssey.data.MessageRepository
 import io.github.nodyssey.data.MessageThread
 import io.github.nodyssey.data.NotificationRepository
+import io.github.nodyssey.data.composer.ImageUploader
 import io.github.nodyssey.data.session.SessionRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -151,6 +152,7 @@ class MessageThreadViewModelTest {
         notifications = notifications,
         session = SessionRepository(WebViewCookieJar(cookieManager)),
         clock = AppClock { NOW },
+        uploader = ImageUploader { _, _ -> "https://cdn.nodeimage.com/i/x.webp" },
         uid = 4471,
         userName = "iwil",
     )


### PR DESCRIPTION
起因是一条用户反馈：「按钮布局都不太合理，用起来不顺手…在手机上我都不太想点那蚂蚁一样的功能按钮」。

## 键小是结果，不是原因

发帖把「内容/预览/对照」三格视图开关塞在了工具栏里，七个格子被占掉三个，剩下的只能缩到 32dp。视图切换改变的是整屏显示什么，跟加粗改变光标处文本不是一类东西——它连同回帖的预览一起搬进了各自的 chrome：

| | 之前 | 现在 |
|---|---|---|
| 发帖 | 工具栏尾部三格开关 | 顶栏（顶掉了「新建帖子」这个多余标题） |
| 回帖 | 工具栏里一个眼睛键 | sheet 标题行 |
| 私信 | 工具栏里一个眼睛键 | 撤掉（一句话的消息，发出去立刻能在气泡里看到） |

「对照」保留了——有人就喜欢上面打字下面看。发帖顶栏的返回箭头随之取消：开关常驻之后，点「内容」就是退出预览的路，关闭键在任何模式下都只是关闭。

腾出来的格子让键长到 **48dp**（Material 最小触摸目标，原来 32dp 是不达标的）。回帖是唯一例外 42dp：它把「发布」钉在条尾，六个 48dp 键加那颗按钮要 392dp，屏幕只有 360dp。备选是让工具栏横滑，但横滑永远先藏最后一个键，代价集中砸在一个键上，不如摊成每个键少 6dp。

## 可自定义

扳手在**滚动区末尾**而不是钉住——它是唯一没人写到一半会去按的键，正适合放在需要滑一下才够到的地方，何况回帖只有一个钉住的位置且归发布。点开是从底部弹出的面板而不是跳转设置页：回帖本身就是 sheet，跳走会连同半句话一起消失。每次改动直接落盘，没有保存按钮。

三套配置独立（发帖 / 回帖 / 私信）。发帖默认要列表和链接，回帖要引用和 @，一套共享配置必须从某一边的默认里踢掉一个才能存在。

**没有复用首页板块那套排名模型**——那套是为「服务端列表会变、排名里有已消失的板块、也可能有排名没见过的新板块」设计的容错，`EditorAction` 是本 app 自己的封闭枚举，用不上。留下的只有两条任何存枚举名的地方都需要的规则：解析不出的名字丢掉；配置没见过的动作进「可添加」而不是自动上栏。空配置意味着从没自定义过，这条只在面板不允许删掉最后一个键时才成立，所以那个约束是硬的。

## 私信补齐

MD 开关打开时浮出工具栏（关掉是整条消失而不是禁用——服务端原样收文本，插 `**` 只会变成字面星号），表情面板出现在输入栏下方顶掉键盘的位置，图片走 `ImageUploadQueue` → NodeImage，跟发帖同一条路径。

私信确实支持图片，站点实测过：`message/send` 只有 `receiverUid`/`content`/`markdown` 三个字段，图片从来不是附件而是插进正文的 `![](url)`，气泡渲染本来就传了 `onImageClick`。

**顺带修的 bug**：`canSend` 原来只看正文非空。图片进来后这是真问题——上传没完就点发送，会把地址还没生成的 `![](…)` 发出去，而消息发出去收不回。改成计算属性，有 `UPLOADING`/`WAITING` 的附件时压住发送键，跟发帖的 `canPublish` 同一条守卫。

## 顺带收掉的散落实现

- 四份 `BasicTextField` + 占位骨架 → `EditorTextField`
- 两份表情面板状态机 → `MarkdownEditorBar`
- 签名编辑器手搓的那排 `IconButton` → 共享 `EditorToolbar`（为此加了 `FormatItalic`/`StrikethroughS` 两个图标，删了重复的 `account_format_*` 五条 string）

## 行为变化（需要 reviewer 留意）

1. **签名编辑器的光标行为变了**。原来点「加粗」光标落在占位符**前面**，接着打字会得到「你的字加粗文字」，占位符留在原地。旧注释把这记成刻意为之，它是 bug。现在跟发帖一样选中占位符。
2. **表情面板打开时返回键先关面板**，再按才退出屏幕。三处统一，以前是直接退屏。
3. 发帖顶栏不再有返回箭头（见上）。

## 拖拽排序踩的两层坑

`pointerInput` 拿列表当 key，每换一位就重启手势块，拖一下就断。改用 `rememberUpdatedState` 后仍然错——一次拖动能在同一帧内来好几个 move 事件，中间没有重组，读到的还是旧列表。最终让一个 `mutableStateListOf` 在拖动期间当权威（快照写入对同一协程后续的读立即可见，不依赖帧），手势之间再交回调用方。

面板样式也修了一轮：可排序那半漏了 `verticalArrangement`，行贴在一起糊成一块；行底色用的 `surface` 跟 sheet 背景几乎同色。补成 8dp 间距 + `surfaceContainerHigh`。有了间距，拖动的一步随之从「一个行高」变成「一个槽位」（行高+间距），否则列表每换一位就比手指快 8dp。

## 测试

新增 4 个测试文件，全套 `testDebugUnitTest` + `lintDebug` 通过。

- `ToolbarLayoutTest` — 废弃名丢弃、纯垃圾回退默认、新键只进池子、重名去重、池子按枚举序
- `ToolbarCustomizeSheetTest` — 池子内容、加键落尾、最后一个键删不掉、**一次拖两格不断**（这条在前两版实现下都是红的）
- `ReplyComposerScreenTest` — 六键与发布同屏不横滑、键宽 42dp、预览是 chrome（40dp `IconButton` 而非条上的键）
- `MessageComposerTest` — 工具栏跟 MD 开关联动、格式键包裹并选中、表情面板、扳手在位、上传中压住发送

## ⚠️ 未做真机验证

这批改动**一行都没在真机上跑过**。尤其：

- 私信的图片上传是**新接的链路**（`ImageUploadQueue` 是现成的，但接进私信是新的）
- 扳手面板的拖拽只有 Robolectric 合成手势验证过
- 面板的间距/行高是按数值改的，没看过渲染结果

合并前建议先 `./gradlew installDebug` 过一遍这三处。

🤖 Generated with [Claude Code](https://claude.com/claude-code)