### PR TITLE
修好联系方式屏：不再误报人机验证，Telegram 绑定/解绑走通

### DIFF
--- a/app/src/main/java/io/github/nodyssey/Navigation.kt
+++ b/app/src/main/java/io/github/nodyssey/Navigation.kt
@@ -636,9 +636,20 @@ fun MainNavigation(
                 ContactRoute(
                     viewModel = viewModel,
                     onBack = { backStack.removeLastOrNull() },
-                    // The bind link belongs to Telegram (t.me / tg://), so it leaves the app for
-                    // whatever owns the scheme — the Telegram app, or the browser's web version.
-                    // Never the in-app web view, whose cookie jar is for nodeseek.com only.
+                    // 修改邮箱 and 绑定 Telegram are errands on nodeseek.com's own settings page, so
+                    // they go to the web view that shares the app's session. A Custom Tab would hand
+                    // them to the browser's cookie jar, where the account is not signed in.
+                    onOpenSite = { url, forBinding ->
+                        backStack.add(
+                            WebKey(
+                                url,
+                                siteTitle,
+                                if (forBinding) WebViewGoal.TELEGRAM_BIND else WebViewGoal.MANAGE,
+                            ),
+                        )
+                    },
+                    // 打开 Bot 会话 is Telegram's own link, and belongs to whatever owns the scheme —
+                    // the Telegram app, or the browser's web version. Never the in-app web view.
                     onOpenUrl = { url -> runCatching { uriHandler.openUri(url) } },
                 )
             }
@@ -807,6 +818,13 @@ fun MainNavigation(
                     userAgent = container.userAgent,
                     onOpenExternal = openExternalUrl,
                     onClose = { backStack.removeLastOrNull() },
+                    // A failed poll means "not yet", never "give up": the page is still open and the
+                    // user is still working, so a hiccup on one request must not end the watch.
+                    isBound = {
+                        runCatchingExceptCancellation {
+                            container.accountSettingsRepository.telegramBinding().bound
+                        }.getOrDefault(false)
+                    },
                 )
             }
         }

--- a/app/src/main/java/io/github/nodyssey/Navigation.kt
+++ b/app/src/main/java/io/github/nodyssey/Navigation.kt
@@ -648,9 +648,6 @@ fun MainNavigation(
                             ),
                         )
                     },
-                    // 打开 Bot 会话 is Telegram's own link, and belongs to whatever owns the scheme —
-                    // the Telegram app, or the browser's web version. Never the in-app web view.
-                    onOpenUrl = { url -> runCatching { uriHandler.openUri(url) } },
                 )
             }
 

--- a/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
+++ b/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
@@ -307,10 +307,24 @@ object NodeSeekSite {
     }
 
     /** Only these URLs may execute JavaScript inside the authenticated WebView. */
-    fun isTrustedWebViewUrl(url: String): Boolean =
+    fun isTrustedWebViewUrl(url: String): Boolean = isHttpsHost(url, TRUSTED_WEBVIEW_HOSTS)
+
+    /**
+     * Telegram's own authorisation host, the one 绑定 Telegram detours through.
+     *
+     * 联系方式's bind button is the site handing the user to `oauth.telegram.org`, which sends them
+     * back to `/setting` with the widget's result. Both halves have to happen in the same web view:
+     * the return leg is what writes `telegram_id` onto the account, and it only counts if it arrives
+     * with the NodeSeek session — which lives in this app's cookie jar, not the browser's. Kept apart
+     * from [isTrustedWebViewUrl] because sign-in and Cloudflare challenges have no business leaving
+     * nodeseek.com; see the caller in `WebViewRoute`, which admits this host for 管理 pages only.
+     */
+    fun isTelegramOAuthUrl(url: String): Boolean = isHttpsHost(url, TELEGRAM_OAUTH_HOSTS)
+
+    private fun isHttpsHost(url: String, hosts: Set<String>): Boolean =
         parseWebUri(url)?.let { uri ->
             uri.scheme.equals("https", ignoreCase = true) &&
-                uri.host?.lowercase() in TRUSTED_WEBVIEW_HOSTS &&
+                uri.host?.lowercase() in hosts &&
                 (uri.port == -1 || uri.port == 443)
         } == true
 
