### PR TITLE
重做浏览历史界面，保留条数可调

### DIFF
--- a/app/src/main/java/io/github/nodyssey/data/PostRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/PostRepository.kt
@@ -18,6 +18,7 @@ import io.github.nodyssey.data.local.NodeSeekDatabase
 import io.github.nodyssey.data.local.ReadMarkEntity
 import io.github.nodyssey.data.local.toSnapshot
 import io.github.nodyssey.data.local.toSummary
+import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.PostListPage
 import io.github.nodyssey.model.PostSummary
@@ -26,6 +27,7 @@ import io.github.nodyssey.model.ThreadSnapshot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -218,6 +220,25 @@ interface PostRepository {
     suspend fun removeFromHistory(postId: Long)
 
     /**
+     * Puts a just-removed row back, for 撤销.
+     *
+     * The unread baseline comes back at the snapshot's reply count rather than the exact
+     * `lastSeenCommentCount` that was deleted with it — the history entry does not carry that field.
+     * The two are written from the same read and differ only for a thread whose replies were deleted
+     * between reads, so an undo can at worst re-announce a reply the reader had already seen.
+     */
+    suspend fun restoreToHistory(entry: ReadHistoryEntry)
+
+    /**
+     * Drops everything past the current 保留条数.
+     *
+     * Called after the limit is lowered. Every other caller gets this for free when a thread is read;
+     * this exists because a setting change has to take effect on rows nobody is about to re-read —
+     * otherwise a thread the user just told the app to forget would keep greying out its feed row.
+     */
+    suspend fun trimReadHistory()
+
+    /**
      * Forgets every thread this device has read.
      *
      * Also clears the unread baselines, because they are the same rows: read marks do both jobs.
@@ -248,6 +269,11 @@ class OfflineFirstPostRepository(
     private val showBlockedContent: Flow<Boolean> = flowOf(false),
     /** Absent for the same reason [reactions] is; see its note. */
     private val collections: PostCollectionWriter? = null,
+    /**
+     * 浏览历史保留条数, as a flow for the same reason [showBlockedContent] is one: it can change while
+     * the history is on screen, and the list has to re-length itself when it does.
+     */
+    private val readHistoryLimit: Flow<Int> = flowOf(SettingsRepository.DEFAULT_READ_HISTORY_LIMIT),
 ) : PostRepository {
     override fun feed(
         categorySlug: String?,
@@ -444,17 +470,39 @@ class OfflineFirstPostRepository(
             categoryTitle = cached?.body?.categoryTitle ?: listRow?.categoryTitle,
             totalComments = listRow?.commentCount,
         )
-        database.readMarkDao().trimTo(MAX_READ_HISTORY)
+        trimReadHistory()
     }
 
     override fun readHistory(): Flow<List<ReadHistoryEntry>> =
-        database
-            .readMarkDao()
-            .observeHistory(MAX_READ_HISTORY)
+        readHistoryLimit
+            .distinctUntilChanged()
+            .flatMapLatest { limit -> database.readMarkDao().observeHistory(limit) }
             .map { marks -> marks.map(ReadMarkEntity::toHistoryEntry) }
 
     override suspend fun removeFromHistory(postId: Long) {
         database.readMarkDao().delete(postId)
+    }
+
+    override suspend fun restoreToHistory(entry: ReadHistoryEntry) {
+        database.readMarkDao().upsert(
+            ReadMarkEntity(
+                postId = entry.postId,
+                lastReadAtMillis = entry.lastReadAtMillis,
+                lastSeenCommentCount = entry.commentCount ?: 0,
+                title = entry.title,
+                authorName = entry.authorName,
+                authorUid = entry.authorUid,
+                categoryTitle = entry.categoryTitle,
+                commentCount = entry.commentCount,
+            ),
+        )
+    }
+
+    override suspend fun trimReadHistory() {
+        val limit = readHistoryLimit.first()
+        // Skipped rather than run with Int.MAX_VALUE: 无上限 should not cost a full-table DELETE scan
+        // on every thread the user opens.
+        if (limit != SettingsRepository.READ_HISTORY_UNLIMITED) database.readMarkDao().trimTo(limit)
     }
 
     override suspend fun clearReadHistory() {
@@ -501,15 +549,6 @@ class OfflineFirstPostRepository(
 
         /** Enough to cover a browsing session without letting the cache grow forever. */
         const val MAX_CACHED_THREADS = 60
-
-        /**
-         * How many threads the history remembers.
-         *
-         * Far larger than [MAX_CACHED_THREADS] because a row here is a handful of strings rather
-         * than a whole thread, and because it doubles as the unread baseline — trimming it too
-         * eagerly would make threads look unread again while the reader still cares.
-         */
-        const val MAX_READ_HISTORY = 300
     }
 }
 

--- a/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
@@ -76,6 +76,9 @@ class SettingsRepository(
                 notifyMentions = preferences[KEY_NOTIFY_MENTIONS] ?: true,
                 notifyReplies = preferences[KEY_NOTIFY_REPLIES] ?: true,
                 notifyMessages = preferences[KEY_NOTIFY_MESSAGES] ?: true,
+                readHistoryLimit =
+                (preferences[KEY_READ_HISTORY_LIMIT] ?: DEFAULT_READ_HISTORY_LIMIT)
+                    .let { limit -> if (limit in READ_HISTORY_LIMIT_CHOICES) limit else DEFAULT_READ_HISTORY_LIMIT },
             )
         }
 
