### PR TITLE
「我的」不再每次进入都重查签到状态

### DIFF
--- a/app/src/main/java/io/github/nodyssey/data/AssetsRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/AssetsRepository.kt
@@ -62,9 +62,15 @@ data class AttendanceResult(
     val message: String?,
 )
 
-/** The signed-in account's attendance receipt for the current NodeSeek calendar day. */
+/**
+ * The signed-in account's attendance receipt for one NodeSeek calendar day.
+ *
+ * [date] is that day in the site's zone, and it is what makes the receipt cacheable: without it a
+ * "已签到" read from yesterday is indistinguishable from one taken a minute ago.
+ */
 data class AttendanceStatus(
     val uid: Long,
+    val date: LocalDate,
     val hasSignedIn: Boolean,
     val gain: Int? = null,
 )
@@ -94,7 +100,14 @@ interface AssetsRepository {
 
     suspend fun growth(): GrowthSnapshot
 
-    /** Checks the account's own ledger without performing the sign-in write. */
+    /**
+     * Checks the account's own ledger without performing the sign-in write.
+     *
+     * A "已签到" receipt already held for today is returned as-is rather than re-read: signing in is
+     * one-way within a NodeSeek day, so that answer cannot go stale before the date rolls over, and
+     * re-reading it costs up to ten ledger pages. An unsigned day is always re-checked — that one
+     * can change from anywhere, including the site itself.
+     */
     suspend fun refreshAttendanceStatus(uid: Long): AttendanceStatus
 
     suspend fun signInForToday(mode: AttendanceMode): AttendanceResult
@@ -191,7 +204,12 @@ class NetworkAssetsRepository(
         val gain = attendanceRecordToday() ?: attendanceGainToday()
         profileRepository.selfUid?.let { uid ->
             attendanceStatus.value =
-                AttendanceStatus(uid = uid, hasSignedIn = gain != null, gain = gain)
+                AttendanceStatus(
+                    uid = uid,
+                    date = clock.nowMillis().toDate(),
+                    hasSignedIn = gain != null,
+                    gain = gain,
+                )
         }
         return if (gain != null) {
             DailyQuota(used = gain, total = gain)
@@ -259,6 +277,7 @@ class NetworkAssetsRepository(
             attendanceStatus.value =
                 AttendanceStatus(
                     uid = uid,
+                    date = clock.nowMillis().toDate(),
                     hasSignedIn = true,
                     gain = resolvedGain,
                 )
@@ -267,9 +286,14 @@ class NetworkAssetsRepository(
     }
 
     override suspend fun refreshAttendanceStatus(uid: Long): AttendanceStatus {
+        val today = clock.nowMillis().toDate()
+        attendanceStatus.value?.let { cached ->
+            if (cached.uid == uid && cached.date == today && cached.hasSignedIn) return cached
+        }
         val gain = attendanceGainToday()
         return AttendanceStatus(
             uid = uid,
+            date = today,
             hasSignedIn = gain != null,
             gain = gain,
         ).also { attendanceStatus.value = it }

--- a/app/src/main/java/io/github/nodyssey/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/profile/ProfileScreen.kt
@@ -34,7 +34,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,7 +49,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nodyssey.R
 import io.github.nodyssey.core.net.NodeSeekError
@@ -82,9 +85,7 @@ fun ProfileRoute(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
-        viewModel.refreshAttendance()
-    }
+    RefreshOnReturnToForeground(viewModel::refreshAttendance)
     ProfileScreen(
         state = state,
         onSignIn = onSignIn,
@@ -104,6 +105,32 @@ fun ProfileRoute(
         onTools = onTools,
         modifier = modifier,
     )
+}
+
+/**
+ * Runs [onForeground] when the app comes back to the foreground — and only then.
+ *
+ * `LifecycleEventEffect(ON_RESUME)` would not do: this entry has no lifecycle of its own (the tabs
+ * share the activity's), and `LifecycleRegistry` replays the up-events an already-resumed owner has
+ * passed to every observer that joins late. Since 我的 leaves composition on each tab switch and
+ * re-enters on the way back, that replay made "returning to the tab" indistinguishable from
+ * "returning to the app", and fired the callback on every visit. The replayed event is dropped here;
+ * the real transitions after it are the ones worth reacting to.
+ */
+@Composable
+internal fun RefreshOnReturnToForeground(onForeground: () -> Unit) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val currentOnForeground by rememberUpdatedState(onForeground)
+    DisposableEffect(lifecycleOwner) {
+        var replay = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event != Lifecycle.Event.ON_RESUME) return@LifecycleEventObserver
+                if (replay) replay = false else currentOnForeground()
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 }
 
 @Composable
@@ -173,7 +200,7 @@ fun ProfileScreen(
             item(key = "attendance") {
                 Button(
                     onClick = if (state.hasSignedInToday) onAttendanceBoard else onAttendance,
-                    enabled = !state.isCheckingAttendance,
+                    enabled = !state.isAttendanceUnknown,
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(24.dp),
                     colors =
@@ -184,7 +211,7 @@ fun ProfileScreen(
                     },
                 ) {
                     when {
-                        state.isCheckingAttendance -> {
+                        state.isAttendanceUnknown -> {
                             CircularProgressIndicator(Modifier.size(18.dp))
                             Text(
                                 stringResource(R.string.profile_attendance_checking),

--- a/app/src/main/java/io/github/nodyssey/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/profile/ProfileViewModel.kt
@@ -105,6 +105,8 @@ class ProfileViewModel(
                             error = current.error,
                             isCheckingAttendance =
                             current.isCheckingAttendance.takeIf { current.uid == profile.uid } ?: false,
+                            attendanceKnown =
+                            current.attendanceKnown.takeIf { current.uid == profile.uid } ?: false,
                             hasSignedInToday =
                             current.hasSignedInToday.takeIf { current.uid == profile.uid } ?: false,
                             attendanceGain =
@@ -135,6 +137,7 @@ class ProfileViewModel(
                     _uiState.update { current ->
                         profile.toUiState().copy(
                             isCheckingAttendance = current.isCheckingAttendance,
+                            attendanceKnown = current.attendanceKnown,
                             hasSignedInToday = current.hasSignedInToday,
                             attendanceGain = current.attendanceGain,
                             boardOpen = current.boardOpen,
@@ -177,6 +180,7 @@ class ProfileViewModel(
             } else {
                 current.copy(
                     isCheckingAttendance = false,
+                    attendanceKnown = true,
                     hasSignedInToday = status.hasSignedIn,
                     attendanceGain = status.gain,
                 )
@@ -280,6 +284,8 @@ data class ProfileUiState(
     val chickenCount: Int? = null,
     val starCount: Int? = null,
     val isCheckingAttendance: Boolean = false,
+    /** Whether today's receipt has been read at least once; a re-check never un-answers it. */
+    val attendanceKnown: Boolean = false,
     val hasSignedInToday: Boolean = false,
     val attendanceGain: Int? = null,
     val boardOpen: Boolean = false,
@@ -289,6 +295,15 @@ data class ProfileUiState(
 ) {
     val hasProfile: Boolean
         get() = uid != null && displayName.isNotBlank()
+
+    /**
+     * Whether the sign-in button has nothing to show yet.
+     *
+     * Only this may put the button into its spinner: a check running over an answer we already have
+     * is a background refresh, and regressing 已签到 to 检查中… on every visit was the bug.
+     */
+    val isAttendanceUnknown: Boolean
+        get() = isCheckingAttendance && !attendanceKnown
 }
 
 private val REGISTERED_YEAR_MONTH = Regex("""^(\d{4})-(\d{2})""")

--- a/app/src/test/java/io/github/nodyssey/data/AssetsRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/AssetsRepositoryTest.kt
@@ -29,12 +29,13 @@ class AssetsRepositoryTest {
     private fun repository(
         source: JsonSource,
         profiles: ProfileRepository = UnusedProfileRepository,
+        clock: AppClock = AppClock { MIDNIGHT_2025_07_29 },
     ) = NetworkAssetsRepository(
         profiles,
         NetworkCreditRepository(source, dispatchers),
         source,
         dispatchers,
-        AppClock { 1_753_718_400_000L }, // 2025-07-29T00:00:00+08:00
+        clock,
     )
 
     private fun growthRepository(source: JsonSource) = repository(source, FakeProfileRepository)
@@ -266,6 +267,65 @@ class AssetsRepositoryTest {
 
             assertEquals(DailyQuota(0, 20), growth.attendanceQuota)
         }
+
+    /**
+     * 我的 re-checks the receipt whenever it comes back to the foreground, and the check costs up to
+     * ten ledger pages. Signing in is one-way within a NodeSeek day, so once today's answer is "已签到"
+     * there is nothing left to learn from asking again.
+     */
+    @Test
+    fun `answers a known sign-in from the cache instead of re-reading the ledger`() =
+        runTest {
+            val source =
+                FakeCreditJsonSource(
+                    """{"success":true,"data":[[7,344,"签到收益7个鸡腿","2025-07-28T16:30:00.000Z"]]}""",
+                )
+            val repository = repository(source)
+
+            repository.refreshAttendanceStatus(uid = 31037)
+            val status = repository.refreshAttendanceStatus(uid = 31037)
+
+            assertEquals(1, source.requestCount)
+            assertEquals(true, status.hasSignedIn)
+            assertEquals(7, status.gain)
+        }
+
+    /** The other direction is not one-way: the account can sign in from the site at any point. */
+    @Test
+    fun `keeps re-reading the ledger while the day is still unsigned`() =
+        runTest {
+            val source = FakeCreditJsonSource("""{"success":true,"data":[]}""")
+            val repository = repository(source)
+
+            repository.refreshAttendanceStatus(uid = 31037)
+            repository.refreshAttendanceStatus(uid = 31037)
+
+            assertEquals(2, source.requestCount)
+        }
+
+    @Test
+    fun `re-reads the ledger once the NodeSeek day has rolled over`() =
+        runTest {
+            val source =
+                FakeCreditJsonSource(
+                    """{"success":true,"data":[[7,344,"签到收益7个鸡腿","2025-07-28T16:30:00.000Z"]]}""",
+                )
+            var now = MIDNIGHT_2025_07_29
+            val repository = repository(source, clock = AppClock { now })
+
+            repository.refreshAttendanceStatus(uid = 31037)
+            now += ONE_DAY_MILLIS
+            val status = repository.refreshAttendanceStatus(uid = 31037)
+
+            assertEquals(2, source.requestCount)
+            // Yesterday's row is not today's receipt, whatever the cache was holding.
+            assertEquals(false, status.hasSignedIn)
+        }
+
+    private companion object {
+        const val MIDNIGHT_2025_07_29 = 1_753_718_400_000L // 2025-07-29T00:00:00+08:00
+        const val ONE_DAY_MILLIS = 86_400_000L
+    }
 }
 
 /** Answers per path, because [NetworkAssetsRepository.growth] reads three different endpoints. */
@@ -286,9 +346,12 @@ private class FakeCreditJsonSource(
 ) : JsonSource {
     var requestedPath: String? = null
         private set
+    var requestCount = 0
+        private set
 
     override suspend fun getJson(path: String, referer: String): String {
         requestedPath = path
+        requestCount++
         return body
     }
 

--- a/app/src/test/java/io/github/nodyssey/ui/profile/ProfileScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/profile/ProfileScreenTest.kt
@@ -1,13 +1,22 @@
 package io.github.nodyssey.ui.profile
 
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import io.github.nodyssey.data.AttendanceBoardEntry
 import io.github.nodyssey.ui.theme.NodysseyTheme
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -280,4 +289,58 @@ class ProfileScreenTest {
         composeRule.onNodeWithText("缭雾").assertIsDisplayed()
         composeRule.onNodeWithText("+7").assertIsDisplayed()
     }
+
+    /**
+     * 我的 shares the activity's lifecycle and re-enters composition on every tab switch, so an
+     * observer that joins an already-resumed owner is handed a replayed ON_RESUME. Reacting to that
+     * one is what re-checked the sign-in on every visit.
+     */
+    @Test
+    fun `foreground effect ignores the resume replayed to a late observer`() {
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        var refreshes = 0
+        var attached by mutableStateOf(true)
+        composeRule.setContent {
+            CompositionLocalProvider(LocalLifecycleOwner provides owner) {
+                if (attached) RefreshOnReturnToForeground { refreshes++ }
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertEquals(0, refreshes)
+
+        // Leaving 我的 for another tab and coming back: a second late observer, a second replay.
+        attached = false
+        composeRule.waitForIdle()
+        attached = true
+        composeRule.waitForIdle()
+
+        assertEquals(0, refreshes)
+    }
+
+    @Test
+    fun `foreground effect reacts to a real return to the foreground`() {
+        val owner = FakeLifecycleOwner()
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        var refreshes = 0
+        composeRule.setContent {
+            CompositionLocalProvider(LocalLifecycleOwner provides owner) {
+                RefreshOnReturnToForeground { refreshes++ }
+            }
+        }
+        composeRule.waitForIdle()
+
+        owner.registry.currentState = Lifecycle.State.CREATED
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        composeRule.waitForIdle()
+
+        assertEquals(1, refreshes)
+    }
+}
+
+private class FakeLifecycleOwner : LifecycleOwner {
+    val registry = LifecycleRegistry(this)
+
+    override val lifecycle: Lifecycle get() = registry
 }

--- a/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
@@ -41,6 +41,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.time.LocalDate
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -180,6 +181,41 @@ class ProfileViewModelTest {
         }
 
     @Test
+    fun `keeps today's receipt on screen while a re-check runs`() =
+        runTest(dispatcher) {
+            val assets = FakeAssetsRepository(gain = 7)
+            val viewModel =
+                ProfileViewModel(
+                    session = SessionRepository(WebViewCookieJar(cookieManager)),
+                    postRepository = NoOpPostRepository,
+                    profileRepository =
+                    FakeProfileRepository(
+                        UserProfile(
+                            uid = 31037,
+                            name = "缭雾",
+                            avatarUrl = "https://www.nodeseek.com/avatar/31037.png",
+                        ),
+                    ),
+                    assetsRepository = assets,
+                )
+            advanceUntilIdle()
+
+            // What returning to the foreground does. The button must not fall back to 检查中… — the
+            // answer it is already showing stays true until the ledger says otherwise.
+            viewModel.refreshAttendance()
+            runCurrent()
+
+            assertFalse(viewModel.uiState.value.isAttendanceUnknown)
+            assertEquals(true, viewModel.uiState.value.hasSignedInToday)
+            assertEquals(7, viewModel.uiState.value.attendanceGain)
+
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isAttendanceUnknown)
+            assertEquals(7, viewModel.uiState.value.attendanceGain)
+        }
+
+    @Test
     fun `opens attendance board in the profile state without navigation`() =
         runTest(dispatcher) {
             val entries =
@@ -221,21 +257,30 @@ private class FakeAssetsRepository(
     private val board: List<AttendanceBoardEntry> = emptyList(),
 ) : AssetsRepository {
     private val status = MutableStateFlow<AttendanceStatus?>(null)
+    var refreshCount = 0
+        private set
 
     override fun observeAttendanceStatus(): StateFlow<AttendanceStatus?> = status
 
     override suspend fun growth(): GrowthSnapshot = error("Not used")
 
-    override suspend fun refreshAttendanceStatus(uid: Long): AttendanceStatus =
-        AttendanceStatus(
+    override suspend fun refreshAttendanceStatus(uid: Long): AttendanceStatus {
+        refreshCount++
+        return AttendanceStatus(
             uid = uid,
+            date = TODAY,
             hasSignedIn = gain != null,
             gain = gain,
         ).also { status.value = it }
+    }
 
     override suspend fun signInForToday(mode: AttendanceMode): AttendanceResult = error("Not used")
 
     override suspend fun attendanceBoard(page: Int): List<AttendanceBoardEntry> = board
+
+    private companion object {
+        val TODAY: LocalDate = LocalDate.of(2026, 8, 2)
+    }
 }
 
 private class FakeProfileRepository(


### PR DESCRIPTION
## 问题

「我的」里的签到按钮每次进入页面都会退回成禁用的转圈「检查中…」，并重新翻一遍积分流水（`attendanceGainToday()` 最多 10 页）。看起来像状态一直在自己刷新。

三个原因叠在一起：

1. `ProfileRoute` 的 `LifecycleEventEffect(ON_RESUME)` 本意是「回到前台时重查」，但这条 NavEntry 没有自己的生命周期——`Navigation.kt` 的 entryDecorators 只挂了 saveable state 和 ViewModelStore，没有 lifecycle decorator，`LocalLifecycleOwner` 是 Activity 的。而 `LifecycleRegistry` 会把已经过去的上行事件补发给迟到的观察者。「我的」在每次切 tab 时退出组合、返回时重新进入，于是「回到这个 tab」和「回到 App」变得无法区分。
2. `refreshAttendanceStatus` 没有任何缓存，每次都真的去翻流水。
3. `refreshAttendance` 无条件先置 `isCheckingAttendance = true`，明明内存里已有确定答案，UI 却先退化再恢复。

## 改动

**仓库层** — `AttendanceStatus` 带上站点时区（Asia/Shanghai）的日历日，`refreshAttendanceStatus` 命中「同一 uid、同一天、且已签到」的缓存时直接返回。签到在一个 NodeSeek 日内是单向的，这个答案在跨天之前不会变。未签到仍然每次重查——那个方向能从站点那边改。

**UI 状态** — `ProfileUiState` 新增 `attendanceKnown`，派生出 `isAttendanceUnknown = isCheckingAttendance && !attendanceKnown`。按钮的 spinner 和 `enabled` 都改用它，只有一次都没查到过时才转圈；已有答案之后的重查是静默的。

**生命周期** — `LifecycleEventEffect` 换成 `RefreshOnReturnToForeground`：挂观察者前先看 owner 是否已经 RESUMED，是就吞掉那条补发的 `ON_RESUME`，只对之后真实的前后台切换做出反应。

## 为什么这样不会漏状态

- App 内原生签到走 `signInForToday`，本来就会写共享的 `attendanceStatus`，ProfileViewModel 通过 `observeAttendanceStatus()` 收到。
- 「访问网站」是打开外部浏览器 → App 进后台 → 回来时是真实 ON_RESUME → 重查。
- 跨天由 `date` 判断，缓存不会永久生效。

## 测试

新增 5 个：

- `AssetsRepositoryTest`：缓存命中不再请求 / 未签到仍然重查 / 跨天重查并给出「未签到」。
- `ProfileViewModelTest`：重查期间 `isAttendanceUnknown` 保持 false，已签到和 gain 不回退。
- `ProfileScreenTest`：补发的 `ON_RESUME`（含二次进出组合，模拟切 tab 往返）不触发回调；真实的 `CREATED → RESUMED` 触发一次。第一个在旧实现下会得到 1 而不是 0，所以它钉的确实是这次的修复。

`spotlessCheck`、`:app:testDebugUnitTest`（全量）、`:app:lintDebug` 全绿。

## Reviewer 需要知道的

真机验证没跑成：手机连着但处于锁屏状态，解锁密码不该由我输。上面的生命周期语义是用 Compose 测试钉的，不是靠手动观察。

🤖 Generated with [Claude Code](https://claude.com/claude-code)