@@ -332,6 +346,7 @@ object NodeSeekSite {
     private val POST_PATH = Regex("""/post-(\d+)(?:-(\d+))?""")
     private val SPACE_PATH = Regex("""/space/(\d+)""")
     private val TRUSTED_WEBVIEW_HOSTS = setOf("www.nodeseek.com", "nodeseek.com")
+    private val TELEGRAM_OAUTH_HOSTS = setOf("oauth.telegram.org")
 
     /** Extracts the post id (and page, when present) from `/post-703863-2`. */
     fun parsePostRoute(href: String?): PostRoute? {

--- a/app/src/main/java/io/github/nodyssey/core/html/Selectors.kt
+++ b/app/src/main/java/io/github/nodyssey/core/html/Selectors.kt
@@ -57,13 +57,24 @@ object Selectors {
 
     // --- Page-level state ---------------------------------------------------
 
-    /** Markers that prove we received a real NodeSeek page rather than an interstitial. */
+    /**
+     * Markers that prove we received a real NodeSeek page rather than an interstitial.
+     *
+     * The bootstrap is on this list because Cloudflare inlines its `/cdn-cgi/challenge-platform/`
+     * script into *every* page it serves us, challenge or not — measured on device 2026-08-02, where
+     * the home feed and `/setting` came back 200 with `cf-mitigated` empty and both carrying that
+     * script. The four content markers are what saved the forum pages. `/setting` has none of them:
+     * it is server-rendered without `nsk-body` and its account fields (email, `telegram_id`) live
+     * only in the bootstrap, so 联系方式 read every good response as a challenge until this line
+     * existed. An interstitial is served *instead of* the site and so never carries the bootstrap.
+     */
     val USABLE_PAGE_MARKERS = listOf(
         "id=\"nsk-body\"",
         "class=\"post-list\"",
         "class=\"nsk-post\"",
         "class=\"post-content\"",
         "class=\"comments\"",
+        "id=\"temp-script\"",
     )
 
     val LOGIN_REQUIRED_MARKERS = listOf("需要注册用户才能查看", "权限不足")

--- a/app/src/main/java/io/github/nodyssey/ui/account/ContactScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/account/ContactScreen.kt
@@ -58,7 +58,6 @@ fun ContactRoute(
     onBack: () -> Unit,
     /** The URL, and whether this trip is the Telegram bind — which knows when it is finished. */
     onOpenSite: (String, Boolean) -> Unit,
-    onOpenUrl: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -106,7 +105,6 @@ fun ContactRoute(
         onRequestUnbind = viewModel::requestUnbind,
         onDismissUnbind = viewModel::dismissUnbind,
         onConfirmUnbind = viewModel::confirmUnbind,
-        onOpenBotChat = { onOpenUrl(TELEGRAM_BOT_CHAT_URL) },
         modifier = modifier,
     )
 }
@@ -137,7 +135,6 @@ fun ContactScreen(
     onRequestUnbind: () -> Unit,
     onDismissUnbind: () -> Unit,
     onConfirmUnbind: () -> Unit,
-    onOpenBotChat: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -189,7 +186,6 @@ fun ContactScreen(
                 binding = state.telegram,
                 onRequestBind = onRequestBind,
                 onRequestUnbind = onRequestUnbind,
-                onOpenBotChat = onOpenBotChat,
             )
         }
     }
@@ -312,7 +308,6 @@ private fun TelegramCard(
     binding: TelegramBinding?,
     onRequestBind: () -> Unit,
     onRequestUnbind: () -> Unit,
-    onOpenBotChat: () -> Unit,
 ) {
     Surface(
         shape = AccountFieldShape,
@@ -376,25 +371,11 @@ private fun TelegramCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             if (binding?.bound == true) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    TextButton(onClick = onRequestUnbind) {
-                        Text(
-                            stringResource(R.string.account_telegram_unbind),
-                            color = MaterialTheme.colorScheme.error,
-                        )
-                    }
-                    Row(Modifier.weight(1f)) {}
-                    TextButton(onClick = onOpenBotChat) {
-                        Icon(
-                            NodysseyIcons.OpenInNew,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp),
-                        )
-                        Text(
-                            stringResource(R.string.account_telegram_open_bot),
-                            modifier = Modifier.padding(start = Spacing.xs),
-                        )
-                    }
+                TextButton(onClick = onRequestUnbind) {
+                    Text(
+                        stringResource(R.string.account_telegram_unbind),
+                        color = MaterialTheme.colorScheme.error,
+                    )
                 }
             } else {
                 Button(onClick = onRequestBind, enabled = binding != null) {
@@ -514,15 +495,6 @@ private fun TelegramBindDialog(
 
 private const val DISABLED_CARD_ALPHA = 0.55f
 
-/**
- * The bot conversation 「打开 Bot 会话」 reopens — `t.me/nodeseek`, the bot the site's footer links to.
- *
- * The account this opens is not necessarily the one the login widget binds: the widget is handed a
- * `botId` from `/api/telegram/botid` at bind time, and that id is not published anywhere the app can
- * read. This is a convenience link, not a claim about which bot holds the binding.
- */
-internal const val TELEGRAM_BOT_CHAT_URL = "https://t.me/nodeseek"
-
 @Preview(showBackground = true, widthDp = 360, heightDp = 800)
 @Composable
 private fun ContactPreviewUnbound() {
@@ -545,7 +517,6 @@ private fun ContactPreviewUnbound() {
             onRequestUnbind = {},
             onDismissUnbind = {},
             onConfirmUnbind = {},
-            onOpenBotChat = {},
         )
     }
 }
@@ -577,7 +548,6 @@ private fun ContactPreviewBound() {
             onRequestUnbind = {},
             onDismissUnbind = {},
             onConfirmUnbind = {},
-            onOpenBotChat = {},
         )
     }
 }

--- a/app/src/main/java/io/github/nodyssey/ui/account/ContactScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/account/ContactScreen.kt
@@ -56,6 +56,8 @@ import io.github.nodyssey.ui.theme.readableWidth
 fun ContactRoute(
     viewModel: ContactViewModel,
     onBack: () -> Unit,
+    /** The URL, and whether this trip is the Telegram bind — which knows when it is finished. */
+    onOpenSite: (String, Boolean) -> Unit,
     onOpenUrl: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -69,15 +71,25 @@ fun ContactRoute(
         viewModel.consumeMessage()
     }
 
-    // The site link is opened from here rather than the ViewModel — leaving the app is a UI concern.
+    // Opened from here rather than the ViewModel — where a URL goes is a UI concern. Both of this
+    // screen's site errands (修改邮箱, 绑定 Telegram) need the signed-in session, which lives in the
+    // WebView's cookie jar; a Custom Tab is the *browser's* jar and shows 用户未登录 instead.
     LaunchedEffect(state.urlToOpen) {
         state.urlToOpen?.let { url ->
+            val forBinding = state.awaitingBinding
             viewModel.consumeUrl()
-            onOpenUrl(url)
+            onOpenSite(url, forBinding)
         }
     }
 
-    // Coming back from the website is the moment the user wants the answer; see onResumed.
+    // Coming back is the moment the user wants the answer. Two ways to come back, hence two effects:
+    // ON_RESUME for the trip that left the app (the Telegram app, an external browser), and the
+    // recomposition for the in-app web view, which never takes the Activity out of RESUMED.
+    // `onResumed` is a no-op unless a bind is actually in flight, so neither one fires on arrival.
+    LaunchedEffect(Unit) {
+        viewModel.onResumed()
+    }
+
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.onResumed()
     }

--- a/app/src/main/java/io/github/nodyssey/ui/login/WebViewScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/login/WebViewScreen.kt
@@ -58,6 +58,16 @@ enum class WebViewGoal {
      * when they say so, and auto-closing mid-form would lose what they typed.
      */
     MANAGE,
+
+    /**
+     * 绑定 Telegram: [MANAGE], plus it closes itself once the account actually carries a binding.
+     *
+     * The condition is not a cookie, so unlike the two above it costs a request per poll — which is
+     * why it is its own goal rather than something [MANAGE] always does. It earns that: the errand
+     * ends at Telegram's own confirmation, a screen with no reason to know it should send the user
+     * back to an Android app, so without this the user is left holding a finished web page.
+     */
+    TELEGRAM_BIND,
 }
 
 /**
@@ -77,6 +87,12 @@ fun WebViewRoute(
     onOpenExternal: (String) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    /**
+     * Answers "has the binding landed yet?" for [WebViewGoal.TELEGRAM_BIND]. Supplied by the caller
+     * because this screen has no repositories of its own — and left null for every other goal, which
+     * closes on a cookie instead.
+     */
+    isBound: (suspend () -> Boolean)? = null,
 ) {
     if (!NodeSeekSite.isTrustedWebViewUrl(url)) {
         // A restored or malformed navigation key must fail closed. Authentication WebViews are never
@@ -121,6 +137,25 @@ fun WebViewRoute(
             }
 
             WebViewGoal.MANAGE -> null
+
+            WebViewGoal.TELEGRAM_BIND -> isBound
+        },
+        // A poll that costs a request is paced for the server, not for the eye; the cookie goals
+        // above read a local jar and can afford twice a second.
+        pollIntervalMillis =
+        if (goal == WebViewGoal.TELEGRAM_BIND) BINDING_POLL_MILLIS else GOAL_POLL_MILLIS,
+        // 绑定 Telegram is the one errand on these pages that has to leave nodeseek.com and come
+        // back; letting the detour out to the browser strands the return leg in a jar with no
+        // session. Sign-in and challenge pages keep the narrower rule.
+        isInScope =
+        when (goal) {
+            WebViewGoal.MANAGE, WebViewGoal.TELEGRAM_BIND -> {
+                { target ->
+                    NodeSeekSite.isTrustedWebViewUrl(target) || NodeSeekSite.isTelegramOAuthUrl(target)
+                }
+            }
+
+            WebViewGoal.SIGN_IN, WebViewGoal.CHALLENGE -> NodeSeekSite::isTrustedWebViewUrl
         },
         modifier = modifier,
     )
@@ -153,23 +188,35 @@ private fun WebViewScreen(
      * Polling rather than a callback because there is nothing to hook: NodeSeek signs in over an XHR,
      * so no navigation happens, `onPageFinished` never fires, and [CookieManager] has no listener.
      */
-    onCheckGoal: (() -> Boolean)? = null,
+    onCheckGoal: (suspend () -> Boolean)? = null,
+    /** How often [onCheckGoal] is asked. */
+    pollIntervalMillis: Long = GOAL_POLL_MILLIS,
+    /**
+     * Which main-frame navigations belong to this screen. Everything else is a link the user
+     * followed out, and is handed to the browser.
+     */
+    isInScope: (String) -> Boolean = NodeSeekSite::isTrustedWebViewUrl,
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
+    var popup by remember { mutableStateOf<WebView?>(null) }
     var loading by remember { mutableStateOf(true) }
     var canGoBack by remember { mutableStateOf(false) }
 
-    BackHandler(enabled = canGoBack) { webView?.goBack() }
+    // Back dismisses the popup first — it is the topmost thing on screen, and the page underneath is
+    // still where the user was.
+    BackHandler(enabled = popup != null) { popup = null }
+    BackHandler(enabled = popup == null && canGoBack) { webView?.goBack() }
 
     val autoReturn = onCheckGoal != null
     val checkGoal by rememberUpdatedState(onCheckGoal)
     val close by rememberUpdatedState(onClose)
     val openExternal by rememberUpdatedState(onOpenExternal)
+    val staysHere by rememberUpdatedState(isInScope)
 
     LaunchedEffect(autoReturn) {
         if (!autoReturn) return@LaunchedEffect
         while (true) {
-            delay(GOAL_POLL_MILLIS)
+            delay(pollIntervalMillis)
             if (checkGoal?.invoke() == true) {
                 // NodeSeek redirects to the front page right after a successful sign-in, and that
                 // navigation carries the rest of the cookies. Waiting a beat also stops the return
@@ -209,46 +256,17 @@ private fun WebViewScreen(
                 modifier = Modifier.fillMaxSize(),
                 factory = { context ->
                     WebView(context).apply {
-                        settings.javaScriptEnabled = true
-                        settings.domStorageEnabled = true
-                        settings.allowFileAccess = false
-                        settings.allowContentAccess = false
-                        settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
-                        settings.safeBrowsingEnabled = true
-                        if (userAgent != null && !userAgent.isWebViewDefault) {
-                            settings.userAgentString = userAgent.value
-                        }
-                        val cookies = CookieManager.getInstance()
-                        cookies.setAcceptCookie(true)
-                        // Turnstile runs in an iframe served from challenges.cloudflare.com, so its
-                        // cookies are third-party ones. Block them and the checkbox never sticks.
-                        cookies.setAcceptThirdPartyCookies(this, true)
-                        // Cloudflare's interactive challenge expects a host that can answer for popups
-                        // and console output. Without one, some challenge variants silently restart.
-                        webChromeClient = WebChromeClient()
-                        webViewClient = object : WebViewClient() {
-                            override fun shouldOverrideUrlLoading(
-                                view: WebView?,
-                                request: WebResourceRequest?,
-                            ): Boolean {
-                                val target = request?.url?.toString() ?: return true
-                                if (!request.isForMainFrame || NodeSeekSite.isTrustedWebViewUrl(target)) {
-                                    return false
-                                }
-                                // User-controlled links and redirects leave the authenticated
-                                // WebView. It retains JavaScript and third-party cookies solely for
-                                // NodeSeek login and Cloudflare challenge pages.
-                                view?.post { openExternal(target) }
-                                return true
-                            }
-
-                            override fun onPageFinished(view: WebView?, url: String?) {
+                        configureForNodeSeek(
+                            userAgent = userAgent,
+                            staysHere = { staysHere(it) },
+                            openExternal = { openExternal(it) },
+                            onPageLoaded = { view ->
                                 loading = false
-                                canGoBack = view?.canGoBack() == true
-                                // Persist immediately: the user may leave right after logging in.
-                                CookieManager.getInstance().flush()
-                            }
-                        }
+                                canGoBack = view.canGoBack()
+                            },
+                            onOpenPopup = { child -> popup = child },
+                            onClosePopup = { popup = null },
+                        )
                         loadUrl(url)
                         webView = this
                     }
@@ -262,6 +280,22 @@ private fun WebViewScreen(
                     view.destroy()
                 },
             )
+            // The popup window, when the page opened one. Telegram's login widget is the reason this
+            // exists: it authorises in a `window.open` child and posts the result back to its opener,
+            // so a WebView that quietly turns that into a same-window navigation loses the opener and
+            // the binding never lands. Drawn over the page it belongs to, and dismissed by the same
+            // `window.close()` the widget already calls.
+            popup?.let { child ->
+                AndroidView(
+                    modifier = Modifier.fillMaxSize(),
+                    factory = { child },
+                    onRelease = { view ->
+                        CookieManager.getInstance().flush()
+                        view.stopLoading()
+                        view.destroy()
+                    },
+                )
+            }
             if (loading) {
                 LinearProgressIndicator(
                     modifier = Modifier
@@ -273,7 +307,99 @@ private fun WebViewScreen(
     }
 }
 
+/**
+ * The one place a WebView on this screen is configured — the page itself and any popup it opens.
+ *
+ * Shared rather than copied because a popup with weaker settings is a security hole and a popup with
+ * different ones is a bug: the Telegram authorisation window needs the same cookie jar, the same user
+ * agent and the same idea of which hosts belong here as the page that opened it.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+private fun WebView.configureForNodeSeek(
+    userAgent: UserAgent?,
+    staysHere: (String) -> Boolean,
+    openExternal: (String) -> Unit,
+    onPageLoaded: (WebView) -> Unit,
+    onOpenPopup: (WebView) -> Unit,
+    onClosePopup: () -> Unit,
+) {
+    settings.javaScriptEnabled = true
+    settings.domStorageEnabled = true
+    settings.allowFileAccess = false
+    settings.allowContentAccess = false
+    settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+    settings.safeBrowsingEnabled = true
+    // Off by default, which makes Android silently rewrite `window.open` into a same-window
+    // navigation. `setJavaScriptCanOpenWindowsAutomatically` stays off: a popup is allowed because
+    // the user tapped something, not because a script felt like it.
+    settings.setSupportMultipleWindows(true)
+    if (userAgent != null && !userAgent.isWebViewDefault) {
+        settings.userAgentString = userAgent.value
+    }
+    val cookies = CookieManager.getInstance()
+    cookies.setAcceptCookie(true)
+    // Turnstile runs in an iframe served from challenges.cloudflare.com, so its cookies are
+    // third-party ones. Block them and the checkbox never sticks.
+    cookies.setAcceptThirdPartyCookies(this, true)
+    // Cloudflare's interactive challenge expects a host that can answer for popups and console
+    // output. Without one, some challenge variants silently restart.
+    webChromeClient = object : WebChromeClient() {
+        override fun onCreateWindow(
+            view: WebView?,
+            isDialog: Boolean,
+            isUserGesture: Boolean,
+            resultMsg: android.os.Message?,
+        ): Boolean {
+            val host = view ?: return false
+            val transport = resultMsg?.obj as? WebView.WebViewTransport ?: return false
+            val child = WebView(host.context)
+            child.configureForNodeSeek(
+                userAgent = userAgent,
+                staysHere = staysHere,
+                openExternal = openExternal,
+                // A popup carries no progress bar and cannot go back; only the page owns those.
+                onPageLoaded = {},
+                onOpenPopup = onOpenPopup,
+                onClosePopup = onClosePopup,
+            )
+            onOpenPopup(child)
+            transport.webView = child
+            resultMsg.sendToTarget()
+            return true
+        }
+
+        override fun onCloseWindow(window: WebView?) {
+            onClosePopup()
+        }
+    }
+    webViewClient = object : WebViewClient() {
+        override fun shouldOverrideUrlLoading(
+            view: WebView?,
+            request: WebResourceRequest?,
+        ): Boolean {
+            val target = request?.url?.toString() ?: return true
+            if (!request.isForMainFrame || staysHere(target)) {
+                return false
+            }
+            // User-controlled links and redirects leave the authenticated WebView. It retains
+            // JavaScript and third-party cookies solely for NodeSeek login and Cloudflare
+            // challenge pages.
+            view?.post { openExternal(target) }
+            return true
+        }
+
+        override fun onPageFinished(view: WebView?, url: String?) {
+            view?.let(onPageLoaded)
+            // Persist immediately: the user may leave right after logging in.
+            CookieManager.getInstance().flush()
+        }
+    }
+}
+
 /** Fast enough that the return feels immediate, slow enough to be free at 60fps. */
 private const val GOAL_POLL_MILLIS = 500L
+
+/** One `/setting` fetch each; slow enough to sit politely behind a page the user is still reading. */
+private const val BINDING_POLL_MILLIS = 4_000L
 
 private const val GOAL_SETTLE_MILLIS = 500L

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -470,7 +470,6 @@
     <string name="account_telegram_bind_hint">绑定 telegram 后可以及时提醒未读消息，@我、回复与私信都会转发到你的 Telegram。</string>
     <string name="account_telegram_bound_hint">未读的 @我、回复与私信会转发到你的 Telegram；已读消息不重复提醒。</string>
     <string name="account_telegram_unbind">解绑</string>
-    <string name="account_telegram_open_bot">打开 Bot 会话</string>
     <string name="account_telegram_dialog_title">在网页中完成绑定</string>
     <string name="account_telegram_dialog_body">即将打开 NodeSeek 的联系方式设置页。绑定要用 Telegram 官方的登录挂件完成，只能在网页里进行；确认后 @我、回复与私信的未读提醒将转发到你的 Telegram。</string>
     <string name="account_telegram_dialog_note">网页会跳转到 Telegram 授权，返回本页后绑定状态会自动刷新。</string>

--- a/app/src/test/java/io/github/nodyssey/core/net/ChallengeDetectorTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/net/ChallengeDetectorTest.kt
@@ -13,6 +13,24 @@ class ChallengeDetectorTest {
         assertNull(ChallengeDetector.detect(Fixtures.load("post-703863-1.html"), 200, emptyMap()))
     }
 
+    /**
+     * The shape `/setting` actually comes back as — captured off the device on 2026-08-02: a 200
+     * carrying the bootstrap, no content markup, and Cloudflare's own script inlined into it. It used
+     * to be read as a challenge, which is why 联系方式 could never show an email.
+     */
+    @Test
+    fun `a settings page carrying the bootstrap is not a challenge`() {
+        val html =
+            """
+            <!DOCTYPE html> <html data-server-rendered="true"><head>
+            <script src="/cdn-cgi/challenge-platform/scripts/jsd/main.js"></script>
+            </head><body><div id="app"></div>
+            <script id="temp-script" type="text/json">eyJ1c2VyIjp7fX0=</script>
+            </body></html>
+            """.trimIndent()
+        assertNull(ChallengeDetector.detect(html, 200, emptyMap()))
+    }
+
     @Test
     fun `a cloudflare interstitial is detected`() {
         assertEquals(


### PR DESCRIPTION
## 起因

每次打开「联系方式」都弹「需要确认一下你不是机器人」，邮箱和 Telegram 绑定状态一直是「—」。顺着查下去，发现这一屏的三条路——读取、绑定、解绑——只有解绑是通的。

## 改了什么

### 1. 设置页不再被误判成人机验证（`ad41de5`）

真机上给 `NodeSeekClient` 加临时日志抓到的实况：

```
path=/setting status=200 cf-mitigated=null cf-cache=DYNAMIC
usable=[] cfMarkers=[/cdn-cgi/challenge-platform/] bootstrap=true verdict=Cloudflare
path=/       status=200 cf-mitigated=null cf-cache=DYNAMIC
usable=[id="nsk-body", class="post-list"] cfMarkers=[/cdn-cgi/challenge-platform/] verdict=null
```

Cloudflare 往**每个**页面都内联了 `/cdn-cgi/challenge-platform/` 那段脚本，首页也有，只是首页命中内容标记先一步放行。`/setting` 是服务端渲染但没有 `nsk-body`，一条内容标记都不命中，那段到处都有的脚本就成了唯一信号。请求本身完全正常（200、`cf-mitigated` 为空），是判定错了。

修法：把站点自己的 bootstrap（`id="temp-script"`）加进放行标记。挑战页是**替代**站点返回的，永远不会带 bootstrap；而 `/setting` 的账号字段（email、`telegram_id`）本来就只存在于这份 bootstrap 里。

### 2. Telegram 绑定走通（`9bacc4a`）

三处**串联**的断点，逐一在真机上撞出来：

- **「打开网页」走的是 Custom Tab**，用外部浏览器的 cookie 罐，而登录态在 WebView 的 CookieManager 里 → 页面直接是「用户未登录」。这个回调本来是给 `t.me` 那种真·外部链接准备的，被改邮箱和绑定两处站内 URL 复用了。现在两类分开。
- **站点的绑定按钮跳 `oauth.telegram.org`**，而内置 WebView 只信 `nodeseek.com`，主框架一换域就把人交给外部浏览器 → 授权完 Telegram 回调落在没有 session 的罐子里，照样写不进账号。管理类页面因此放行这一个域，登录和过 CF 挑战的 WebView 边界不动。
- **Telegram 用 `window.open` 弹窗 + `postMessage` 回传**，而这个 WebView 没开多窗口支持，Android 会把 `window.open` 悄悄改写成同窗口跳转，`window.opener` 就此丢失 → 授权完页面白着，账号上什么也没写。现在弹窗由配置相同的子 WebView 承载，`window.close()` 收走。

连带补上返回这一段：内置 WebView 是同一 Activity 内的导航，联系方式屏等的 `ON_RESUME` 永远不会来，所以重进组合时也触发一次轮询；而 Telegram 的确认页没有理由知道该把人送回一个 Android 应用，于是新增 `TELEGRAM_BIND` 目标，轮询到绑定成立就自己关掉退回去。

### 3. 删掉「打开 Bot 会话」（`9c6e0f6`）

站点没有这个功能。按钮指向 `t.me/nodeseek` 是照着页脚链接猜的，而账号实际绑定哪个 bot 由 `/api/telegram/botid` 在绑定时决定，app 读不到。

## 验证

真机（SM-S9310，debug 包）上端到端走过：

- 进屏正常读出邮箱与绑定状态
- 解绑 → 站点 bootstrap 的 `telegram_id` 变 `null`
- 绑定 → 授权在 app 内完成 → WebView 自动退回 → 卡片变「已绑定」→ 站点 `telegram_id` 非空
- 全量单测、spotless、lintDebug 均通过

## 给 reviewer

- 改邮箱那条路现在也走内置 WebView（登录态和站点自己的 Turnstile 都在），但**没有端到端验证**——那要真发验证码改地址，会动到账号。
- `WebViewGoal.MANAGE` 的其他页面（邀请码、星尘转移）一并吃到了多窗口支持与 `oauth.telegram.org` 放行，逻辑上是改善，但没有逐个回归。
- 新增的 `TELEGRAM_BIND` 轮询每 4 秒一次 `/setting`，只在绑定 WebView 打开期间跑；失败按「还没绑上」处理，不中断监视。

🤖 Generated with [Claude Code](https://claude.com/claude-code)