### PR TITLE
重画投票卡片，投票人列表可展开也可收起

### DIFF
--- a/app/src/main/java/io/github/nodyssey/ui/richtext/VotePlaceholderCard.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/richtext/VotePlaceholderCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -43,13 +42,13 @@ fun VotePlaceholderCard(modifier: Modifier = Modifier) {
             Icon(
                 NodysseyIcons.Poll,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
             )
             Column {
                 Text(
                     stringResource(R.string.vote_placeholder_title),
-                    style = MaterialTheme.typography.titleSmall,
+                    style = MaterialTheme.typography.titleMedium,
                 )
                 Text(
                     stringResource(R.string.vote_placeholder_body),
@@ -75,7 +74,7 @@ fun VoteCardSurface(
 ) {
     Surface(
         modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp),
+        shape = MaterialTheme.shapes.medium,
         color = MaterialTheme.colorScheme.surfaceContainerLow,
         tonalElevation = 0.dp,
     ) {

--- a/app/src/main/java/io/github/nodyssey/ui/vote/VoteCard.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/vote/VoteCard.kt
@@ -1,5 +1,9 @@
 package io.github.nodyssey.ui.vote
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -7,27 +11,28 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -38,9 +43,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -50,11 +57,14 @@ import io.github.nodyssey.model.Vote
 import io.github.nodyssey.model.VoteItem
 import io.github.nodyssey.model.totalCount
 import io.github.nodyssey.ui.common.NodysseyIcons
+import io.github.nodyssey.ui.common.SkeletonBar
 import io.github.nodyssey.ui.common.UserAvatar
 import io.github.nodyssey.ui.common.shortMessage
 import io.github.nodyssey.ui.richtext.VoteCardSurface
 import io.github.nodyssey.ui.theme.NodysseyTheme
+import io.github.nodyssey.ui.theme.Sizes
 import io.github.nodyssey.ui.theme.Spacing
+import io.github.nodyssey.ui.theme.TABULAR_FIGURES
 
 @Composable
 fun VoteCard(
@@ -71,7 +81,8 @@ fun VoteCard(
         onSubmit = viewModel::submit,
         onSetLocked = viewModel::setLocked,
         onDelete = viewModel::delete,
-        onExpandVoters = viewModel::expandVoters,
+        onToggleVoters = viewModel::toggleVoters,
+        onLoadMoreVoters = viewModel::loadMoreVoters,
         onSignIn = onSignIn,
         onUserClick = onUserClick,
         modifier = modifier,
@@ -86,6 +97,11 @@ fun VoteCard(
  * nothing else — no bars, no percentages, no totals, and no voter avatars either, even though the
  * voter endpoint would in fact answer. Matching the site here is deliberate; showing a tally it
  * chose to withhold would change what participating means.
+ *
+ * The card keeps to two faces and to as little furniture as it can. Before voting an option is a tick
+ * and a label; after voting the same line grows a hairline bar and its numbers. Nothing gets a box of
+ * its own — this arrives in the middle of someone's post, and a stack of filled slabs would carry more
+ * weight than the paragraph it interrupts.
  */
 @Composable
 fun VoteCard(
@@ -95,7 +111,8 @@ fun VoteCard(
     onSubmit: () -> Unit,
     onSetLocked: (Boolean) -> Unit,
     onDelete: () -> Unit,
-    onExpandVoters: (Long) -> Unit,
+    onToggleVoters: (Long) -> Unit,
+    onLoadMoreVoters: (Long) -> Unit,
     onSignIn: () -> Unit,
     onUserClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
@@ -119,7 +136,8 @@ fun VoteCard(
                     onSubmit = onSubmit,
                     onSetLocked = onSetLocked,
                     onDelete = onDelete,
-                    onExpandVoters = onExpandVoters,
+                    onToggleVoters = onToggleVoters,
+                    onLoadMoreVoters = onLoadMoreVoters,
                     onSignIn = onSignIn,
                     onUserClick = onUserClick,
                 )
@@ -135,7 +153,8 @@ private fun VoteBody(
     onSubmit: () -> Unit,
     onSetLocked: (Boolean) -> Unit,
     onDelete: () -> Unit,
-    onExpandVoters: (Long) -> Unit,
+    onToggleVoters: (Long) -> Unit,
+    onLoadMoreVoters: (Long) -> Unit,
     onSignIn: () -> Unit,
     onUserClick: (Long) -> Unit,
 ) {
@@ -143,58 +162,63 @@ private fun VoteBody(
     var confirmLock by remember { mutableStateOf(false) }
     var confirmDelete by remember { mutableStateOf(false) }
 
+    val total = vote.totalCount
+
     VoteHeader(
         state = state,
         vote = vote,
+        total = total,
         onLock = { confirmLock = true },
         onUnlock = { onSetLocked(false) },
         onDelete = { confirmDelete = true },
     )
 
-    val total = vote.totalCount
-    vote.items.forEach { item ->
-        VoteOptionRow(
-            item = item,
-            multiple = vote.multiple,
-            selected = item.itemId in state.selectedIds,
-            enabled = state.isSignedIn && !vote.locked && !state.hasVoted && !state.isSubmitting,
-            showsResults = state.showsResults,
-            total = total,
-            onToggle = { onToggle(item.itemId) },
-        )
-        if (state.showsResults && vote.isPublic) {
-            VoterStrip(
-                item = item,
-                list = state.voters[item.itemId],
-                onExpand = { onExpandVoters(item.itemId) },
-                onUserClick = onUserClick,
-            )
-        }
-    }
+    // The option with the most votes gets the one emphasis a result row has left, so the answer to
+    // the question can be read without comparing three bars by eye.
+    val leading = if (state.showsResults) vote.items.mapNotNull(VoteItem::count).maxOrNull() else null
 
-    if (state.showsResults && total != null) {
-        Text(
-            stringResource(R.string.vote_total, total),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = Spacing.sm),
-        )
-    } else if (!state.hasVoted && !vote.locked) {
-        Text(
-            stringResource(R.string.vote_results_hidden),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = Spacing.sm),
-        )
+    Column(
+        modifier = Modifier.padding(top = Spacing.sm),
+        // Results are two-part blocks and need air between them; choice rows carry their own touch
+        // target and would drift apart if the column added more on top of it.
+        verticalArrangement = Arrangement.spacedBy(if (state.showsResults) Spacing.sm else 0.dp),
+    ) {
+        vote.items.forEach { item ->
+            if (state.showsResults) {
+                VoteResultRow(
+                    item = item,
+                    total = total,
+                    leading = leading != null && leading > 0 && item.count == leading,
+                    voters = state.voters[item.itemId]?.takeIf { vote.isPublic },
+                    onToggleVoters = { onToggleVoters(item.itemId) }.takeIf { vote.isPublic },
+                    onLoadMore = { onLoadMoreVoters(item.itemId) },
+                    onUserClick = onUserClick,
+                )
+            } else {
+                VoteChoiceRow(
+                    item = item,
+                    multiple = vote.multiple,
+                    selected = item.itemId in state.selectedIds,
+                    enabled = state.isSignedIn && !vote.locked && !state.hasVoted && !state.isSubmitting,
+                    onToggle = { onToggle(item.itemId) },
+                )
+            }
+        }
     }
 
     // No button once voted or locked: neither state has anything left to submit, and a disabled
     // button in a card that is otherwise finished reads as something the reader failed to do.
     if (!state.hasVoted && !vote.locked) {
+        Text(
+            stringResource(R.string.vote_results_hidden),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = Spacing.sm, start = Spacing.xs),
+        )
         Button(
             onClick = { if (state.isSignedIn) confirmSubmit = true else onSignIn() },
             enabled = !state.isSubmitting && (!state.isSignedIn || state.selectedIds.isNotEmpty()),
-            modifier = Modifier.fillMaxWidth().padding(top = Spacing.sm),
+            modifier = Modifier.padding(top = Spacing.sm).fillMaxWidth(),
         ) {
             if (state.isSubmitting) {
                 CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
@@ -246,37 +270,50 @@ private fun VoteBody(
     }
 }
 
+/**
+ * Title, badge and the vote's own properties.
+ *
+ * The total sits here rather than under the options: it describes the vote, like "单选" and "匿名投票"
+ * do, and as a footer it left the card ending on a stray grey line once the button was gone.
+ */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun VoteHeader(
     state: VoteUiState,
     vote: Vote,
+    total: Int?,
     onLock: () -> Unit,
     onUnlock: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row(verticalAlignment = Alignment.Top) {
         Column(Modifier.weight(1f)) {
-            Text(vote.title, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                VoteChip(
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    NodysseyIcons.Poll,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(16.dp),
+                )
+                Text(
+                    vote.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = Spacing.xs),
+                )
+            }
+            // Separate Text nodes rather than one joined string: each of these is a fact about the
+            // vote that TalkBack should be able to land on, and "单选 · 已锁定" as one blob is also
+            // one long line to re-read every time the card redraws.
+            VoteMetaLine(
+                listOfNotNull(
                     stringResource(
                         if (vote.multiple) R.string.vote_multiple_choice else R.string.vote_single_choice,
                     ),
-                )
-                if (!vote.isPublic) VoteChip(stringResource(R.string.vote_anonymous))
-                if (vote.locked) {
-                    Icon(
-                        Icons.Default.Lock,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(14.dp),
-                    )
-                    VoteChip(stringResource(R.string.vote_locked))
-                }
-            }
+                    stringResource(R.string.vote_anonymous).takeIf { !vote.isPublic },
+                    stringResource(R.string.vote_locked).takeIf { vote.locked },
+                    total?.let { stringResource(R.string.vote_total, it) }.takeIf { state.showsResults },
+                ),
+            )
         }
         // Only when there is at least one thing this account may actually do: the owner of a locked
         // vote can neither unlock nor delete it, so an empty menu would be a promise we cannot keep.
@@ -335,83 +372,247 @@ private fun VoteManageMenu(
     }
 }
 
+/** The vote's own properties, as one grey line under the title. */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun VoteOptionRow(
+private fun VoteMetaLine(parts: List<String>) {
+    val style = MaterialTheme.typography.labelSmall.copy(fontFeatureSettings = TABULAR_FIGURES)
+    FlowRow(modifier = Modifier.padding(top = 2.dp, start = 20.dp)) {
+        parts.forEachIndexed { index, part ->
+            if (index > 0) {
+                Text(
+                    " · ",
+                    style = style,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            }
+            Text(part, style = style, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}
+
+/**
+ * An option before the vote is cast.
+ *
+ * No container of its own: a box per option turned a three-option vote into three stacked slabs, and
+ * the card was heavier than the paragraph it interrupts. What is left is a tick and a label, and the
+ * tick is the only thing that changes when the reader picks one.
+ *
+ * The row carries the [selectable]/[toggleable] semantics itself, which is both why the target is the
+ * full width and why the tick can be a drawing rather than a real control — a `RadioButton` inside a
+ * clickable row either announces itself twice or, silenced, announces nothing at all.
+ */
+@Composable
+private fun VoteChoiceRow(
     item: VoteItem,
     multiple: Boolean,
     selected: Boolean,
     enabled: Boolean,
-    showsResults: Boolean,
-    total: Int?,
     onToggle: () -> Unit,
 ) {
-    Column(
+    Row(
+        modifier =
         Modifier
             .fillMaxWidth()
-            .clickable(enabled = enabled, onClick = onToggle)
-            .padding(vertical = Spacing.xs),
+            .clip(OptionShape)
+            .then(
+                if (multiple) {
+                    Modifier.toggleable(
+                        value = selected,
+                        enabled = enabled,
+                        role = Role.Checkbox,
+                        onValueChange = { onToggle() },
+                    )
+                } else {
+                    Modifier.selectable(
+                        selected = selected,
+                        enabled = enabled,
+                        role = Role.RadioButton,
+                        onClick = onToggle,
+                    )
+                },
+            )
+            .defaultMinSize(minHeight = Sizes.minTouchTarget)
+            .padding(horizontal = Spacing.xs, vertical = Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        VoteTick(selected = selected, multiple = multiple, enabled = enabled)
+        Text(
+            item.text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f).padding(start = Spacing.md),
+        )
+    }
+}
+
+/** The mark for "this one". Drawn rather than a control — see [VoteChoiceRow]. */
+@Composable
+private fun VoteTick(
+    selected: Boolean,
+    multiple: Boolean,
+    enabled: Boolean,
+) {
+    val shape = if (multiple) RoundedCornerShape(6.dp) else CircleShape
+    val tint by animateColorAsState(
+        targetValue =
+        when {
+            selected -> MaterialTheme.colorScheme.primary
+            enabled -> MaterialTheme.colorScheme.outline
+            else -> MaterialTheme.colorScheme.outlineVariant
+        },
+        animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+        label = "voteTick",
+    )
+    Box(
+        modifier =
+        Modifier
+            .size(TICK_SIZE)
+            .clip(shape)
+            .background(if (selected) tint else Color.Transparent)
+            .border(2.dp, tint, shape),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(14.dp),
+            )
+        }
+    }
+}
+
+/**
+ * An option once the results exist: one line of text, one hairline of bar under it.
+ *
+ * The bar is 4dp and sits tight under its own label, because three of these have to read as a
+ * comparison at a glance. A taller bar — or a filled row — says the same thing while taking three
+ * times the space, in a card that interrupts someone's post.
+ *
+ * On a public vote the whole block is the handle for the voter list, which is why there is no button
+ * for it: a row of "12 人" under every option was a third of the card's height spent on an affordance
+ * the count beside it already named.
+ */
+@Composable
+private fun VoteResultRow(
+    item: VoteItem,
+    total: Int?,
+    leading: Boolean,
+    voters: VoterListState?,
+    onToggleVoters: (() -> Unit)?,
+    onLoadMore: () -> Unit,
+    onUserClick: (Long) -> Unit,
+) {
+    val fraction =
+        if (item.count != null && total != null && total > 0) item.count.toFloat() / total else 0f
+    // Grown rather than snapped: this row is redrawn the moment the submit comes back, and a bar that
+    // appears at its final length loses the only feedback the reader gets that the vote was counted.
+    val grown by animateFloatAsState(
+        targetValue = fraction,
+        animationSpec = MaterialTheme.motionScheme.slowEffectsSpec(),
+        label = "voteBar",
+    )
+    val fill =
+        if (item.voted) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant
+
+    val open = voters?.expanded == true
+    val togglable = onToggleVoters != null && (item.count ?: 0) > 0
+    Column(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .clip(OptionShape)
+            .then(
+                if (togglable) {
+                    Modifier.clickable(
+                        onClickLabel =
+                        if (open) {
+                            stringResource(R.string.vote_voters_collapse)
+                        } else {
+                            stringResource(R.string.vote_voters_expand, item.count ?: 0)
+                        },
+                        onClick = { onToggleVoters?.invoke() },
+                    )
+                } else {
+                    Modifier
+                },
+            )
+            .padding(Spacing.xs),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            when {
-                // Once voted, the control is a read-out rather than an input: a disabled radio still
-                // looks like something to press, and a tick does not.
-                showsResults ->
-                    Icon(
-                        Icons.Default.Check,
-                        contentDescription = null,
-                        tint =
-                        if (item.voted) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.surfaceVariant
-                        },
-                        modifier = Modifier.size(20.dp),
-                    )
-
-                multiple ->
-                    Checkbox(
-                        checked = selected,
-                        onCheckedChange = { onToggle() },
-                        enabled = enabled,
-                        modifier = Modifier.clearAndSetSemantics { },
-                    )
-
-                else ->
-                    RadioButton(
-                        selected = selected,
-                        onClick = onToggle,
-                        enabled = enabled,
-                        modifier = Modifier.clearAndSetSemantics { },
-                    )
+            if (item.voted) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(15.dp).padding(end = 3.dp),
+                )
             }
             Text(
                 item.text,
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.weight(1f).padding(start = Spacing.sm),
+                fontWeight = if (item.voted) FontWeight.SemiBold else null,
+                modifier = Modifier.weight(1f),
             )
-            if (showsResults && item.count != null) {
+            // The one mark that says this line opens: without it the voter list — which the site has
+            // and which is half of why a public vote is public — is a feature nobody would find. It
+            // stays put once open, because by then it is the way back.
+            if (togglable) {
+                Icon(
+                    NodysseyIcons.Group,
+                    contentDescription = null,
+                    tint =
+                    if (open) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    },
+                    modifier = Modifier.size(17.dp).padding(end = 3.dp),
+                )
+            }
+            if (item.count != null) {
                 Text(
                     stringResource(R.string.vote_count, item.count),
-                    style = MaterialTheme.typography.labelMedium,
+                    style = MaterialTheme.typography.labelSmall.copy(fontFeatureSettings = TABULAR_FIGURES),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (total != null && total > 0) {
+                    Text(
+                        stringResource(R.string.vote_percent, (fraction * 100).toInt()),
+                        style =
+                        MaterialTheme.typography.labelMedium.copy(fontFeatureSettings = TABULAR_FIGURES),
+                        color =
+                        if (leading) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        textAlign = TextAlign.End,
+                        // A fixed column so the percentages line up down the card instead of
+                        // stepping left and right with the width of their own digits.
+                        modifier = Modifier.padding(start = Spacing.sm).widthIn(min = PERCENT_COLUMN),
+                    )
+                }
             }
         }
-        if (showsResults && item.count != null && total != null && total > 0) {
-            val fraction = item.count.toFloat() / total
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                LinearProgressIndicator(
-                    progress = { fraction },
-                    modifier = Modifier.weight(1f).height(6.dp).clip(RoundedCornerShape(3.dp)),
-                )
-                Text(
-                    stringResource(R.string.vote_percent, (fraction * 100).toInt()),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(start = Spacing.sm),
-                )
-            }
+        Box(
+            Modifier
+                .padding(top = 3.dp)
+                .fillMaxWidth()
+                .height(BAR_HEIGHT)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        ) {
+            Box(
+                Modifier
+                    .fillMaxWidth(grown)
+                    .fillMaxHeight()
+                    .clip(CircleShape)
+                    .background(fill),
+            )
         }
+        if (open && voters != null) VoterStrip(list = voters, onLoadMore = onLoadMore, onUserClick = onUserClick)
     }
 }
 
@@ -425,73 +626,69 @@ private fun VoteOptionRow(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun VoterStrip(
-    item: VoteItem,
-    list: VoterListState?,
-    onExpand: () -> Unit,
+    list: VoterListState,
+    onLoadMore: () -> Unit,
     onUserClick: (Long) -> Unit,
 ) {
-    val count = item.count ?: return
-    if (count == 0) return
-
-    if (list == null) {
-        TextButton(onClick = onExpand, modifier = Modifier.padding(start = Spacing.xl)) {
-            Text(stringResource(R.string.vote_voters_expand, count))
-        }
-        return
-    }
-
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-        modifier = Modifier.padding(start = Spacing.xl, bottom = Spacing.xs),
-    ) {
+    FlowRow(modifier = Modifier.padding(top = Spacing.xs)) {
         list.uids.forEach { uid ->
             // uid as the name, because that is all the endpoint returns. Fetching a display name
             // per avatar would be one request each for a strip that is decoration.
             UserAvatar(
                 url = NodeSeekSite.avatarUrl(uid),
                 name = uid.toString(),
-                size = 24.dp,
+                size = VOTER_AVATAR,
                 // The avatar itself is decorative (UserAvatar passes a null description), so the
                 // uid has to reach TalkBack through the click label or the strip is a dead end.
+                //
+                // Padding *inside* the clickable, so the gap between two avatars belongs to the one
+                // the finger is nearer to. Ordered the other way it would be dead space, and these
+                // are the handles onto everyone who voted.
                 modifier =
-                Modifier.clickable(
-                    onClickLabel = stringResource(R.string.vote_voter_uid, uid),
-                ) { onUserClick(uid) },
+                Modifier
+                    .clickable(
+                        onClickLabel = stringResource(R.string.vote_voter_uid, uid),
+                    ) { onUserClick(uid) }
+                    .padding(Spacing.xs),
             )
         }
         if (list.isLoading) {
-            CircularProgressIndicator(Modifier.size(20.dp), strokeWidth = 2.dp)
+            CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
         } else if (list.hasMore) {
-            TextButton(onClick = onExpand) { Text(stringResource(R.string.vote_voters_more)) }
+            TextButton(onClick = onLoadMore) { Text(stringResource(R.string.vote_voters_more)) }
         }
     }
 }
 
-@Composable
-private fun VoteChip(text: String) {
-    Surface(
-        shape = RoundedCornerShape(4.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHighest,
-    ) {
-        Text(
-            text,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = Spacing.xs, vertical = 1.dp),
-        )
-    }
-}
-
+/**
+ * The card's own skeleton, in the shapes the loaded card will use.
+ *
+ * A bare spinner said "something is happening" without saying what, and the card then jumped from one
+ * line to five. Three bars at the option rows' height reserve roughly the space the answer needs.
+ */
 @Composable
 private fun VoteLoading() {
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-        CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            NodysseyIcons.Poll,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp),
+        )
         Text(
             stringResource(R.string.vote_placeholder_title),
-            style = MaterialTheme.typography.titleSmall,
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = Spacing.xs),
         )
+    }
+    Column(
+        modifier = Modifier.padding(top = Spacing.md, start = Spacing.xs),
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        SKELETON_WIDTHS.forEach { width ->
+            SkeletonBar(fraction = width, height = 14.dp)
+        }
     }
 }
 
@@ -538,6 +735,21 @@ private fun VoteConfirmDialog(
     )
 }
 
+/** Only ever seen as a ripple: the option rows have no fill of their own. */
+private val OptionShape = RoundedCornerShape(8.dp)
+
+private val TICK_SIZE = 20.dp
+
+/** A hairline. Any taller and three of these read as blocks rather than as lengths to compare. */
+private val BAR_HEIGHT = 4.dp
+
+/** Fits "100%" at [androidx.compose.material3.Typography.labelMedium]. */
+private val PERCENT_COLUMN = 32.dp
+
+private val VOTER_AVATAR = 28.dp
+
+private val SKELETON_WIDTHS = listOf(0.55f, 0.85f, 0.7f)
+
 private fun previewVote(
     locked: Boolean = false,
     voted: Boolean = false,
@@ -567,7 +779,34 @@ private fun VoteCardUnvotedPreview() {
             onSubmit = {},
             onSetLocked = {},
             onDelete = {},
-            onExpandVoters = {},
+            onToggleVoters = {},
+            onLoadMoreVoters = {},
+            onSignIn = {},
+            onUserClick = {},
+            modifier = Modifier.padding(Spacing.lg),
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, name = "投票 · 已选中")
+@Composable
+private fun VoteCardSelectedPreview() {
+    NodysseyTheme {
+        VoteCard(
+            state =
+            VoteUiState(
+                vote = previewVote(),
+                isLoading = false,
+                isSignedIn = true,
+                selectedIds = setOf(13202),
+            ),
+            onRetry = {},
+            onToggle = {},
+            onSubmit = {},
+            onSetLocked = {},
+            onDelete = {},
+            onToggleVoters = {},
+            onLoadMoreVoters = {},
             onSignIn = {},
             onUserClick = {},
             modifier = Modifier.padding(Spacing.lg),
@@ -586,7 +825,28 @@ private fun VoteCardVotedPreview() {
             onSubmit = {},
             onSetLocked = {},
             onDelete = {},
-            onExpandVoters = {},
+            onToggleVoters = {},
+            onLoadMoreVoters = {},
+            onSignIn = {},
+            onUserClick = {},
+            modifier = Modifier.padding(Spacing.lg),
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, name = "投票 · 载入中")
+@Composable
+private fun VoteCardLoadingPreview() {
+    NodysseyTheme {
+        VoteCard(
+            state = VoteUiState(isLoading = true),
+            onRetry = {},
+            onToggle = {},
+            onSubmit = {},
+            onSetLocked = {},
+            onDelete = {},
+            onToggleVoters = {},
+            onLoadMoreVoters = {},
             onSignIn = {},
             onUserClick = {},
             modifier = Modifier.padding(Spacing.lg),

--- a/app/src/main/java/io/github/nodyssey/ui/vote/VoteComposeDialog.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/vote/VoteComposeDialog.kt
@@ -1,19 +1,24 @@
 package io.github.nodyssey.ui.vote
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -29,12 +34,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.nodyssey.R
+import io.github.nodyssey.ui.common.NodysseyIcons
 import io.github.nodyssey.ui.theme.NodysseyTheme
+import io.github.nodyssey.ui.theme.Sizes
 import io.github.nodyssey.ui.theme.Spacing
+import io.github.nodyssey.ui.theme.TABULAR_FIGURES
 
 /** How a vote creation is going, so the dialog can wait and report without owning the request. */
 sealed interface VoteCreationState {
@@ -75,6 +85,7 @@ fun VoteComposeDialog(
 
     AlertDialog(
         onDismissRequest = { if (state !is VoteCreationState.InFlight) onDismiss() },
+        icon = { Icon(NodysseyIcons.Poll, contentDescription = null) },
         title = { Text(stringResource(R.string.vote_compose_title)) },
         text = {
             Column(
@@ -86,6 +97,7 @@ fun VoteComposeDialog(
                     onValueChange = { title = it },
                     label = { Text(stringResource(R.string.vote_compose_question)) },
                     singleLine = true,
+                    shape = MaterialTheme.shapes.small,
                     modifier = Modifier.fillMaxWidth(),
                 )
 
@@ -96,47 +108,87 @@ fun VoteComposeDialog(
                             onValueChange = { options[index] = it },
                             label = { Text(stringResource(R.string.vote_compose_option, index + 1)) },
                             singleLine = true,
+                            shape = MaterialTheme.shapes.small,
                             modifier = Modifier.weight(1f),
                         )
-                        // Two is the floor: a vote with one option is not a question.
-                        IconButton(
-                            onClick = { options.removeAt(index) },
-                            enabled = options.size > MIN_OPTIONS,
-                        ) {
-                            Icon(
-                                Icons.Default.Close,
-                                contentDescription = stringResource(R.string.vote_compose_remove_option, index + 1),
-                            )
+                        // Two is the floor: a vote with one option is not a question. Below it the
+                        // button is absent rather than greyed — a disabled cross on every row of a
+                        // two-option vote reads as something the author has done wrong.
+                        if (options.size > MIN_OPTIONS) {
+                            IconButton(onClick = { options.removeAt(index) }) {
+                                Icon(
+                                    Icons.Default.Close,
+                                    contentDescription =
+                                    stringResource(R.string.vote_compose_remove_option, index + 1),
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            }
                         }
                     }
                 }
 
-                TextButton(onClick = { options.add("") }, enabled = options.size < MAX_OPTIONS) {
-                    Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    TextButton(onClick = { options.add("") }, enabled = options.size < MAX_OPTIONS) {
+                        Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Text(
+                            stringResource(R.string.vote_compose_add_option),
+                            modifier = Modifier.padding(start = Spacing.xs),
+                        )
+                    }
+                    Spacer(Modifier.weight(1f))
                     Text(
-                        stringResource(R.string.vote_compose_add_option),
-                        modifier = Modifier.padding(start = Spacing.xs),
+                        "${options.size} / $MAX_OPTIONS",
+                        style = MaterialTheme.typography.labelSmall.copy(fontFeatureSettings = TABULAR_FIGURES),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(end = Spacing.sm),
                     )
                 }
 
-                VoteToggleRow(
-                    label = stringResource(R.string.vote_compose_multiple),
-                    checked = multiple,
-                    onChange = { multiple = it },
-                )
-                VoteToggleRow(
-                    label = stringResource(R.string.vote_compose_public),
-                    description = stringResource(R.string.vote_compose_public_body),
-                    checked = isPublic,
-                    onChange = { isPublic = it },
-                )
+                // The two switches are settings on the vote rather than more of the form, so they sit
+                // in their own block instead of continuing the column of text fields.
+                Column(
+                    Modifier
+                        .clip(MaterialTheme.shapes.medium)
+                        .background(MaterialTheme.colorScheme.surfaceContainerLow),
+                ) {
+                    VoteToggleRow(
+                        label = stringResource(R.string.vote_compose_multiple),
+                        checked = multiple,
+                        onChange = { multiple = it },
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    VoteToggleRow(
+                        label = stringResource(R.string.vote_compose_public),
+                        description = stringResource(R.string.vote_compose_public_body),
+                        checked = isPublic,
+                        onChange = { isPublic = it },
+                    )
+                }
 
                 (state as? VoteCreationState.Failed)?.let { failure ->
-                    Text(
-                        failure.detail?.takeIf { it.isNotBlank() } ?: stringResource(R.string.vote_compose_failed),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                    )
+                    Row(
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.small)
+                            .background(MaterialTheme.colorScheme.errorContainer)
+                            .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            NodysseyIcons.ErrorCircle,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(
+                            failure.detail?.takeIf { it.isNotBlank() }
+                                ?: stringResource(R.string.vote_compose_failed),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.padding(start = Spacing.sm),
+                        )
+                    }
                 }
             }
         },
@@ -183,8 +235,16 @@ private fun VoteToggleRow(
     onChange: (Boolean) -> Unit,
     description: String? = null,
 ) {
-    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-        Column(Modifier.weight(1f)) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .toggleable(value = checked, role = Role.Switch, onValueChange = onChange)
+            .defaultMinSize(minHeight = Sizes.minTouchTarget)
+            .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+    ) {
+        Column(Modifier.weight(1f).padding(end = Spacing.sm)) {
             Text(label, style = MaterialTheme.typography.bodyMedium)
             description?.let {
                 Text(
@@ -194,7 +254,9 @@ private fun VoteToggleRow(
                 )
             }
         }
-        Switch(checked = checked, onCheckedChange = onChange)
+        // null, not `onChange`: the row above already carries the toggle and its semantics, and a
+        // switch that also handles clicks announces the same control twice.
+        Switch(checked = checked, onCheckedChange = null)
     }
 }
 

--- a/app/src/main/java/io/github/nodyssey/ui/vote/VoteViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/vote/VoteViewModel.kt
@@ -32,6 +32,14 @@ data class VoterListState(
     val uids: List<Long> = emptyList(),
     val loadedPages: Int = 0,
     val isLoading: Boolean = false,
+    /**
+     * Whether the card is currently showing it.
+     *
+     * A closed list stays in the map rather than being dropped: someone who paged three times, closed
+     * the strip and opened it again would otherwise be back at the first ten, and the pages they had
+     * already been given would have to be fetched a second time.
+     */
+    val expanded: Boolean = true,
 ) {
     /** A short page is the last page — the endpoint reports no total. */
     val hasMore: Boolean get() = loadedPages > 0 && uids.size >= loadedPages * NodeSeekJsonClient.VOTER_PAGE_SIZE
@@ -186,23 +194,37 @@ class VoteViewModel(
     }
 
     /**
-     * Opens (or extends) one option's voter list.
+     * Opens or closes one option's voter list.
      *
-     * The first page comes with the vote itself, so opening costs nothing; only "more" is a request.
-     * Anonymous votes never get here — the card offers no handle to pull.
+     * Never a request either way. The first page comes with the vote itself, and a list that has been
+     * paged further is kept across a close — see [VoterListState.expanded]. Anonymous votes never get
+     * here: the card offers no handle to pull.
      */
-    fun expandVoters(itemId: Long) {
+    fun toggleVoters(itemId: Long) {
         val state = _uiState.value
         val vote = state.vote ?: return
         if (!vote.isPublic || !state.showsResults) return
         val existing = state.voters[itemId]
-        if (existing == null) {
-            val seed = vote.items.firstOrNull { it.itemId == itemId }?.voters.orEmpty()
-            _uiState.update {
-                it.copy(voters = it.voters + (itemId to VoterListState(uids = seed, loadedPages = 1)))
-            }
-            return
-        }
+        val next =
+            existing?.copy(expanded = !existing.expanded)
+                ?: VoterListState(
+                    uids = vote.items.firstOrNull { it.itemId == itemId }?.voters.orEmpty(),
+                    loadedPages = 1,
+                )
+        _uiState.update { it.copy(voters = it.voters + (itemId to next)) }
+    }
+
+    /**
+     * Asks for the next page of an already-open voter list.
+     *
+     * Separate from [toggleVoters] because only this one costs a request: the strip's own "more" is
+     * the only thing that reaches the network, and a row tapped shut must not.
+     */
+    fun loadMoreVoters(itemId: Long) {
+        val state = _uiState.value
+        val vote = state.vote ?: return
+        if (!vote.isPublic || !state.showsResults) return
+        val existing = state.voters[itemId] ?: return
         if (existing.isLoading || !existing.hasMore) return
         _uiState.update {
             it.copy(voters = it.voters + (itemId to existing.copy(isLoading = true)))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -839,7 +839,8 @@
     <string name="vote_count">%1$d 票</string>
     <string name="vote_percent">%1$d%%</string>
     <string name="vote_total">共 %1$d 票</string>
-    <string name="vote_voters_expand">%1$d 人</string>
+    <string name="vote_voters_expand">查看投票的 %1$d 人</string>
+    <string name="vote_voters_collapse">收起投票人</string>
     <string name="vote_voters_more">加载更多</string>
     <string name="vote_voter_uid">用户 %1$d</string>
     <string name="vote_manage">管理投票</string>

--- a/app/src/test/java/io/github/nodyssey/ui/vote/VoteCardTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/vote/VoteCardTest.kt
@@ -41,7 +41,8 @@ class VoteCardTest {
                     onSubmit = onSubmit,
                     onSetLocked = {},
                     onDelete = {},
-                    onExpandVoters = {},
+                    onToggleVoters = {},
+                    onLoadMoreVoters = {},
                     onSignIn = onSignIn,
                     onUserClick = {},
                 )

--- a/app/src/test/java/io/github/nodyssey/ui/vote/VoteViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/vote/VoteViewModelTest.kt
@@ -250,7 +250,7 @@ class VoteViewModelTest {
             val vm = viewModel(repository)
             advanceUntilIdle()
 
-            vm.expandVoters(13201)
+            vm.toggleVoters(13201)
             advanceUntilIdle()
 
             assertEquals((1L..10L).toList(), vm.uiState.value.voters[13201]?.uids)
@@ -267,15 +267,48 @@ class VoteViewModelTest {
                 )
             val vm = viewModel(repository)
             advanceUntilIdle()
-            vm.expandVoters(13201)
+            vm.toggleVoters(13201)
             advanceUntilIdle()
 
-            vm.expandVoters(13201)
+            vm.loadMoreVoters(13201)
             advanceUntilIdle()
 
             val list = requireNotNull(vm.uiState.value.voters[13201])
             assertEquals((1L..13L).toList(), list.uids)
             assertFalse(list.hasMore)
+            assertEquals(listOf(2), repository.voterPages)
+        }
+
+    /**
+     * Closing keeps what was paged in. Dropping the list instead would make the second open show ten
+     * of thirty voters again, and cost a request per page to get back to where the reader was.
+     */
+    @Test
+    fun `closing a voter list hides it without discarding the pages already fetched`() =
+        runTest(dispatcher) {
+            val repository =
+                FakeVoteRepository(
+                    vote = voted(firstPageVoters = (1L..10L).toList()),
+                    voterPagesByPage = mapOf(2 to (11L..13L).toList()),
+                )
+            val vm = viewModel(repository)
+            advanceUntilIdle()
+            vm.toggleVoters(13201)
+            vm.loadMoreVoters(13201)
+            advanceUntilIdle()
+
+            vm.toggleVoters(13201)
+            advanceUntilIdle()
+
+            assertFalse(requireNotNull(vm.uiState.value.voters[13201]).expanded)
+
+            vm.toggleVoters(13201)
+            advanceUntilIdle()
+
+            val reopened = requireNotNull(vm.uiState.value.voters[13201])
+            assertTrue(reopened.expanded)
+            assertEquals((1L..13L).toList(), reopened.uids)
+            // Still the one request from the first "more": reopening asked for nothing.
             assertEquals(listOf(2), repository.voterPages)
         }
 
@@ -287,7 +320,7 @@ class VoteViewModelTest {
             val vm = viewModel(repository)
             advanceUntilIdle()
 
-            vm.expandVoters(13201)
+            vm.toggleVoters(13201)
             advanceUntilIdle()
 
             assertTrue(vm.uiState.value.voters.isEmpty())


### PR DESCRIPTION
## 为什么

投票帖刚支持没多久，卡片本身「太丑、缺少精致感」。具体的毛病是三条：

1. 一个选项占两行三条基线——文字一行，细进度条一行，票数在右上、百分比在右下，进度条还自带一个 M3 的圆点端头。
2. 没投的选项也画一个灰勾，看着像那些也被选了。
3. 每个选项底下挂一个「N 人」按钮展开投票人，三个就是卡片三分之一的高度，而旁边的票数已经把这个数说过一遍。

中途做过一版「每个选项装进一个盒子」的方案，结果比原版还臃肿，已推翻——这个 PR 是重做的轻量版，靠字重和间距做层次，不给任何元素加容器。这张卡出现在别人的正文中间，一摞填满的色块比它打断的段落还重。

## 改了什么

**结果态**：文字、票数、百分比压在同一行，底下一条 4dp 细线按比例长出来（spring 动画，提交回来时读者能看见票被计上）。自己投的那条是 primary 实色并加粗，票数最高的百分比用 `onSurface` 加重。已投票的卡片高度从 355px 降到 200px。

**投票态**：选项行去掉描边和底色，只剩一个勾和文字。勾是自己画的，因为行本身带 `selectable`/`toggleable` 语义——原来的 `RadioButton`/`Checkbox` 被 `clearAndSetSemantics {}` 清空，读屏根本读不出选中状态，顺手修了。

**投票人列表**（站点原有功能，头像可点进个人空间，链路是 `onUserClick` → `Navigation.kt` 的 `openSpace`，未改动）：

- 入口改成点结果行本身，票数前一个小人图标是唯一提示；匿名投票不出现这个图标。
- `VoteViewModel.expandVoters` 拆成 `toggleVoters`（开关，**永不发请求**）和 `loadMoreVoters`（翻页，只有头像墙里的「加载更多」会调）。原来两件事挤在一个方法里靠"map 里有没有这项"区分，加收起之后这个判断不够用了。
- `VoterListState` 加 `expanded` 字段。**收起保留已加载的页**：翻过三页的人收起再展开，看到的还是那 30 个，不会退回最初的 10 个再让他重新翻。
- 头像 24dp → 28dp，间距挪进点击区里（`clickable` 在前、`padding` 在后），实际点击目标 24dp → 36dp；原来那 4dp 间距是死区。

**其余**：胶囊 chip 和彩色徽标换成标题下一行灰字（仍是各自独立的 `Text` 节点，读屏能逐项停），「共 N 票」从卡底挪进这一行，卡片不再以一行孤零零的灰字收尾；骨架屏改用共享的 `SkeletonBar`；插入投票对话框只剩两个选项时删除按钮直接消失而不是灰着，另加 N/20 计数、开关分组、整行可点、失败提示用 `errorContainer`。

## Reviewer 需要知道的

- **「未投票不显示任何票数」这条规则一行没动**，`VoteCardTest` 里那条最吃重的断言原样通过。站点在本账号投票前不下发 count，卡片也就不显示。
- 新字符串 `vote_voters_collapse`；`vote_voters_expand` 的文案从 `%1$d 人` 改成「查看投票的 %1$d 人」——它现在是读屏的点击标签而不是按钮文字，念"双击 12 人"讲不通。
- 新增测试 `closing a voter list hides it without discarding the pages already fetched`，断言收起后 `expanded=false`、重开后 uid 仍是 1..13、且 `voterPages` 仍只有 `[2]`（重开没发请求）。
- **未在真机验证**：设备是连着的，但要看到结果态就得真投一票，这是不可撤销的站点操作，没做。截图是临时写的 Robolectric 截图测试渲染的（360dp 宽，浅色/深色/锁定/载入/展开各态都看过），测试文件已删除。
- `:app:testDebugUnitTest`、`spotlessCheck`、`:app:lintDebug` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)