@@ -130,6 +133,20 @@ class SettingsRepository(
     suspend fun setNotifyReplies(enabled: Boolean) = edit { it[KEY_NOTIFY_REPLIES] = enabled }
 
     suspend fun setNotifyMessages(enabled: Boolean) = edit { it[KEY_NOTIFY_MESSAGES] = enabled }
+
+    /**
+     * How long 浏览历史 remembers. Anything outside [READ_HISTORY_LIMIT_CHOICES] is refused rather
+     * than stored, so a bad write cannot leave the history capped at some number no picker can undo.
+     *
+     * Lowering it does not itself delete anything — the rows go on the next
+     * [io.github.nodyssey.data.PostRepository.trimReadHistory]. The caller that changes this setting
+     * is expected to ask for that trim; see the history screen's ViewModel.
+     */
+    suspend fun setReadHistoryLimit(limit: Int) =
+        edit {
+            it[KEY_READ_HISTORY_LIMIT] =
+                if (limit in READ_HISTORY_LIMIT_CHOICES) limit else DEFAULT_READ_HISTORY_LIMIT
+        }
 
     suspend fun addSearchHistory(entry: SearchHistoryEntry) {
         val normalized = entry.copy(query = entry.query.trim())
@@ -330,6 +347,27 @@ class SettingsRepository(
         val POLL_MINUTE_CHOICES = listOf(15, 30, 60)
         const val DEFAULT_POLL_MINUTES = 30
 
+        /**
+         * 无上限, expressed as a limit so that every caller stays one `LIMIT :n` and one `trimTo(n)`.
+         *
+         * A sentinel of 0 was the obvious alternative and is the dangerous one: a stray 0 anywhere in
+         * this chain would silently mean "keep nothing", and these rows are the unread baselines. The
+         * failure mode of the largest possible number is that nothing gets trimmed.
+         */
+        const val READ_HISTORY_UNLIMITED = Int.MAX_VALUE
+
+        /**
+         * How many threads 浏览历史 keeps.
+         *
+         * A row is a handful of strings — a thousand of them is well under a megabyte — so the cap is
+         * not really about storage. It is about the second job these rows do: they are the baselines
+         * behind 已读变灰 and 「N 条新回复」, and a small cap makes threads look unread again while the
+         * reader still cares. That is why the default is 300 rather than the 100 the list itself
+         * would be tidier at.
+         */
+        val READ_HISTORY_LIMIT_CHOICES = listOf(100, 300, 1000, READ_HISTORY_UNLIMITED)
+        const val DEFAULT_READ_HISTORY_LIMIT = 300
+
         private val KEY_THEME_MODE = stringPreferencesKey("theme_mode")
         private val KEY_DYNAMIC_COLOR = booleanPreferencesKey("dynamic_color")
         private val KEY_FONT_SCALE = floatPreferencesKey("font_scale")
@@ -355,6 +393,7 @@ class SettingsRepository(
         private val KEY_SEEN_REPLIES = intPreferencesKey("notification_seen_replies")
         private val KEY_SEEN_MENTIONS = intPreferencesKey("notification_seen_mentions")
         private val KEY_SEEN_MESSAGES = intPreferencesKey("notification_seen_messages")
+        private val KEY_READ_HISTORY_LIMIT = intPreferencesKey("read_history_limit")
         private val KEY_UPDATE_CHECKED_AT = longPreferencesKey("update_checked_at")
         private val KEY_UPDATE_RELEASE = stringPreferencesKey("update_latest_release")
 
@@ -453,6 +492,8 @@ data class UserSettings(
     val notifyMentions: Boolean = true,
     val notifyReplies: Boolean = true,
     val notifyMessages: Boolean = true,
+    /** 浏览历史保留条数; [SettingsRepository.READ_HISTORY_UNLIMITED] for 无上限. */
+    val readHistoryLimit: Int = SettingsRepository.DEFAULT_READ_HISTORY_LIMIT,
 )
 
 /**

--- a/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
@@ -69,6 +69,8 @@ import io.github.nodyssey.data.update.DefaultAppUpdateRepository
 import io.github.nodyssey.data.update.GitHubReleaseSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import okhttp3.OkHttpClient
 import java.io.File
 import java.util.concurrent.TimeUnit
@@ -190,6 +192,7 @@ class DefaultAppContainer(
             PostReactionWriter(jsonClient),
             settingsRepository.showBlockedContent,
             PostCollectionWriter(jsonClient),
+            settingsRepository.settings.map { it.readHistoryLimit }.distinctUntilChanged(),
         )
     }
 

--- a/app/src/main/java/io/github/nodyssey/ui/common/ChoiceRow.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/ChoiceRow.kt
@@ -1,0 +1,45 @@
+package io.github.nodyssey.ui.common
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * One option in a single-choice list: radio, label, whole row tappable.
+ *
+ * The row rather than the button carries the click — `RadioButton(onClick = null)` is deliberate, and
+ * is what makes the label part of the target and lets TalkBack announce the pair as one selectable.
+ * No height of its own: the radio's own 48dp touch target sets it, which is the minimum this needs
+ * to clear anyway.
+ */
+@Composable
+fun ChoiceRow(
+    label: String,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+        modifier.selectable(
+            selected = selected,
+            role = Role.RadioButton,
+            onClick = onSelect,
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = null)
+        Text(
+            text = label,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}

--- a/app/src/main/java/io/github/nodyssey/ui/common/ThreadRow.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/common/ThreadRow.kt
@@ -1,0 +1,116 @@
+package io.github.nodyssey.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.FlowRowScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.github.nodyssey.ui.theme.Spacing
+
+/**
+ * One thread, as every list of threads in this app draws it: avatar, title, one 12sp meta line.
+ *
+ * The title is the only thing with visual weight; everything else is metadata under it. That is the
+ * whole design of these lists — nine rows fit on an 800dp screen and the title is legible in every
+ * one of them.
+ *
+ * Shared rather than copied because the feed and 浏览历史 list the same objects: two lists of NodeSeek
+ * threads that round their gutters differently read as two different apps, and that is exactly what
+ * happened when the history screen was built out of `ListItem`. Everything that varies between the
+ * two — a pin instead of an avatar, a lock beside the title, which counts go on the meta line — is a
+ * slot here, so a caller can differ without re-deciding the geometry.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ThreadRow(
+    onClick: () -> Unit,
+    leading: @Composable () -> Unit,
+    title: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    meta: @Composable FlowRowScope.() -> Unit,
+) {
+    Row(
+        modifier =
+        modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .background(containerColor)
+            .padding(start = 14.dp, end = Spacing.lg, top = 10.dp, bottom = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        leading()
+        Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
+            Row(verticalAlignment = Alignment.CenterVertically, content = title)
+            // Flows rather than clips so that a large system font wraps the meta onto a second line
+            // instead of pushing the timestamp — the single most useful item there — off the edge.
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+                itemVerticalAlignment = Alignment.CenterVertically,
+                content = meta,
+            )
+        }
+    }
+}
+
+/**
+ * The thread title, at the one size and rhythm every list states it in.
+ *
+ * [color] and [fontWeight] are parameters because a read thread in the feed is dimmed by both, while
+ * every row of the history is read by definition and dimming them all would say nothing.
+ */
+@Composable
+fun ThreadRowTitle(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.onSurface,
+    fontWeight: FontWeight = FontWeight.SemiBold,
+) {
+    Text(
+        text = text,
+        // Trimmed at the top so the glyphs start at the row's top edge instead of 3sp below it:
+        // 15/21 leaves leading above the first line, and against the avatar beside it that gap read
+        // as the avatar sitting higher than the title.
+        style =
+        MaterialTheme.typography.titleMedium.copy(
+            lineHeightStyle =
+            LineHeightStyle(
+                alignment = LineHeightStyle.Alignment.Proportional,
+                trim = LineHeightStyle.Trim.FirstLineTop,
+            ),
+        ),
+        color = color,
+        fontWeight = fontWeight,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Drops the avatar onto the title's cap line.
+ *
+ * Even with the first line's leading trimmed, a 15sp line box still starts a few pixels above the
+ * tallest glyph — ascent is not cap height — so a top-aligned avatar reads as floating higher than
+ * the title next to it. Measured at 15sp on the row as built. An offset rather than padding so the
+ * row keeps its height and the list still fits nine of them on a 800dp screen.
+ */
+val AvatarCapOffset = 5.dp

--- a/app/src/main/java/io/github/nodyssey/ui/history/ReadHistoryScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/history/ReadHistoryScreen.kt
@@ -1,42 +1,81 @@
 package io.github.nodyssey.ui.history
 
-import androidx.compose.foundation.clickable
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Surface
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nodyssey.R
+import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.TimeFormat
 import io.github.nodyssey.data.ReadHistoryEntry
+import io.github.nodyssey.data.settings.SettingsRepository
+import io.github.nodyssey.ui.common.AvatarCapOffset
+import io.github.nodyssey.ui.common.BoardTag
+import io.github.nodyssey.ui.common.ChoiceRow
 import io.github.nodyssey.ui.common.LoadingState
+import io.github.nodyssey.ui.common.MetaText
 import io.github.nodyssey.ui.common.NodysseyIcons
+import io.github.nodyssey.ui.common.SectionLabel
 import io.github.nodyssey.ui.common.StatusView
+import io.github.nodyssey.ui.common.ThreadRow
+import io.github.nodyssey.ui.common.ThreadRowTitle
+import io.github.nodyssey.ui.common.UserAvatar
 import io.github.nodyssey.ui.theme.NodysseyTheme
+import io.github.nodyssey.ui.theme.Sizes
+import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.StatusShapes
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 @Composable
 fun ReadHistoryRoute(
@@ -51,7 +90,9 @@ fun ReadHistoryRoute(
         onBack = onBack,
         onPostClick = onPostClick,
         onRemove = viewModel::remove,
+        onRestore = viewModel::restore,
         onClearAll = viewModel::clear,
+        onLimitChange = viewModel::setLimit,
         modifier = modifier,
     )
 }
@@ -62,19 +103,61 @@ fun ReadHistoryScreen(
     state: ReadHistoryUiState,
     onBack: () -> Unit,
     onPostClick: (Long) -> Unit,
-    onRemove: (Long) -> Unit,
+    onRemove: (ReadHistoryEntry) -> Unit,
+    onRestore: (ReadHistoryEntry) -> Unit,
     onClearAll: () -> Unit,
+    onLimitChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
-    /** Injectable so the relative stamps can be asserted without the test racing the wall clock. */
+    /** Injectable so the relative stamps and the day grouping can be asserted without racing the clock. */
     nowMillis: Long = System.currentTimeMillis(),
 ) {
     var confirmClear by remember { mutableStateOf(false) }
+    var pickingLimit by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val removedMessage = stringResource(R.string.history_removed)
+    val undoLabel = stringResource(R.string.history_undo)
+
+    // Removing one row also drops that thread's unread baseline, so a swipe the reader did not mean
+    // costs them the 「N 条新回复」 on it. Cheap to offer the way back; the row carries everything
+    // needed to write it again.
+    val removeWithUndo: (ReadHistoryEntry) -> Unit = { entry ->
+        onRemove(entry)
+        scope.launch {
+            val outcome =
+                snackbarHostState.showSnackbar(
+                    message = removedMessage,
+                    actionLabel = undoLabel,
+                    duration = SnackbarDuration.Short,
+                )
+            if (outcome == SnackbarResult.ActionPerformed) onRestore(entry)
+        }
+    }
 
     Scaffold(
         modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.history_title)) },
+                title = {
+                    Column {
+                        Text(stringResource(R.string.history_title))
+                        // The one place the retention setting is visible without opening a menu:
+                        // "how much does this thing keep" is the question the screen itself raises.
+                        if (state.entries.isNotEmpty()) {
+                            Text(
+                                text =
+                                stringResource(
+                                    R.string.history_subtitle,
+                                    state.entries.size,
+                                    limitLabel(state.limit),
+                                ),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(
@@ -84,11 +167,12 @@ fun ReadHistoryScreen(
                     }
                 },
                 actions = {
-                    if (state.entries.isNotEmpty()) {
-                        TextButton(onClick = { confirmClear = true }) {
-                            Text(stringResource(R.string.history_clear_all))
-                        }
-                    }
+                    HistoryMenu(
+                        limit = state.limit,
+                        canClear = state.entries.isNotEmpty(),
+                        onPickLimit = { pickingLimit = true },
+                        onClearAll = { confirmClear = true },
+                    )
                 },
             )
         },
@@ -107,17 +191,25 @@ fun ReadHistoryScreen(
                         description = stringResource(R.string.history_empty_body),
                     )
 
-                else ->
-                    LazyColumn {
-                        items(state.entries, key = ReadHistoryEntry::postId) { entry ->
-                            HistoryRow(
-                                entry = entry,
-                                nowMillis = nowMillis,
-                                onClick = { onPostClick(entry.postId) },
-                                onRemove = { onRemove(entry.postId) },
-                            )
+                else -> {
+                    val sections = remember(state.entries, nowMillis) { historySections(state.entries, nowMillis) }
+                    LazyColumn(Modifier.fillMaxSize()) {
+                        sections.forEach { section ->
+                            stickyHeader(key = section.bucket) {
+                                HistorySectionHeader(stringResource(section.bucket.labelRes))
+                            }
+                            items(section.entries, key = ReadHistoryEntry::postId) { entry ->
+                                HistoryRow(
+                                    entry = entry,
+                                    stamp = historyStamp(entry, section.bucket, nowMillis),
+                                    onClick = { onPostClick(entry.postId) },
+                                    onRemove = { removeWithUndo(entry) },
+                                    modifier = Modifier.animateItem(),
+                                )
+                            }
                         }
                     }
+                }
             }
         }
     }
@@ -145,53 +237,307 @@ fun ReadHistoryScreen(
             },
         )
     }
+
+    if (pickingLimit) {
+        HistoryLimitDialog(
+            current = state.limit,
+            onSelect = onLimitChange,
+            onDismiss = { pickingLimit = false },
+        )
+    }
 }
 
+/**
+ * 保留条数 and 全部清除, behind one overflow.
+ *
+ * 全部清除 used to be a text button in the bar. It is the most destructive thing on the screen and it
+ * sat one mis-tap from 返回, which is not where a button that un-reads the whole feed belongs.
+ */
+@Composable
+private fun HistoryMenu(
+    limit: Int,
+    canClear: Boolean,
+    onPickLimit: () -> Unit,
+    onClearAll: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.action_more))
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.history_limit_title)) },
+                leadingIcon = { Icon(NodysseyIcons.History, contentDescription = null) },
+                trailingIcon = {
+                    Text(
+                        text = limitLabel(limit),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                onClick = {
+                    expanded = false
+                    onPickLimit()
+                },
+            )
+            if (canClear) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            stringResource(R.string.history_clear_all),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onClearAll()
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One read thread, laid out like the feed row it came from: avatar, title, one 12sp meta line.
+ *
+ * Deliberately not a `ListItem`. The history is the same objects the feed lists, and rendering them
+ * in a different vocabulary — a clock icon on every row, the board as plain text — made the screen
+ * read as a different app's list. The clock is gone for the same reason a "history" badge on every
+ * row of the history carries no information.
+ */
 @Composable
 private fun HistoryRow(
     entry: ReadHistoryEntry,
-    nowMillis: Long,
+    stamp: String,
     onClick: () -> Unit,
     onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     // A thread read before the snapshot columns existed, or one whose page never carried a title.
     // The id is not much, but it is true, and it still opens the thread.
     val title = entry.title?.takeIf { it.isNotBlank() } ?: stringResource(R.string.history_untitled, entry.postId)
-    ListItem(
-        headlineContent = { Text(title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
-        supportingContent = { Text(entry.subtitle(nowMillis)) },
-        leadingContent = {
-            Icon(
-                NodysseyIcons.History,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
-        trailingContent = {
-            IconButton(onClick = onRemove) {
-                Icon(
-                    Icons.Default.Close,
-                    contentDescription = stringResource(R.string.history_remove, title),
+    val removeLabel = stringResource(R.string.history_remove, title)
+    val dismissState =
+        rememberSwipeToDismissBoxState(
+            // Only 起点→终点 would be a second gesture for the same destructive action, and it is the
+            // one the back gesture starts from at the screen edge.
+            confirmValueChange = { it == SwipeToDismissBoxValue.EndToStart },
+        )
+
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = modifier,
+        enableDismissFromStartToEnd = false,
+        onDismiss = { onRemove() },
+        backgroundContent = { RemoveBackdrop() },
+    ) {
+        ThreadRow(
+            onClick = onClick,
+            // Swipe is a mouse-and-eyes gesture; TalkBack gets the same action by name. On the row
+            // rather than on the dismiss box so it lands on the node TalkBack actually focuses.
+            modifier =
+            Modifier.semantics {
+                customActions = listOf(
+                    CustomAccessibilityAction(removeLabel) {
+                        onRemove()
+                        true
+                    },
                 )
+            },
+            leading = {
+                UserAvatar(
+                    // The uid is all the snapshot kept, which is all the site needs: avatars are
+                    // served at /avatar/<uid>.png. A row with no uid falls back to the initial.
+                    url = entry.authorUid?.let(NodeSeekSite::avatarUrl),
+                    name = entry.authorName?.takeIf { it.isNotBlank() } ?: title,
+                    size = Sizes.avatarList,
+                    modifier = Modifier.offset(y = AvatarCapOffset),
+                )
+            },
+            title = {
+                ThreadRowTitle(
+                    text = AnnotatedString(title),
+                    // Every row here is read by definition, so the feed's read/unread weight split
+                    // would say nothing. Full contrast: the title is what the reader is scanning for.
+                    fontWeight = FontWeight.Medium,
+                )
+            },
+        ) {
+            // No slug in the snapshot; the tag falls back to matching on the board's name.
+            BoardTag(title = entry.categoryTitle, slug = null)
+            entry.authorName?.takeIf { it.isNotBlank() }?.let { MetaText(it, singleLine = true) }
+            entry.commentCount?.let {
+                MetaText(stringResource(R.string.post_reply_count, it), singleLine = true)
+            }
+            MetaText(stamp, singleLine = true)
+        }
+    }
+}
+
+/** What sits under a row being swiped away. */
+@Composable
+private fun RemoveBackdrop() {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.errorContainer)
+            .padding(horizontal = Spacing.xl),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            Icons.Default.Delete,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onErrorContainer,
+        )
+    }
+}
+
+/**
+ * 今天 / 昨天 / 最近七天 / 更早.
+ *
+ * Sticky, so a long scroll always says which day it is looking at — the timestamps alone answer
+ * "how long ago" but not "where am I", and the answer is the reason anyone opens this screen.
+ * Opaque for the same reason: the rows scroll underneath it.
+ */
+@Composable
+private fun HistorySectionHeader(label: String) {
+    Surface(color = MaterialTheme.colorScheme.surface, modifier = Modifier.fillMaxWidth()) {
+        // 10dp + SectionLabel's own 4dp start inset lines the label up with the row titles' gutter.
+        SectionLabel(label, Modifier.padding(start = 10.dp, top = Spacing.md))
+    }
+}
+
+@Composable
+private fun HistoryLimitDialog(
+    current: Int,
+    onSelect: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.history_limit_title)) },
+        text = {
+            Column {
+                // The cost of a small number is not obvious from the number, so it is stated here
+                // rather than left for the reader to work out from their feed going un-greyed.
+                Text(
+                    text = stringResource(R.string.history_limit_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = Spacing.sm),
+                )
+                SettingsRepository.READ_HISTORY_LIMIT_CHOICES.forEach { choice ->
+                    ChoiceRow(
+                        label = limitChoiceLabel(choice),
+                        selected = choice == current,
+                        onSelect = {
+                            onSelect(choice)
+                            onDismiss()
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         },
-        modifier = Modifier.clickable(onClick = onClick),
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.action_cancel)) }
+        },
     )
 }
 
-/** `日常 · someone · 3 天前`, skipping whatever the snapshot did not capture. */
-private fun ReadHistoryEntry.subtitle(nowMillis: Long): String =
-    listOfNotNull(
-        categoryTitle?.takeIf { it.isNotBlank() },
-        authorName?.takeIf { it.isNotBlank() },
-        TimeFormat.relative(lastReadAtMillis, nowMillis),
-    ).joinToString(SUBTITLE_SEPARATOR)
+/** `300 条` / `无上限` — the short form, for the bar and the menu. */
+@Composable
+private fun limitLabel(limit: Int): String =
+    if (limit == SettingsRepository.READ_HISTORY_UNLIMITED) {
+        stringResource(R.string.history_limit_unlimited)
+    } else {
+        stringResource(R.string.history_limit_count, limit)
+    }
 
-private const val SUBTITLE_SEPARATOR = " · "
+/** The same, plus which one is the default — worth knowing while choosing, and noise everywhere else. */
+@Composable
+private fun limitChoiceLabel(limit: Int): String =
+    if (limit == SettingsRepository.DEFAULT_READ_HISTORY_LIMIT) {
+        stringResource(R.string.history_limit_default, limit)
+    } else {
+        limitLabel(limit)
+    }
+
+/**
+ * What the row says about when it was read, given the heading it already sits under.
+ *
+ * A row under 昨天 that also said "昨天" was the first version, and it wasted the most useful slot on
+ * the line to repeat the header. The day is the heading's job; inside today and yesterday the row
+ * adds the clock, and further back — where the heading is only a range — it adds the distance.
+ */
+private fun historyStamp(
+    entry: ReadHistoryEntry,
+    bucket: HistoryBucket,
+    nowMillis: Long,
+): String =
+    when (bucket) {
+        HistoryBucket.Today, HistoryBucket.Yesterday -> TimeFormat.clock(entry.lastReadAtMillis)
+        HistoryBucket.Week, HistoryBucket.Earlier -> TimeFormat.relative(entry.lastReadAtMillis, nowMillis)
+    }
+
+/** The day headings, newest first. */
+internal enum class HistoryBucket(
+    @StringRes val labelRes: Int,
+) {
+    Today(R.string.history_section_today),
+    Yesterday(R.string.history_section_yesterday),
+    Week(R.string.history_section_week),
+    Earlier(R.string.history_section_earlier),
+}
+
+internal data class HistorySection(
+    val bucket: HistoryBucket,
+    val entries: List<ReadHistoryEntry>,
+)
+
+/**
+ * Buckets the history by calendar day rather than by elapsed hours.
+ *
+ * Calendar days because that is how a reader remembers reading something: a thread opened at 00:30
+ * belongs to 今天 even though "22 小时前" would put it a day back. The bucket order is the enum's, so
+ * an out-of-order list — which the database never returns, but a preview might — still reads top to
+ * bottom. A timestamp in the future (a clock that moved) lands in 今天; there is no heading for it
+ * and pretending it is old would be worse.
+ */
+internal fun historySections(
+    entries: List<ReadHistoryEntry>,
+    nowMillis: Long,
+    zone: ZoneId = ZoneId.systemDefault(),
+): List<HistorySection> {
+    val today = Instant.ofEpochMilli(nowMillis).atZone(zone).toLocalDate()
+    return entries
+        .groupBy { entry ->
+            val day = Instant.ofEpochMilli(entry.lastReadAtMillis).atZone(zone).toLocalDate()
+            when (ChronoUnit.DAYS.between(day, today)) {
+                1L -> HistoryBucket.Yesterday
+                in 2L..6L -> HistoryBucket.Week
+                in 7L..Long.MAX_VALUE -> HistoryBucket.Earlier
+                else -> HistoryBucket.Today
+            }
+        }.map { (bucket, rows) -> HistorySection(bucket, rows) }
+        .sortedBy { it.bucket.ordinal }
+}
 
 @Preview
 @Composable
 private fun ReadHistoryScreenPreview() {
+    val now = 1_800_000_000_000L
     NodysseyTheme {
         ReadHistoryScreen(
             state =
@@ -199,16 +545,18 @@ private fun ReadHistoryScreenPreview() {
                 isLoading = false,
                 entries =
                 listOf(
-                    ReadHistoryEntry(1, "绿云抢鸡竞赛又要开始了", "ipv4", 34378, "日常", 42, 1_000_000L),
-                    ReadHistoryEntry(2, null, null, null, null, null, 900_000L),
+                    ReadHistoryEntry(1, "绿云抢鸡竞赛又要开始了", "ipv4", 34378, "日常", 42, now - 3 * 60 * 60 * 1000L),
+                    ReadHistoryEntry(2, "求一个便宜的小鸡跑 NAT", "someone", 1, "交易", 7, now - 26 * 60 * 60 * 1000L),
+                    ReadHistoryEntry(3, null, null, null, null, null, now - 5 * 24 * 60 * 60 * 1000L),
                 ),
             ),
             onBack = {},
             onPostClick = {},
             onRemove = {},
+            onRestore = {},
             onClearAll = {},
-            // Two days after the newest row, so the preview shows the relative stamps doing work.
-            nowMillis = 1_000_000L + 2 * 24 * 60 * 60 * 1000L,
+            onLimitChange = {},
+            nowMillis = now,
         )
     }
 }

--- a/app/src/main/java/io/github/nodyssey/ui/history/ReadHistoryViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/history/ReadHistoryViewModel.kt
@@ -7,10 +7,13 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import io.github.nodyssey.data.PostRepository
 import io.github.nodyssey.data.ReadHistoryEntry
+import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.di.AppContainer
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -18,6 +21,8 @@ data class ReadHistoryUiState(
     val entries: List<ReadHistoryEntry> = emptyList(),
     /** True until the first database emission; an empty list before that is not yet an empty history. */
     val isLoading: Boolean = true,
+    /** 保留条数, as the picker shows it. [SettingsRepository.READ_HISTORY_UNLIMITED] means 无上限. */
+    val limit: Int = SettingsRepository.DEFAULT_READ_HISTORY_LIMIT,
 )
 
 /**
@@ -27,10 +32,12 @@ data class ReadHistoryUiState(
  * failure state: the database either has rows or it does not.
  *
  * The rows are the same ones that make "4 条新回复" work on the feed. That sharing is why clearing
- * the history is a confirmed action rather than a plain button — see the screen.
+ * the history is a confirmed action rather than a plain button, why a single removal offers 撤销, and
+ * why the 保留条数 picker says out loud what a smaller number costs — see the screen.
  */
 class ReadHistoryViewModel(
     private val repository: PostRepository,
+    private val settings: SettingsRepository,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ReadHistoryUiState())
     val uiState: StateFlow<ReadHistoryUiState> = _uiState.asStateFlow()
@@ -41,20 +48,44 @@ class ReadHistoryViewModel(
                 _uiState.update { it.copy(entries = entries, isLoading = false) }
             }
         }
