### PR TITLE
让签名字号跟着所在楼层的正文走

### DIFF
--- a/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
@@ -120,6 +120,7 @@ import io.github.nodyssey.ui.theme.PostTitle
 import io.github.nodyssey.ui.theme.Sizes
 import io.github.nodyssey.ui.theme.Spacing
 import io.github.nodyssey.ui.theme.TABULAR_FIGURES
+import io.github.nodyssey.ui.theme.asSignature
 import io.github.nodyssey.ui.theme.readableWidth
 import kotlinx.coroutines.launch
 
@@ -931,6 +932,7 @@ private fun OriginalPost(
         }
         UserSignature(
             nodes = body.signatureNodes,
+            bodyStyle = MaterialTheme.typography.bodyLarge,
             onOpenBrowser = onOpenBrowser,
             onImageClick = onImageClick,
             onJumpToFloor = onJumpToFloor,
@@ -1075,6 +1077,7 @@ private fun CommentRow(
         )
         UserSignature(
             nodes = comment.signatureNodes,
+            bodyStyle = MaterialTheme.typography.bodyMedium,
             onOpenBrowser = onOpenBrowser,
             onImageClick = onImageClick,
             onJumpToFloor = onJumpToFloor,
@@ -1089,10 +1092,17 @@ private fun CommentRow(
     }
 }
 
-/** NodeSeek's public Markdown signature, visually separated from the floor's actual content. */
+/**
+ * NodeSeek's public Markdown signature, visually separated from the floor's actual content.
+ *
+ * [bodyStyle] is the style of the floor this signature hangs off, which [asSignature] steps down
+ * from — a signature is a footer to *that* text, so it has to stay smaller than it at any reading
+ * size rather than sit at a size of its own.
+ */
 @Composable
 private fun UserSignature(
     nodes: List<RichNode>,
+    bodyStyle: TextStyle,
     onOpenBrowser: (String) -> Unit,
     onImageClick: (String) -> Unit,
     onJumpToFloor: (String) -> Unit,
@@ -1108,7 +1118,7 @@ private fun UserSignature(
         onLinkClick = onOpenBrowser,
         onImageClick = onImageClick,
         onQuoteRefClick = { onJumpToFloor(it.floor) },
-        textStyle = MaterialTheme.typography.labelMedium.copy(
+        textStyle = bodyStyle.asSignature().copy(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         ),
     )

--- a/app/src/main/java/io/github/nodyssey/ui/richtext/RichContent.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/richtext/RichContent.kt
@@ -198,13 +198,21 @@ private fun RichBlock(
                 inlines = node.inlines,
                 style =
                 textStyle.copy(
+                    // A multiple of the text it heads, not a fixed sp. The same renderer draws a
+                    // 16sp opening post and a signature two thirds that size, and absolute sizes
+                    // made a signature's `##` line the largest type on the floor it hung off — 20sp
+                    // bold over a 15sp reply, which is not what the site does with the same markup.
+                    // Sized off the base, headings also finally follow the reading-size preference,
+                    // which the fixed sizes ignored: at the largest setting an h1 came out *below*
+                    // the body it introduced.
                     fontSize =
-                    when (node.level) {
-                        1 -> 22.sp
-                        2 -> 20.sp
-                        3 -> 18.sp
-                        else -> 17.sp
-                    },
+                    textStyle.fontSize *
+                        when (node.level) {
+                            1 -> 1.375f
+                            2 -> 1.25f
+                            3 -> 1.125f
+                            else -> 1.0625f
+                        },
                     // Weight, never size alone: a level-4 heading and body text are two points
                     // apart and would otherwise be indistinguishable in Chinese.
                     fontWeight = FontWeight.Bold,

--- a/app/src/main/java/io/github/nodyssey/ui/theme/Type.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/theme/Type.kt
@@ -109,6 +109,26 @@ fun TextStyle.asProse(): TextStyle =
     )
 
 /**
+ * A floor's signature, one step under the body it hangs off.
+ *
+ * Derived from that body's own style rather than fixed, so the step holds at every reading size:
+ * the signature has to stay the quieter voice whether the body is set to 13sp or 24sp, and a fixed
+ * 13sp label overtook the body as soon as the reading size went below default.
+ *
+ * The weight drops back to normal because `labelMedium`'s 500 was making a 13sp signature read
+ * heavier — and so bigger — than the 15sp reply above it. The site does the same thing more
+ * bluntly: it runs signatures at 13px against a 14px body and resets `strong` inside them to 400.
+ */
+fun TextStyle.asSignature(): TextStyle =
+    copy(
+        fontSize = fontSize * SIGNATURE_SCALE,
+        lineHeight = lineHeight * SIGNATURE_SCALE,
+        fontWeight = FontWeight.Normal,
+    )
+
+private const val SIGNATURE_SCALE = 0.85f
+
+/**
  * The full title on the detail screen, where it may wrap to several lines.
  *
  * [LineBreak.Heading] balances the wrapped lines instead of filling the first and leaving a couple


### PR DESCRIPTION
签名看着比正文还大。去站上把真实数值量了一遍（post-703863-1 的 computed style）：

| | 网站 |
|---|---|
| 楼层正文 `p` | 14px / 21px，字重 400 |
| `div.signature` | 13px / 19.5px，400，#787878（0.93×） |
| 签名里的 `h2` | 15.6px（`h2 { font-size: 120% }`，按签名自己的 13px 算） |

app 里同一段 markdown：签名的 `##` 渲染成 **20sp 粗体**，比 15sp 的回复正文大三分之一。

## 两个原因

**标题字号写死成 sp。** `RichContent` 的 heading 分支用的是固定的 22/20/18/17sp，跟传进来的 `textStyle` 无关。同一个渲染器既画 16sp 的主楼也画三分之二大小的签名，写死就意味着签名的标题永远按主楼的尺寸出。写死还让标题不跟阅读字号走——调到最大档时正文 24sp、h1 才 22sp，标题反而比它引出的正文小。

**签名正文用 `labelMedium`，字重 500。** 13sp 的中粗压在 15sp 常规上，看着比正文更重也更大。网站把签名放在 400，连里面的 `strong` 都重置成 400。

## 改动

- `RichContent`：标题字号改成正文字号的倍数（1.375 / 1.25 / 1.125 / 1.0625）。16sp 正文下算出来还是 22/20/18/17，**主楼观感一字不差**；签名里的 h2 落到主楼 17sp、回复 15.9sp，跟网站 15.6 vs 14 是同一个比例。
- `Type.kt` 新增 `asSignature()`：由所在楼层的正文样式退 0.85 档，字重回到 400。主楼 16→13.6sp，回复 15→12.75sp。
- `UserSignature` 收一个 `bodyStyle`，主楼传 `bodyLarge`、回复传 `bodyMedium`。

比例因此在任何阅读字号下都成立——原先固定 13sp 的签名，只要阅读字号调低一档（0.85 档下 bodyMedium = 12.75sp）就会反超正文。

## 验证

`compileDebugKotlin` / `spotlessCheck` / `testDebugUnitTest` 全过。真机连着但锁屏，没解锁，所以这次没有截图；开 post-703863-1 翻到 ggbeng 那楼（签名是个 `<h2>`）就是最直观的对比。

## Reviewer 留意

网站还有两处差异这次**没动**，需要的话另开 PR：

- `.signature { max-height: 44px; overflow: hidden }` — 网站把签名硬裁成两行，超出不显示；app 仍是完整渲染，长签名照样占屏。
- `.signature strong { font-weight: 400 }` — 网站抹平签名里的加粗，app 还照常加粗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)