### PR TITLE
设置页关于行显示真实版本号

### DIFF
--- a/app/src/main/java/io/github/nodyssey/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/settings/SettingsScreen.kt
@@ -221,7 +221,7 @@ fun SettingsScreen(
                     title = stringResource(R.string.settings_about_app),
                     subtitle = state.updateVersionName
                         ?.let { stringResource(R.string.settings_about_app_update, it) }
-                        ?: stringResource(R.string.settings_version),
+                        ?: stringResource(R.string.settings_version, state.versionName),
                     top = true,
                     onClick = onOpenAbout,
                     leading = { Icon(Icons.Default.Info, contentDescription = null) },
@@ -293,7 +293,7 @@ private fun bodySizeToFontScale(bodySize: Float): Float =
 private fun SettingsPreview() {
     NodysseyTheme {
         SettingsScreen(
-            state = SettingsUiState(),
+            state = SettingsUiState(versionName = "1.1.1"),
             onBack = {},
             onThemeModeChange = {},
             onFontScaleChange = {},

--- a/app/src/main/java/io/github/nodyssey/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import io.github.nodyssey.core.AppVersion
 import io.github.nodyssey.data.PostRepository
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.nodyssey.data.settings.ExternalLinkTarget
@@ -25,14 +26,18 @@ class SettingsViewModel(
     private val posts: PostRepository,
     private val session: SessionRepository,
     updates: AppUpdateRepository,
+    appVersion: AppVersion,
 ) : ViewModel() {
     private val clearingCache = MutableStateFlow(false)
+
+    private val versionName = appVersion.name.ifBlank { "—" }
 
     val uiState: StateFlow<SettingsUiState> =
         combine(settings.settings, clearingCache, updates.state) { values, clearing, update ->
             SettingsUiState(
                 settings = values,
                 isClearingCache = clearing,
+                versionName = versionName,
                 // Read off the shared updater rather than checked here: the answer is already in
                 // memory by the time this screen opens, and 我的 shows the same dot from the same
                 // state.
@@ -41,7 +46,7 @@ class SettingsViewModel(
         }.stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = SettingsUiState(),
+            initialValue = SettingsUiState(versionName = versionName),
         )
 
     fun setThemeMode(value: ThemeMode) {
@@ -82,6 +87,7 @@ class SettingsViewModel(
                         posts = container.postRepository,
                         session = container.sessionRepository,
                         updates = container.appUpdateRepository,
+                        appVersion = container.appVersion,
                     )
                 }
             }
@@ -91,6 +97,8 @@ class SettingsViewModel(
 data class SettingsUiState(
     val settings: UserSettings = UserSettings(),
     val isClearingCache: Boolean = false,
+    /** The installed build's own version, as `PackageManager` reports it. */
+    val versionName: String = "—",
     /** The newer version on GitHub, or null when there is none to offer. */
     val updateVersionName: String? = null,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,7 +278,7 @@
     <string name="settings_clear_cache">清除缓存</string>
     <string name="settings_about">关于</string>
     <string name="settings_about_app">关于 Nodyssey</string>
-    <string name="settings_version">v1.0</string>
+    <string name="settings_version">v%1$s</string>
     <string name="settings_licenses">开源许可</string>
 
     <!-- About & community (board f1). -->

--- a/app/src/test/java/io/github/nodyssey/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/settings/SettingsScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsSelected
@@ -13,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipe
 import io.github.nodyssey.data.settings.ThemeMode
@@ -178,5 +180,44 @@ class SettingsScreenTest {
 
         composeRule.waitForIdle()
         assertTrue(appliedScale != null)
+    }
+
+    @Test
+    fun `about row states the installed version`() {
+        composeRule.setContent {
+            NodysseyTheme {
+                SettingsScreen(
+                    state = SettingsUiState(versionName = "9.9.9"),
+                    onBack = {},
+                    onThemeModeChange = {},
+                    onFontScaleChange = {},
+                    onImagesOnWifiOnlyChange = {},
+                    onExternalLinkTargetChange = {},
+                    onClearCache = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("v9.9.9").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `about row gives up the version line to the update offer`() {
+        composeRule.setContent {
+            NodysseyTheme {
+                SettingsScreen(
+                    state = SettingsUiState(versionName = "9.9.9", updateVersionName = "10.0.0"),
+                    onBack = {},
+                    onThemeModeChange = {},
+                    onFontScaleChange = {},
+                    onImagesOnWifiOnlyChange = {},
+                    onExternalLinkTargetChange = {},
+                    onClearCache = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("发现新版本 10.0.0").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("v9.9.9").assertDoesNotExist()
     }
 }


### PR DESCRIPTION
## 问题

设置页「关于 Nodyssey」那行的副标题读的是 `settings_version`，而这条字符串是写死的 `v1.0`，跟实际安装的版本（现在 1.1.1）没有关系。只有检测到新版本时那行才会被「发现新版本 X」顶掉，所以平常看到的永远是 `v1.0`。

## 改动

- `settings_version` 改成带占位符的 `v%1$s`。
- `SettingsViewModel` 注入 `container.appVersion`（与关于页同一来源，走 `PackageManager` 读已安装版本），`SettingsUiState` 新增 `versionName`；读不出来时和关于页一致退化成 `—`。
- `SettingsScreen` 用 `state.versionName` 格式化副标题；有新版本时仍显示「发现新版本 X」+ 红点，这部分行为未改。
- 补两个 Robolectric 测试：装的是 9.9.9 时该行显示 `v9.9.9`；有更新时让位给更新提示。

## 验证

`testDebugUnitTest`（SettingsScreenTest）、`spotlessCheck`、`lintDebug` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)