+        viewModelScope.launch {
+            settings.settings
+                .map { it.readHistoryLimit }
+                .distinctUntilChanged()
+                .collect { limit -> _uiState.update { it.copy(limit = limit) } }
+        }
     }
 
-    fun remove(postId: Long) {
-        viewModelScope.launch { repository.removeFromHistory(postId) }
+    fun remove(entry: ReadHistoryEntry) {
+        viewModelScope.launch { repository.removeFromHistory(entry.postId) }
+    }
+
+    /** Undo for [remove]. See [PostRepository.restoreToHistory] for what comes back and what does not. */
+    fun restore(entry: ReadHistoryEntry) {
+        viewModelScope.launch { repository.restoreToHistory(entry) }
     }
 
     fun clear() {
         viewModelScope.launch { repository.clearReadHistory() }
     }
 
+    /**
+     * Stores the new 保留条数 and applies it at once.
+     *
+     * The trim is not decoration: rows past the limit would otherwise keep greying out their feed
+     * rows until the next thread is opened, so the setting would look like it had not taken.
+     */
+    fun setLimit(limit: Int) {
+        viewModelScope.launch {
+            settings.setReadHistoryLimit(limit)
+            repository.trimReadHistory()
+        }
+    }
+
     companion object {
         fun factory(container: AppContainer): ViewModelProvider.Factory =
             viewModelFactory {
-                initializer { ReadHistoryViewModel(container.postRepository) }
+                initializer { ReadHistoryViewModel(container.postRepository, container.settingsRepository) }
             }
     }
 }

