### PR TITLE
两个列表测试整类挂掉：一个 Snackbar 卡死了全 JVM 的 Compose 调度器

### DIFF
--- a/app/src/main/java/io/github/nodyssey/NodysseyApp.kt
+++ b/app/src/main/java/io/github/nodyssey/NodysseyApp.kt
@@ -23,7 +23,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
-class NodysseyApp :
+// Open only so the unit tests can install a subclass carrying Robolectric's teardown hook; see
+// RobolectricApp in the test sources. Nothing in the app subclasses this.
+open class NodysseyApp :
     Application(),
     SingletonImageLoader.Factory,
     Configuration.Provider {

--- a/app/src/test/java/io/github/nodyssey/RobolectricApp.kt
+++ b/app/src/test/java/io/github/nodyssey/RobolectricApp.kt
@@ -1,0 +1,42 @@
+package io.github.nodyssey
+
+import android.os.Looper
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.TestLifecycleApplication
+import java.lang.reflect.Method
+
+/**
+ * [NodysseyApp] plus one teardown chore, installed for every Robolectric test by
+ * `robolectric.properties`. The application under test is otherwise unchanged — this only adds the
+ * hook, which is why it subclasses rather than replaces.
+ *
+ * The chore is draining the main looper, and it exists because two Compose singletons outlive a
+ * Robolectric test while the looper under them does not. `AndroidUiDispatcher.Main` is built once
+ * per JVM, and `GlobalSnapshotManager` runs its snapshot-draining coroutine on it, also once per
+ * JVM. A test that ends with that coroutine resumed but not yet run leaves the dispatcher holding
+ * `scheduledTrampolineDispatch = true` and a callback posted to the main looper; Robolectric then
+ * discards that queue, so the callback never runs and the flag never clears. From then on every
+ * `dispatch` on it only appends to a queue nobody drains, for the rest of the suite. Idling here
+ * runs the stranded callback while its looper is still alive, which is the whole fix.
+ *
+ * Nothing notices a dead dispatcher, because the Compose test rule drives its own clock and never
+ * needs that one — except Paging. `LazyPagingItems` hands `AndroidUiDispatcher.Main` to its
+ * `PagingDataPresenter` as the context it presents on, so once it is wedged a list receives neither
+ * its items nor its load states, and every assertion about either fails. That is `PostListScreenTest`
+ * and `LedgerScreensTest` failing wholesale because of a class that ran before them — the class that
+ * wedges it is never the one that fails, which is why this is fixed here and not in a test.
+ *
+ * It also has to be this late. An `@After` runs before the Compose rule disposes the composition,
+ * and disposal is when the last dispatch is posted.
+ */
+class RobolectricApp :
+    NodysseyApp(),
+    TestLifecycleApplication {
+    override fun beforeTest(method: Method?) = Unit
+
+    override fun prepareTest(test: Any?) = Unit
+
+    override fun afterTest(method: Method?) {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -3,3 +3,7 @@
 # Pinned rather than tracking compileSdk: the framework jar is downloaded per SDK level, and letting
 # it float would mean a compileSdk bump silently changes what the tests execute against.
 sdk=35
+
+# The manifest's NodysseyApp plus a teardown hook, so that one test cannot wedge a Compose
+# singleton for every test after it. RobolectricApp explains what and why.
+application=io.github.nodyssey.RobolectricApp


### PR DESCRIPTION
## 症状

`PostListScreenTest` 16 个、`LedgerScreensTest` 5 个，单跑全绿，跟全套一起跑就全挂，报的都是「某段文字没显示」。这两个是全套里仅有的、用手搓 `PagingData` 驱动的 Robolectric 屏幕测试。

**在本机反复跑 `--rerun-tasks` 是复现不出来的**：Gradle 按类全名字母序跑，`ui.settings.AboutCommunityScreenTest` 恰好排在两个受害类**后面**。得自己指定顺序跑才碰得到。

## 根因

肇事的是 `AboutCommunityScreenTest` 里点「复制 RSS 地址」那个方法——它结束时屏幕上还留着一个 Snackbar。

漏的既不是主调度器也不是 Robolectric 的 looper，而是 `AndroidUiDispatcher.Main` 这个每 JVM 一份的 Compose 单例：

1. Compose 的 `GlobalSnapshotManager` 把那条排空快照的协程跑在它上面，同样每 JVM 一份。
2. 测试收场时协程刚被 resume 还没跑，dispatcher 就带着 `scheduledTrampolineDispatch = true` 和一条 posted 到主 looper 的 callback 结束。
3. Robolectric 随后把那条队列丢掉，callback 永远不执行，flag 也就永远不清零。而 `dispatch()` 只在 flag 为 false 时才补发 callback —— **此后每次 dispatch 都只是往一个没人排空的队列里塞东西**，这个调度器对 JVM 剩下的测试已经死了。

探针实测：

```
跑之前：scheduledTrampolineDispatch=false  队列=0  任务能跑完
跑之后：scheduledTrampolineDispatch=true   队列=1  任务再也不执行
        卡住的是 GlobalSnapshotManager$ensureStarted$1
```

别的 Compose 测试察觉不到，因为测试规则自己驱动时钟，压根不需要这个调度器。**只有 Paging 需要**：`LazyPagingItems` 正是把 `AndroidUiDispatcher.Main` 交给 `PagingDataPresenter` 当呈现上下文，卡死之后列表既拿不到 items 也拿不到 load state —— 所以连错误态的断言都一起挂，不只是行断言。

## 改法

新增 `RobolectricApp`，通过 `robolectric.properties` 的 `application=` 对所有 Robolectric 测试生效，在 `afterTest` 里 idle 主 looper，趁 looper 还活着把卡住的 callback 跑掉。它继承 `NodysseyApp` 而不是替换，被测应用行为不变。

**几个需要 reviewer 知道的取舍：**

- **为什么修在中心而不是改那一个测试** —— 卡死调度器的类从来不是失败的类。只改 `AboutCommunityScreenTest` 的话，下一个留着动画收场的测试照样能再捅一遍，而报错还是出在毫不相干的列表测试上。
- **为什么不能用 `@After`** —— `@After` 早于 Compose 规则销毁 composition，而最后一次 dispatch 正是销毁时发出的。实测过，无效。
- **为什么不用 `forkEvery`** —— 能盖住，但盖的是症状。
- **`NodysseyApp` 加了个 `open`** —— 这是唯一的生产代码改动，只为让测试能挂上这个钩子。

顺带修了 `ReplyComposerScreenTest` 的编译错（`onClearQuote` 早已改名 `onClearReplyTo`），不然整套根本编译不过。

CHANGELOG 没动 —— 那份只记用户可见的变化。

## 验证

同样的随机种子，改前改后各跑一遍：

| 顺序 | 无这个 hook | 有这个 hook |
|---|---|---|
| 3 个打乱的全量顺序 | 各 21 个失败（16 + 5） | 0 |
| 12 个打乱的全量顺序 | — | 663 个测试，0 失败 |
| Gradle `--rerun-tasks` | — | 5 轮，663/0 |

`spotlessCheck`、`:app:lintDebug` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
