### PR TITLE
修正引用回复圆角框的竖直位置

### DIFF
--- a/app/src/main/java/io/github/nodyssey/ui/richtext/RichContent.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/richtext/RichContent.kt
@@ -667,7 +667,7 @@ private fun InlineText(
             style =
             SpanStyle(
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
-                fontSize = 12.sp,
+                fontSize = QUOTE_LABEL_SIZE,
                 fontWeight = FontWeight.SemiBold,
                 fontFeatureSettings = TABULAR_FIGURES,
             ),
@@ -855,6 +855,7 @@ private fun InlineText(
         Modifier.drawBehind {
             val layout = textLayoutResult ?: return@drawBehind
             val chipHeight = QUOTE_HEIGHT.toPx()
+            val labelCenter = QUOTE_LABEL_CENTER.toPx()
             quoteRanges.forEach { range ->
                 var start = range.first
                 while (start <= range.last) {
@@ -866,7 +867,11 @@ private fun InlineText(
                     val last = layout.getBoundingBox(end - 1)
                     val left = minOf(first.left, last.left)
                     val right = maxOf(first.right, last.right)
-                    val centerY = (first.top + first.bottom) / 2f
+                    // Hung off the baseline rather than centred in the line box. The box is as tall
+                    // as the *paragraph's* 16sp font plus its leading, and its middle sits well
+                    // above the middle of a 12sp label — which drew the chip a couple of sp high,
+                    // with the label grazing its bottom edge.
+                    val centerY = layout.getLineBaseline(line) - labelCenter
                     drawRoundRect(
                         color = quoteBackground,
                         topLeft = Offset(left, centerY - chipHeight / 2f),
@@ -882,6 +887,17 @@ private fun InlineText(
 
 private val STICKER_SIZE = 20.sp
 private val QUOTE_HEIGHT = 22.sp
+private val QUOTE_LABEL_SIZE = 12.sp
+
+/**
+ * How far the quote label's optical middle sits above the baseline, and so where the chip drawn
+ * behind it is centred.
+ *
+ * Just over a third of the type size is where the middle of a hanzi's em box (0.38em above the
+ * baseline) and the middle of Latin cap height (0.36em) both land — close enough that one figure
+ * centres a label that is usually both at once, `@某人 #12`.
+ */
+private val QUOTE_LABEL_CENTER = QUOTE_LABEL_SIZE * 0.37f
 private const val QUOTE_HORIZONTAL_SPACE = "\u00A0\u00A0"
 private const val STICKER_PREFIX = "sticker:"
 private const val QUOTE_PREFIX = "quote:"


### PR DESCRIPTION
## 问题

正文里 `@某人 #12` 那个引用回复的圆角框整体偏上一点，字反而贴着框的底边。

## 原因

框不是 View，是用 `drawBehind` 画在文字后面的圆角矩形（`RichContent.kt` 的 `InlineText`）。原先圆心取 `layout.getBoundingBox(offset)` 的 top/bottom 中点，但 `getBoundingBox` 返回的是**整行行盒**的上下边，不是这段标签自己的高度：

- 正文 16sp、行高 27sp，行盒中心在基线上方约 5.5sp；正文含汉字时走 CJK 回退字体（ascent 约 1.16em），还会再抬到基线上方 7sp 左右。
- 但框里的标签只有 12sp，它的视觉中心在基线上方约 0.37 × 12 = 4.4sp。

差出的 1~2.5sp 就是框上移的量。字号差得越多、行高越松越明显，所以正文（16sp）里比楼层评论（15sp）里更容易看出来。

## 改动

把框挂在**基线**上，不再取行盒中心：

```kotlin
val centerY = layout.getLineBaseline(line) - QUOTE_LABEL_CENTER.toPx()
```

`QUOTE_LABEL_CENTER = 12.sp × 0.37`。0.37em 是汉字 em 框中心（0.38em）与拉丁大写字高中心（0.36em）的折中——标签 `@某人 #12` 两者都有，一个数就够。顺带把 `fontSize = 12.sp` 提成 `QUOTE_LABEL_SIZE` 常量，避免字号和这个中心值以后各改各的。

水平方向、圆角、颜色、点击热区都没动。

## 验证

- `./gradlew :app:compileDebugKotlin`
- `./gradlew spotlessCheck`

**尚未在设备上截图对比** —— 这是纯几何位移，还请在真机上扫一眼确认观感。没有相应的单测：`drawBehind` 的绘制结果在 Robolectric 下拿不到，且 Robolectric 的字体度量是桩实现，测出来的数字不能反映真机上的 CJK 回退字体，写了也是假绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)