--- a/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postlist/PostListScreen.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -78,8 +76,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.LineHeightStyle
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -96,6 +92,7 @@ import io.github.nodyssey.data.FeedPost
 import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.PostSummary
 import io.github.nodyssey.ui.common.AppendSpinner
+import io.github.nodyssey.ui.common.AvatarCapOffset
 import io.github.nodyssey.ui.common.AvatarShape
 import io.github.nodyssey.ui.common.BoardTag
 import io.github.nodyssey.ui.common.EmptyFeedState
@@ -103,6 +100,8 @@ import io.github.nodyssey.ui.common.MetaText
 import io.github.nodyssey.ui.common.NodeSeekErrorState
 import io.github.nodyssey.ui.common.NodysseyIcons
 import io.github.nodyssey.ui.common.SkeletonBar
+import io.github.nodyssey.ui.common.ThreadRow
+import io.github.nodyssey.ui.common.ThreadRowTitle
 import io.github.nodyssey.ui.common.UserAvatar
 import io.github.nodyssey.ui.theme.NodysseyTheme
 import io.github.nodyssey.ui.theme.Sizes
@@ -365,16 +364,6 @@ private val NavigationDirectionThreshold = 16.dp
 private const val SCROLL_TO_TOP_ANIMATED_ITEMS = 12
 
 /**
- * Drops the avatar onto the title's cap line.
- *
- * Even with the first line's leading trimmed, a 15sp line box still starts a few pixels above the
- * tallest glyph — ascent is not cap height — so a top-aligned avatar reads as floating higher than
- * the title next to it. Measured at 15sp on the row as built. An offset rather than padding so the
- * row keeps its height and the list still fits nine of them on a 800dp screen.
- */
-private val AvatarCapOffset = 5.dp
-
-/**
  * Turns deliberate user scroll direction into a sticky navigation-bar state.
  *
  * A negative Y delta advances the feed and hides the bar. A positive delta moves back toward earlier
@@ -534,100 +523,81 @@ internal fun PostRow(
     highlight: String? = null,
 ) {
     val summary = post.summary
-    Row(
-        modifier =
-        Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .background(
-                if (summary.isPinned) {
-                    MaterialTheme.colorScheme.surfaceContainerLow
-                } else {
-                    MaterialTheme.colorScheme.surface
-                },
-            ).padding(start = 14.dp, end = Spacing.lg, top = 10.dp, bottom = 10.dp),
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
+    ThreadRow(
+        onClick = onClick,
+        containerColor =
         if (summary.isPinned) {
-            Box(
-                modifier =
-                Modifier
-                    .offset(y = AvatarCapOffset)
-                    .size(Sizes.avatarList)
-                    .clip(AvatarShape)
-                    .background(MaterialTheme.colorScheme.primaryContainer),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = NodysseyIcons.PushPin,
-                    contentDescription = stringResource(R.string.post_badge_pinned),
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(18.dp),
+            MaterialTheme.colorScheme.surfaceContainerLow
+        } else {
+            MaterialTheme.colorScheme.surface
+        },
+        leading = {
+            if (summary.isPinned) {
+                Box(
+                    modifier =
+                    Modifier
+                        .offset(y = AvatarCapOffset)
+                        .size(Sizes.avatarList)
+                        .clip(AvatarShape)
+                        .background(MaterialTheme.colorScheme.primaryContainer),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = NodysseyIcons.PushPin,
+                        contentDescription = stringResource(R.string.post_badge_pinned),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            } else {
+                UserAvatar(
+                    url = summary.avatarUrl,
+                    name = summary.authorName,
+                    size = Sizes.avatarList,
+                    modifier = Modifier.offset(y = AvatarCapOffset),
                 )
             }
-        } else {
-            UserAvatar(
-                url = summary.avatarUrl,
-                name = summary.authorName,
-                size = Sizes.avatarList,
-                modifier = Modifier.offset(y = AvatarCapOffset),
+        },
+        title = {
+            ThreadRowTitle(
+                text = highlighted(summary.title, highlight, MaterialTheme.colorScheme.primary),
+                // A read thread is dimmed rather than hidden — the list is still the user's history,
+                // and the drop in both weight and contrast is legible at a glance without adding a
+                // badge that would cost a row's worth of space.
+                color =
+                if (post.isRead) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
+                fontWeight = if (post.isRead) FontWeight.Medium else FontWeight.SemiBold,
+                // Not filling, so the lock beside it keeps its place instead of being pushed off.
+                modifier = Modifier.weight(1f, fill = false),
             )
-        }
-
-        Column(verticalArrangement = Arrangement.spacedBy(Spacing.xs)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = highlighted(summary.title, highlight, MaterialTheme.colorScheme.primary),
-                    // Trimmed at the top so the glyphs start at the row's top edge instead of 3sp
-                    // below it: 15/21 leaves leading above the first line, and against a 40dp avatar
-                    // that gap read as the avatar sitting higher than the title beside it.
-                    style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        lineHeightStyle =
-                        LineHeightStyle(
-                            alignment = LineHeightStyle.Alignment.Proportional,
-                            trim = LineHeightStyle.Trim.FirstLineTop,
-                        ),
-                    ),
-                    // A read thread is dimmed rather than hidden — the list is still the user's
-                    // history, and the drop in both weight and contrast is legible at a glance
-                    // without adding a badge that would cost a row's worth of space.
-                    color =
-                    if (post.isRead) {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    } else {
-                        MaterialTheme.colorScheme.onSurface
-                    },
-                    fontWeight = if (post.isRead) FontWeight.Medium else FontWeight.SemiBold,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false),
+            if (summary.isLocked) {
+                Icon(
+                    Icons.Default.Lock,
+                    contentDescription =
+                    summary.lockLevel
+                        ?.let { stringResource(R.string.post_badge_locked_level, it) }
+                        ?: stringResource(R.string.post_badge_locked),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    // 16dp per the b1 §8 只读→锁定 mapping spec.
+                    modifier = Modifier
+                        .padding(start = Spacing.xs)
+                        .size(16.dp),
                 )
-                if (summary.isLocked) {
-                    Icon(
-                        Icons.Default.Lock,
-                        contentDescription =
-                        summary.lockLevel
-                            ?.let { stringResource(R.string.post_badge_locked_level, it) }
-                            ?: stringResource(R.string.post_badge_locked),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        // 16dp per the b1 §8 只读→锁定 mapping spec.
-                        modifier = Modifier
-                            .padding(start = Spacing.xs)
-                            .size(16.dp),
+                summary.lockLevel?.let { level ->
+                    Text(
+                        text = level.toString(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    summary.lockLevel?.let { level ->
-                        Text(
-                            text = level.toString(),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
                 }
             }
-            PostMetaRow(post)
-        }
-    }
+        },
+        meta = { PostMetaItems(post) },
+    )
 }
 
 /**
@@ -660,29 +630,21 @@ internal fun highlighted(
 /**
  * The meta line, in the order a scanning eye wants it: what board, who, how busy, how fresh.
  *
- * It flows rather than clips so that a large system font wraps it onto a second line instead of
- * pushing the timestamp — the single most useful item here — off the edge.
+ * The row itself belongs to [ThreadRow] — this only says what goes in it.
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun PostMetaRow(post: FeedPost) {
+private fun PostMetaItems(post: FeedPost) {
     val summary = post.summary
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-        itemVerticalAlignment = Alignment.CenterVertically,
-    ) {
-        BoardTag(title = summary.categoryTitle, slug = summary.categorySlug)
-        MetaText(summary.authorName, singleLine = true)
-        if (summary.isPinned) MetaText(stringResource(R.string.post_badge_pinned), singleLine = true)
-        if (post.newCommentCount > 0) {
-            NewReplyBadge(post.newCommentCount)
-        } else {
-            summary.commentCount?.let { MetaText(stringResource(R.string.post_reply_count, it), singleLine = true) }
-        }
-        summary.viewCount?.let { MetaText(stringResource(R.string.post_view_count, it), singleLine = true) }
-        summary.lastActiveText?.let { MetaText(it, singleLine = true) }
+    BoardTag(title = summary.categoryTitle, slug = summary.categorySlug)
+    MetaText(summary.authorName, singleLine = true)
+    if (summary.isPinned) MetaText(stringResource(R.string.post_badge_pinned), singleLine = true)
+    if (post.newCommentCount > 0) {
+        NewReplyBadge(post.newCommentCount)
+    } else {
+        summary.commentCount?.let { MetaText(stringResource(R.string.post_reply_count, it), singleLine = true) }
     }
+    summary.viewCount?.let { MetaText(stringResource(R.string.post_view_count, it), singleLine = true) }
+    summary.lastActiveText?.let { MetaText(it, singleLine = true) }
 }
 
 /** Replaces the reply count once the user has read the thread: the delta is the useful number. */

--- a/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/search/SearchScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
@@ -44,7 +43,6 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryTabRow
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SearchBarValue
@@ -67,7 +65,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -86,6 +83,7 @@ import io.github.nodyssey.data.UserSearchResult
 import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.SearchHistoryEntry
 import io.github.nodyssey.model.SearchTarget
+import io.github.nodyssey.ui.common.ChoiceRow
 import io.github.nodyssey.ui.common.LoadingState
 import io.github.nodyssey.ui.common.NoSearchResultsState
 import io.github.nodyssey.ui.common.NodeSeekErrorState
@@ -803,8 +801,8 @@ private fun BoardRangeSheet(
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(Spacing.sm),
             ) {
-                BoardRadioRow(
-                    title = stringResource(R.string.search_all_boards),
+                ChoiceRow(
+                    label = stringResource(R.string.search_all_boards),
                     selected = picked == null,
                     onSelect = { picked = null },
                 )
@@ -840,8 +838,8 @@ private fun BoardRadioGrid(
     boards.chunked(2).forEach { row ->
         Row(Modifier.fillMaxWidth()) {
             row.forEach { board ->
-                BoardRadioRow(
-                    title = board.title,
+                ChoiceRow(
+                    label = board.title,
                     selected = board.slug != null && board.slug == selected,
                     onSelect = { onSelect(board.slug) },
                     modifier = Modifier.weight(1f),
@@ -849,32 +847,6 @@ private fun BoardRadioGrid(
             }
             if (row.size == 1) Spacer(Modifier.weight(1f))
         }
-    }
-}
-
-@Composable
-private fun BoardRadioRow(
-    title: String,
-    selected: Boolean,
-    onSelect: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier =
-        modifier.selectable(
-            selected = selected,
-            role = Role.RadioButton,
-            onClick = onSelect,
-        ),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        RadioButton(selected = selected, onClick = null)
-        Text(
-            title,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -879,6 +879,20 @@
     <!-- These rows double as the unread baseline, and the reader has to know that before agreeing -->
     <string name="history_clear_body">这些记录同时也是「几条新回复」的已读基准。清除之后，列表里已读变灰的帖子会重新显示为未读。</string>
     <string name="history_clear_confirm">清除</string>
+    <!-- Top bar second line: how much is kept, and how much of that is used -->
+    <string name="history_subtitle">共 %1$d 条 · 保留 %2$s</string>
+    <string name="history_section_today">今天</string>
+    <string name="history_section_yesterday">昨天</string>
+    <string name="history_section_week">最近七天</string>
+    <string name="history_section_earlier">更早</string>
+    <string name="history_removed">已移除一条记录</string>
+    <string name="history_undo">撤销</string>
+    <!-- 保留条数 — the same rows are the unread baseline, so the picker has to say what a small number costs -->
+    <string name="history_limit_title">保留条数</string>
+    <string name="history_limit_body">浏览记录同时是「已读」和「N 条新回复」的判断依据。留得越少，读过的旧帖越早重新显示为未读。一条记录只是几个字段，一千条也远不到 1 MB。</string>
+    <string name="history_limit_count">%1$d 条</string>
+    <string name="history_limit_unlimited">无上限</string>
+    <string name="history_limit_default">%1$d 条（默认）</string>
 
     <!-- 图床 (nodeimage.com) — a separate service; see NodeImageSite for why it has its own vocabulary. -->
     <string name="nodeimage_title">NodeImage 图床</string>

--- a/app/src/test/java/io/github/nodyssey/data/ReadHistoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/ReadHistoryTest.kt
@@ -3,9 +3,12 @@ package io.github.nodyssey.data
 import io.github.nodyssey.data.local.FeedPositionEntity
 import io.github.nodyssey.data.local.NodeSeekDatabase
 import io.github.nodyssey.data.local.toEntity
+import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.model.PostContent
 import io.github.nodyssey.model.PostSummary
 import io.github.nodyssey.model.RichNode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -170,24 +173,85 @@ class ReadHistoryTest {
             assertNull(database.readMarkDao().find(1))
         }
 
+    /** Undo for a swiped-away row: the snapshot is enough to write the whole mark again. */
+    @Test
+    fun `a removed entry can be put back`() =
+        runTest {
+            givenListedPost(postId = 7, title = "绿云抢鸡竞赛", author = "ipv4")
+            repository.markThreadRead(7)
+            val removed = repository.readHistory().first().single()
+
+            repository.removeFromHistory(7)
+            repository.restoreToHistory(removed)
+
+            val restored = repository.readHistory().first().single()
+            assertEquals(removed, restored)
+            // And with it the unread baseline, which is the half of this row nobody can see.
+            assertEquals(10, database.readMarkDao().find(7)?.lastSeenCommentCount)
+        }
+
     /** The table gains a row per thread ever opened, so something has to bound it. */
     @Test
     fun `the history is trimmed to its cap, oldest first`() =
         runTest {
-            val overflow = OfflineFirstPostRepository.MAX_READ_HISTORY + 5
-            repeat(overflow) { index ->
-                val postId = index + 1L
-                givenListedPost(postId = postId, title = "post $postId")
-                repository.markThreadRead(postId)
-                clock.advanceBy(1_000)
-            }
+            val cap = 8
+            repository = repositoryWithLimit(MutableStateFlow(cap))
+            givenReadThreads(cap + 5)
 
             val history = repository.readHistory().first()
-            assertEquals(OfflineFirstPostRepository.MAX_READ_HISTORY, history.size)
-            assertEquals(overflow.toLong(), history.first().postId)
+            assertEquals(cap, history.size)
+            assertEquals((cap + 5).toLong(), history.first().postId)
             // The five oldest went, and so did their read marks.
             assertNull(database.readMarkDao().find(1))
         }
+
+    /** 无上限 keeps everything — including the read marks the feed greys its rows with. */
+    @Test
+    fun `an unlimited history is never trimmed`() =
+        runTest {
+            repository =
+                repositoryWithLimit(MutableStateFlow(SettingsRepository.READ_HISTORY_UNLIMITED))
+            givenReadThreads(12)
+
+            assertEquals(12, repository.readHistory().first().size)
+        }
+
+    /**
+     * Lowering 保留条数 has to take effect on rows nobody is about to re-read: they would otherwise
+     * go on greying out their feed rows until the next thread is opened.
+     */
+    @Test
+    fun `lowering the limit shortens the list and drops the rows on request`() =
+        runTest {
+            val limit = MutableStateFlow(SettingsRepository.READ_HISTORY_UNLIMITED)
+            repository = repositoryWithLimit(limit)
+            givenReadThreads(12)
+
+            limit.value = 5
+
+            // The list re-lengths on its own, because the query is re-run with the new limit.
+            assertEquals(5, repository.readHistory().first().size)
+            // The rows themselves survive until something asks, which is what the setting screen does.
+            assertEquals(12, database.readMarkDao().observeHistory(Int.MAX_VALUE).first().size)
+
+            repository.trimReadHistory()
+
+            assertEquals(5, database.readMarkDao().observeHistory(Int.MAX_VALUE).first().size)
+            assertNull(database.readMarkDao().find(1))
+        }
+
+    private fun repositoryWithLimit(limit: Flow<Int>) =
+        OfflineFirstPostRepository(database, remote, clock, readHistoryLimit = limit)
+
+    /** Reads threads 1..[count], one second apart, so the oldest is the lowest id. */
+    private suspend fun givenReadThreads(count: Int) {
+        repeat(count) { index ->
+            val postId = index + 1L
+            givenListedPost(postId = postId, title = "post $postId")
+            repository.markThreadRead(postId)
+            clock.advanceBy(1_000)
+        }
+    }
 
     private fun opener(
         author: String,

--- a/app/src/test/java/io/github/nodyssey/ui/history/HistorySectionsTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/history/HistorySectionsTest.kt
@@ -1,0 +1,68 @@
+package io.github.nodyssey.ui.history
+
+import io.github.nodyssey.data.ReadHistoryEntry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.ZoneId
+
+/**
+ * The day headings, which are calendar arithmetic and therefore where the off-by-one lives.
+ *
+ * A fixed zone rather than the device's: "yesterday" is a question about a calendar, and a test that
+ * asked it in whatever zone the machine happened to be in would pass or fail by geography.
+ */
+class HistorySectionsTest {
+    private val zone = ZoneId.of("Asia/Shanghai")
+
+    /** 2026-08-06 09:00 local. */
+    private val now = 1_785_978_000_000L
+    private val hour = 60 * 60 * 1000L
+    private val day = 24 * hour
+
+    private fun entry(readAt: Long) = ReadHistoryEntry(1, null, null, null, null, null, readAt)
+
+    private fun bucketOf(readAt: Long) =
+        historySections(listOf(entry(readAt)), now, zone).single().bucket
+
+    @Test
+    fun `a read this morning is today`() {
+        assertEquals(HistoryBucket.Today, bucketOf(now - hour))
+    }
+
+    /**
+     * The case that makes this calendar arithmetic and not elapsed hours: 22 hours ago is still last
+     * night if the reader is up early, and last night is 昨天 however few hours have passed.
+     */
+    @Test
+    fun `last night is yesterday even when it is under a day ago`() {
+        assertEquals(HistoryBucket.Yesterday, bucketOf(now - 22 * hour))
+    }
+
+    @Test
+    fun `the sixth day back is still the week and the seventh is not`() {
+        assertEquals(HistoryBucket.Week, bucketOf(now - 6 * day))
+        assertEquals(HistoryBucket.Earlier, bucketOf(now - 7 * day))
+    }
+
+    /** A device whose clock moved backwards. 今天 is wrong by a hair; 更早 would be wrong by a week. */
+    @Test
+    fun `a timestamp in the future reads as today`() {
+        assertEquals(HistoryBucket.Today, bucketOf(now + 2 * hour))
+    }
+
+    /** Sections come out newest first whatever order the rows arrive in. */
+    @Test
+    fun `sections are ordered even when the rows are not`() {
+        val sections =
+            historySections(
+                listOf(entry(now - 8 * day), entry(now), entry(now - 3 * day), entry(now - day)),
+                now,
+                zone,
+            )
+
+        assertEquals(
+            listOf(HistoryBucket.Today, HistoryBucket.Yesterday, HistoryBucket.Week, HistoryBucket.Earlier),
+            sections.map { it.bucket },
+        )
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/ui/history/ReadHistoryScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/history/ReadHistoryScreenTest.kt
@@ -1,11 +1,15 @@
 package io.github.nodyssey.ui.history
 
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import io.github.nodyssey.core.TimeFormat
 import io.github.nodyssey.data.ReadHistoryEntry
+import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.ui.theme.NodysseyTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -22,13 +26,16 @@ class ReadHistoryScreenTest {
     @get:Rule
     val composeRule = createComposeRule()
 
-    private val now = 1_000_000L
+    private val now = 1_800_000_000_000L
+    private val oneDay = 24 * 60 * 60 * 1000L
 
     private fun setScreen(
         state: ReadHistoryUiState,
         onPostClick: (Long) -> Unit = {},
-        onRemove: (Long) -> Unit = {},
+        onRemove: (ReadHistoryEntry) -> Unit = {},
+        onRestore: (ReadHistoryEntry) -> Unit = {},
         onClearAll: () -> Unit = {},
+        onLimitChange: (Int) -> Unit = {},
     ) {
         composeRule.setContent {
             NodysseyTheme {
@@ -37,7 +44,9 @@ class ReadHistoryScreenTest {
                     onBack = {},
                     onPostClick = onPostClick,
                     onRemove = onRemove,
+                    onRestore = onRestore,
                     onClearAll = onClearAll,
+                    onLimitChange = onLimitChange,
                     nowMillis = now,
                 )
             }
@@ -60,12 +69,28 @@ class ReadHistoryScreenTest {
         lastReadAtMillis = readAt,
     )
 
+    /** The swipe's twin, and the only one TalkBack — or a test — can reach. */
+    private fun SemanticsNodeInteraction.performRemove() {
+        val actions = fetchSemanticsNode().config[SemanticsActions.CustomActions]
+        composeRule.runOnUiThread {
+            actions.single { it.label.startsWith("从历史中移除") }.action()
+        }
+    }
+
+    private fun openMenu() {
+        composeRule.onNodeWithContentDescription("更多").performClick()
+    }
+
     @Test
     fun `lists what the snapshot captured`() {
         setScreen(ReadHistoryUiState(isLoading = false, entries = listOf(entry(7))))
 
         composeRule.onNodeWithText("绿云抢鸡竞赛").assertIsDisplayed()
-        composeRule.onNodeWithText("日常 · ipv4 · 刚刚").assertIsDisplayed()
+        // The meta line is separate pieces now, so the board can be the same coloured tag the feed uses.
+        composeRule.onNodeWithText("日常").assertIsDisplayed()
+        composeRule.onNodeWithText("ipv4").assertIsDisplayed()
+        // Under a 今天 heading the row's slot is better spent on the clock than on repeating the day.
+        composeRule.onNodeWithText(TimeFormat.clock(now)).assertIsDisplayed()
     }
 
     /**
@@ -82,7 +107,27 @@ class ReadHistoryScreenTest {
         )
 
         composeRule.onNodeWithText("帖子 #7").assertIsDisplayed()
-        composeRule.onNodeWithText("刚刚").assertIsDisplayed()
+        composeRule.onNodeWithText(TimeFormat.clock(now)).assertIsDisplayed()
+    }
+
+    /** Day headings are the point of the screen: "when did I read this" is why anyone opens it. */
+    @Test
+    fun `rows are grouped under the day they were read`() {
+        setScreen(
+            ReadHistoryUiState(
+                isLoading = false,
+                entries =
+                listOf(
+                    entry(1, title = "今天读的"),
+                    entry(2, title = "昨天读的", readAt = now - oneDay),
+                    entry(3, title = "上周读的", readAt = now - 9 * oneDay),
+                ),
+            ),
+        )
+
+        composeRule.onNodeWithText("今天").assertIsDisplayed()
+        composeRule.onNodeWithText("昨天").assertIsDisplayed()
+        composeRule.onNodeWithText("更早").assertIsDisplayed()
     }
 
     @Test
@@ -96,13 +141,13 @@ class ReadHistoryScreenTest {
     }
 
     @Test
-    fun `the row's close button removes just that entry`() {
-        var removed: Long? = null
+    fun `removing a row takes just that entry`() {
+        var removed: ReadHistoryEntry? = null
         setScreen(ReadHistoryUiState(isLoading = false, entries = listOf(entry(7))), onRemove = { removed = it })
 
-        composeRule.onNodeWithContentDescription("从历史中移除 绿云抢鸡竞赛").performClick()
+        composeRule.onNodeWithText("绿云抢鸡竞赛").performRemove()
 
-        assertEquals(7L, removed)
+        assertEquals(7L, removed?.postId)
     }
 
     /**
@@ -114,6 +159,7 @@ class ReadHistoryScreenTest {
         var cleared = 0
         setScreen(ReadHistoryUiState(isLoading = false, entries = listOf(entry(7))), onClearAll = { cleared++ })
 
+        openMenu()
         composeRule.onNodeWithText("全部清除").performClick()
 
         composeRule.onNodeWithText("清除浏览历史？").assertIsDisplayed()
@@ -125,11 +171,37 @@ class ReadHistoryScreenTest {
         assertEquals(1, cleared)
     }
 
+    /** How much is kept is a question this screen raises, so it answers it without a menu. */
+    @Test
+    fun `the bar says how much is stored and how much is kept`() {
+        setScreen(ReadHistoryUiState(isLoading = false, entries = listOf(entry(7), entry(8))))
+
+        composeRule.onNodeWithText("共 2 条 · 保留 300 条").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the limit picker states the cost and reports the choice`() {
+        var chosen: Int? = null
+        setScreen(
+            ReadHistoryUiState(isLoading = false, entries = listOf(entry(7))),
+            onLimitChange = { chosen = it },
+        )
+
+        openMenu()
+        composeRule.onNodeWithText("保留条数").performClick()
+
+        composeRule.onNodeWithText("300 条（默认）").assertIsDisplayed()
+        composeRule.onNodeWithText("无上限").performClick()
+
+        assertEquals(SettingsRepository.READ_HISTORY_UNLIMITED, chosen)
+    }
+
     @Test
     fun `an empty history says so and offers nothing to clear`() {
         setScreen(ReadHistoryUiState(isLoading = false, entries = emptyList()))
 
         composeRule.onNodeWithText("还没有看过帖子").assertIsDisplayed()
+        openMenu()
         composeRule.onNodeWithText("全部清除").assertDoesNotExist()
     }
 }

--- a/app/src/test/java/io/github/nodyssey/ui/history/ReadHistoryViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/history/ReadHistoryViewModelTest.kt
@@ -7,9 +7,14 @@ import io.github.nodyssey.data.inMemoryDatabase
 import io.github.nodyssey.data.local.FeedPositionEntity
 import io.github.nodyssey.data.local.NodeSeekDatabase
 import io.github.nodyssey.data.local.toEntity
+import io.github.nodyssey.data.settings.SettingsRepository
+import io.github.nodyssey.data.testSettingsRepository
 import io.github.nodyssey.model.PostSummary
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -30,6 +35,7 @@ class ReadHistoryViewModelTest {
     private val dispatcher = StandardTestDispatcher()
     private val remote = FakePostRemoteDataSource()
     private val clock = MutableClock()
+    private val limit = MutableStateFlow(SettingsRepository.DEFAULT_READ_HISTORY_LIMIT)
     private lateinit var database: NodeSeekDatabase
     private lateinit var repository: OfflineFirstPostRepository
 
@@ -37,7 +43,7 @@ class ReadHistoryViewModelTest {
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         database = inMemoryDatabase(dispatcher)
-        repository = OfflineFirstPostRepository(database, remote, clock)
+        repository = OfflineFirstPostRepository(database, remote, clock, readHistoryLimit = limit)
     }
 
     @After
@@ -80,7 +86,7 @@ class ReadHistoryViewModelTest {
     @Test
     fun `starts loading rather than empty`() =
         runTest(dispatcher) {
-            val vm = ReadHistoryViewModel(repository)
+            val vm = ReadHistoryViewModel(repository, testSettingsRepository(backgroundScope))
 
             assertTrue(vm.uiState.value.isLoading)
             assertTrue(vm.uiState.value.entries.isEmpty())
@@ -92,7 +98,7 @@ class ReadHistoryViewModelTest {
             givenRead(1, "first")
             givenRead(2, "second")
 
-            val vm = ReadHistoryViewModel(repository)
+            val vm = ReadHistoryViewModel(repository, testSettingsRepository(backgroundScope))
             advanceUntilIdle()
 
             assertFalse(vm.uiState.value.isLoading)
@@ -104,20 +110,38 @@ class ReadHistoryViewModelTest {
         runTest(dispatcher) {
             givenRead(1, "first")
             givenRead(2, "second")
-            val vm = ReadHistoryViewModel(repository)
+            val vm = ReadHistoryViewModel(repository, testSettingsRepository(backgroundScope))
             advanceUntilIdle()
 
-            vm.remove(2)
+            vm.remove(vm.uiState.value.entries.first { it.postId == 2L })
             advanceUntilIdle()
 
             assertEquals(listOf(1L), vm.uiState.value.entries.map { it.postId })
+        }
+
+    /** 撤销 on the snackbar. The row comes back where it was, not at the top. */
+    @Test
+    fun `a removed entry can be restored`() =
+        runTest(dispatcher) {
+            givenRead(1, "first")
+            givenRead(2, "second")
+            val vm = ReadHistoryViewModel(repository, testSettingsRepository(backgroundScope))
+            advanceUntilIdle()
+            val removed = vm.uiState.value.entries.first { it.postId == 2L }
+
+            vm.remove(removed)
+            advanceUntilIdle()
+            vm.restore(removed)
+            advanceUntilIdle()
+
+            assertEquals(listOf(2L, 1L), vm.uiState.value.entries.map { it.postId })
         }
 
     @Test
     fun `clearing empties the state`() =
         runTest(dispatcher) {
             givenRead(1, "first")
-            val vm = ReadHistoryViewModel(repository)
+            val vm = ReadHistoryViewModel(repository, testSettingsRepository(backgroundScope))
             advanceUntilIdle()
 
             vm.clear()
@@ -125,5 +149,28 @@ class ReadHistoryViewModelTest {
 
             assertTrue(vm.uiState.value.entries.isEmpty())
             assertFalse(vm.uiState.value.isLoading)
+        }
+
+    /** The picker writes the setting, and the list it is looking at re-lengths from the same store. */
+    @Test
+    fun `choosing a limit stores it and comes back through the state`() =
+        runTest(dispatcher) {
+            val settings = testSettingsRepository(backgroundScope)
+            repository =
+                OfflineFirstPostRepository(
+                    database,
+                    remote,
+                    clock,
+                    readHistoryLimit = settings.settings.map { it.readHistoryLimit },
+                )
+            val vm = ReadHistoryViewModel(repository, settings)
+            advanceUntilIdle()
+            assertEquals(SettingsRepository.DEFAULT_READ_HISTORY_LIMIT, vm.uiState.value.limit)
+
+            vm.setLimit(100)
+            advanceUntilIdle()
+
+            assertEquals(100, settings.settings.first().readHistoryLimit)
+            assertEquals(100, vm.uiState.value.limit)
         }
 }

--- a/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
@@ -349,5 +349,9 @@ private object NoOpPostRepository : PostRepository {
 
     override suspend fun removeFromHistory(postId: Long) = Unit
 
+    override suspend fun restoreToHistory(entry: ReadHistoryEntry) = Unit
+
+    override suspend fun trimReadHistory() = Unit
+
     override suspend fun clearReadHistory() = Unit
 }


### PR DESCRIPTION
## 问题

浏览历史是上个 PR 加的，界面还是一个裸的 M3 `ListItem`：每行左边一个时钟图标（每行都一样，等于没信息）、右边一个 ✕、副标题把版块/作者/时间拼成一个字符串。首页信息流用的是「头像 + 标题 + 彩色版块标签 + 12sp meta 行」，两个列表列的是同一批帖子却是两套视觉语言。

条数上限也是硬编码的 300，藏在 `OfflineFirstPostRepository.MAX_READ_HISTORY` 里，用户看不到也改不了。

## 方案

**界面** — 行改用与信息流同一套：

- 头像用 `authorUid` 拼 `/avatar/<uid>.png`，不动数据库；版块用同一个彩色 `BoardTag`（历史快照没有 slug，标签本来就支持按名字回退）
- 按 **今天 / 昨天 / 最近七天 / 更早** 分组，粘性标题
- 标题下的时间戳看标题给什么：今天/昨天显示时钟（`14:32`），再往前显示 `3 天前` / `7月15日` —— 原先在「昨天」标题下再写一遍「昨天」纯属浪费
- 删除改为左滑，带 Snackbar 撤销；TalkBack 走同名的 custom action（左滑是眼睛和手的手势，读屏用户够不着）
- 「全部清除」从顶栏文字按钮收进溢出菜单 —— 它是这屏最有破坏性的操作，原先离「返回」只差一次误触

**保留条数** — 100 / 300 / 1000 / 无上限，默认仍是 300，存在 DataStore，入口在这屏的溢出菜单，顶栏第二行常驻显示「共 128 条 · 保留 300 条」。

需要强调的一点：这些行同时是**已读基准**，首页的标题变灰和「N 条新回复」都靠它。所以：

- 选择器的说明文字写明了调小的代价（旧帖会重新显示为未读），而不是只给四个数字
- 「无上限」用 `Int.MAX_VALUE` 而不是 0 当哨兵 —— 0 一旦漏到 `trimTo` 就是「一条不留」，而 `Int.MAX_VALUE` 的失败模式只是不裁剪
- 调小后立即 `trimReadHistory()`，否则超出上限的行会继续把首页染灰，看起来像设置没生效
- 单条撤销会把快照连同已读基准一起写回

**顺带的共用件抽取**（回应「共享组件应该能少写不少代码」）：

- `ui/common/ThreadRow.kt` — 行几何 + `ThreadRowTitle` + `AvatarCapOffset`，首页 `PostRow` 和历史行共用
- `ui/common/ChoiceRow.kt` — 单选行，历史的条数对话框和搜索的版块选择器共用（`SearchScreen` 里那个 `BoardRadioRow` 整个删掉）

三处调用点合计 −105 行，两个新文件 +161 行（其中 32 import、40 注释），总行数基本持平。收益是几何和标题样式只有一份，以后改首页行距不会漏掉历史页。

## 验证

```
./gradlew :app:testDebugUnitTest   # 全绿，新增分组/上限/撤销用例
./gradlew :app:lintDebug           # warningsAsErrors，通过
./gradlew spotlessCheck            # 通过
```

新增测试：`HistorySectionsTest`（固定时区下的日期分桶，含 6/7 天边界和时钟回拨），`ReadHistoryTest` 的上限/无上限/调小后裁剪/撤销，`ReadHistoryScreenTest` 的分组标题、顶栏用量行、条数选择器。

真机装过一版看过效果，没有留下改造前后的对照截图。首页那侧的修饰符顺序、内边距和颜色是逐项照搬的，外观应为零变化，但只做了代码核对，没做像素比对。

## 值得单独看一眼的

- 没有加「不记录浏览历史」开关 —— 讨论过，代价是关掉之后全站帖子永远显示未读，收益不抵
- `PostMetaRow` 改名 `PostMetaItems`：`FlowRow` 归 `ThreadRow` 管，它只说里面放什么
- 无 schema 变更、无依赖变更、无选择器变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)
