### PR TITLE
更新检测只认自己的包，发版 tag 只认自己的形状

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 # Pushing a `v*` tag is the whole trigger: it builds that tag, signs it, and publishes the release.
 # Nothing here reads the working tree of `main`, so a tag can be cut from any commit that deserves one.
+#
+# `v*` belongs to Nodyssey alone. A second app in this repository releases under a tag of its own
+# shape — `bbs1-v0.1.0` — which this glob does not match and which its own workflow would claim. Two
+# apps sharing one tag namespace would mean the day their version numbers coincide, the gate below
+# passes and this workflow publishes Nodyssey's APK under the other app's tag.
 on:
   push:
     tags: ['v*']
@@ -37,6 +42,12 @@ jobs:
         id: version
         run: |
           tag="${{ github.event.inputs.tag || github.ref_name }}"
+          # `v*` also matches `v2-experiment`, and workflow_dispatch takes whatever is typed into it —
+          # including another app's tag, which would be built as Nodyssey and published under its name.
+          if ! printf '%s' "$tag" | grep -qE '^v[0-9]+(\.[0-9]+)*$'; then
+            echo "::error::$tag is not a Nodyssey release tag; those are shaped vX.Y.Z." >&2
+            exit 1
+          fi
           version="${tag#v}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -145,6 +156,9 @@ jobs:
           fi
           echo "Signing certificate matches the published one."
 
+      # The `nodyssey-` prefix is load-bearing, not decoration: the in-app update check picks the asset
+      # by it (`NodysseyRelease.ASSET_NAME_PREFIX`), because `releases/latest` answers for the whole
+      # repository and the newest release in it may belong to a different app. Rename one, rename both.
       - name: Name the APK after the release
         id: apk
         run: |

--- a/app/src/main/java/io/github/nodyssey/core/NodysseyRelease.kt
+++ b/app/src/main/java/io/github/nodyssey/core/NodysseyRelease.kt
@@ -12,6 +12,15 @@ import io.github.plaza.core.update.GitHubReleaseSource
 object NodysseyRelease {
     const val REPOSITORY = "5151561/nodyssey"
 
+    /**
+     * What this app's APK is called on a release, so a release belonging to a sibling app is not
+     * mistaken for a newer Nodyssey.
+     *
+     * `release.yml`'s "Name the APK after the release" step is the other end of this string; the two
+     * have to be changed together, and that step's comment says so.
+     */
+    const val ASSET_NAME_PREFIX = "nodyssey-"
+
     /** The releases page, for the "打不开就自己去下载" escape hatch on 关于. */
     val RELEASES_URL = GitHubReleaseSource.releasesUrl(REPOSITORY)
 }

--- a/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
@@ -387,6 +387,7 @@ class DefaultAppContainer(
                 dispatchers = dispatchers,
                 userAgent = "Nodyssey/${appVersion.name} (+https://github.com/${NodysseyRelease.REPOSITORY})",
                 repository = NodysseyRelease.REPOSITORY,
+                assetNamePrefix = NodysseyRelease.ASSET_NAME_PREFIX,
             ),
             store = settingsRepository,
             clock = clock,

--- a/core/src/main/java/io/github/plaza/core/update/GitHubReleaseSource.kt
+++ b/core/src/main/java/io/github/plaza/core/update/GitHubReleaseSource.kt
@@ -44,13 +44,19 @@ interface ReleaseSource {
  * unauthenticated — 60 requests an hour per address, against a check that runs at most every six
  * hours — so no token is needed and none is stored.
  *
- * @param repository `owner/name`, the only thing here that is about one particular app.
+ * @param repository `owner/name`, one of the two things here that are about one particular app.
+ * @param assetNamePrefix what this app's own APK is named after. `releases/latest` answers for the
+ * *repository*, not for an app, so when two apps publish to one repository the newest release can
+ * easily be the other one's — and an APK with a different `applicationId` is either "app not
+ * installed" or a second copy of a different app. No default: an app that has not stated which asset
+ * is its own has not thought about the question, and the failure it invites lands on a user's phone.
  */
 class GitHubReleaseSource(
     private val okHttpClient: OkHttpClient,
     private val dispatchers: AppDispatchers,
     private val userAgent: String,
     private val repository: String,
+    private val assetNamePrefix: String,
 ) : ReleaseSource {
     private val releasesUrl = releasesUrl(repository)
     private val latestReleaseUrl = "https://api.github.com/repos/$repository/releases/latest"
@@ -70,7 +76,7 @@ class GitHubReleaseSource(
                 if (!response.isSuccessful) {
                     throw AppUpdateException(UpdateFailure.Server(response.code))
                 }
-                GitHubReleases.parseLatest(payload, releasesUrl)
+                GitHubReleases.parseLatest(payload, releasesUrl, assetNamePrefix)
             }
         }
 
@@ -146,7 +152,7 @@ class GitHubReleaseSource(
 internal object GitHubReleases {
     private val json = Json { ignoreUnknownKeys = true }
 
-    fun parseLatest(payload: String, releasesUrl: String): AppRelease? {
+    fun parseLatest(payload: String, releasesUrl: String, assetNamePrefix: String): AppRelease? {
         val release =
             try {
                 json.decodeFromString<ReleaseDto>(payload)
@@ -157,9 +163,13 @@ internal object GitHubReleases {
         // not publish must never be pushed at a user as an update.
         if (release.draft || release.prerelease) return null
 
+        // Both halves of the name matter. `.apk` alone would take a sibling app's build off a release
+        // this app has nothing to do with; the prefix alone would take a mapping file or a checksum.
         val asset =
             release.assets.firstOrNull {
-                it.name.endsWith(".apk", ignoreCase = true) && it.browserDownloadUrl.isNotBlank()
+                it.name.startsWith(assetNamePrefix, ignoreCase = true) &&
+                    it.name.endsWith(".apk", ignoreCase = true) &&
+                    it.browserDownloadUrl.isNotBlank()
             } ?: return null
         val versionName = versionNameOfTag(release.tagName)
         if (versionName.isBlank()) return null

--- a/core/src/test/java/io/github/plaza/core/update/GitHubReleasesTest.kt
+++ b/core/src/test/java/io/github/plaza/core/update/GitHubReleasesTest.kt
@@ -18,7 +18,7 @@ class GitHubReleasesTest {
     fun `the APK asset is picked, not the first one`() {
         val release =
             requireNotNull(
-                GitHubReleases.parseLatest(load("github-release-latest.json"), releasesUrl),
+                GitHubReleases.parseLatest(load("github-release-latest.json"), releasesUrl, PREFIX),
             )
 
         assertEquals("1.2.0", release.versionName)
@@ -42,12 +42,53 @@ class GitHubReleasesTest {
               "tag_name": "v1.2.0",
               "html_url": "",
               "assets": [
-                {"name": "a.apk", "size": 10, "browser_download_url": "https://example.invalid/a.apk"}
+                {"name": "plaza-a.apk", "size": 10, "browser_download_url": "https://example.invalid/a.apk"}
               ]
             }
             """.trimIndent()
 
-        assertEquals(releasesUrl, GitHubReleases.parseLatest(payload, releasesUrl)?.htmlUrl)
+        assertEquals(releasesUrl, GitHubReleases.parseLatest(payload, releasesUrl, PREFIX)?.htmlUrl)
+    }
+
+    /**
+     * The case a repository with two apps in it creates: `releases/latest` answers for the repository,
+     * so the newest release is regularly the sibling's, and its APK carries a different
+     * `applicationId`. Offering it would end as "app not installed" on every phone that took it.
+     */
+    @Test
+    fun `a sibling app's release is not offered as this app's update`() {
+        val payload =
+            """
+            {
+              "tag_name": "other-v9.9.9",
+              "draft": false,
+              "prerelease": false,
+              "assets": [
+                {"name": "other-v9.9.9.apk", "size": 10, "browser_download_url": "https://example.invalid/other.apk"}
+              ]
+            }
+            """.trimIndent()
+
+        assertNull(GitHubReleases.parseLatest(payload, releasesUrl, PREFIX))
+    }
+
+    /** And when one release carries both apps, the prefix is what tells them apart. */
+    @Test
+    fun `the APK belonging to this app is picked out of several`() {
+        val payload =
+            """
+            {
+              "tag_name": "v1.2.0",
+              "draft": false,
+              "prerelease": false,
+              "assets": [
+                {"name": "other-v1.2.0.apk", "size": 10, "browser_download_url": "https://example.invalid/other.apk"},
+                {"name": "plaza-v1.2.0.apk", "size": 20, "browser_download_url": "https://example.invalid/plaza.apk"}
+              ]
+            }
+            """.trimIndent()
+
+        assertEquals("plaza-v1.2.0.apk", GitHubReleases.parseLatest(payload, releasesUrl, PREFIX)?.assetName)
     }
 
     @Test
@@ -59,12 +100,12 @@ class GitHubReleasesTest {
               "draft": false,
               "prerelease": false,
               "assets": [
-                {"name": "source.zip", "size": 10, "browser_download_url": "https://example.invalid/source.zip"}
+                {"name": "plaza-source.zip", "size": 10, "browser_download_url": "https://example.invalid/source.zip"}
               ]
             }
             """.trimIndent()
 
-        assertNull(GitHubReleases.parseLatest(payload, releasesUrl))
+        assertNull(GitHubReleases.parseLatest(payload, releasesUrl, PREFIX))
     }
 
     @Test
@@ -80,11 +121,12 @@ class GitHubReleasesTest {
             }
             """.trimIndent()
 
-        assertNull(GitHubReleases.parseLatest(draft, releasesUrl))
+        assertNull(GitHubReleases.parseLatest(draft, releasesUrl, PREFIX))
         assertNull(
             GitHubReleases.parseLatest(
                 draft.replace("\"draft\": true", "\"prerelease\": true"),
                 releasesUrl,
+                PREFIX,
             ),
         )
     }
@@ -93,7 +135,7 @@ class GitHubReleasesTest {
     fun `something other than the release JSON is reported as unreadable`() {
         val failure =
             assertThrows(AppUpdateException::class.java) {
-                GitHubReleases.parseLatest("<html>rate limited</html>", releasesUrl)
+                GitHubReleases.parseLatest("<html>rate limited</html>", releasesUrl, PREFIX)
             }
 
         assertEquals(UpdateFailure.Unreadable, failure.failure)
@@ -106,5 +148,6 @@ class GitHubReleasesTest {
 
     private companion object {
         const val REPOSITORY = "example/plaza"
+        const val PREFIX = "plaza-"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,5 +49,9 @@ nodyssey.versionName=1.2.5
 
 # The bbs1org client, on its own prefix for the reason above. Nothing has shipped and the app's real
 # name is still open, so this stays at 0.x until first release.
+#
+# When it does release, its tags are `bbs1-vX.Y.Z` and its APK is named `bbs1-...apk`: `v*` and
+# `nodyssey-` are Nodyssey's, and its update check reads whichever release is newest in this
+# repository. Two apps under one tag shape would eventually offer each other's builds as updates.
 bbs1.versionCode=1
 bbs1.versionName=0.0.1


### PR DESCRIPTION
## 为什么

`releases/latest` 是**仓库级**的接口：它回答「这个仓库最新的 release」，不回答「这个 App 的最新版」。仓库里现在有两个 application 模块，bbs1 一旦也发到这里，Nodyssey 的更新检测就会拿到它那条 release —— 而挑 asset 的那行只看 `.apk` 结尾、不看叫什么名字，下载的就是 `applicationId` 不同的包：轻则「应用未安装」，重则装成第二个 App。

今天还撞不上，只是因为 bbs1 的版本号（0.0.1）比 Nodyssey（1.2.5）小，`isNewerVersionName` 把它挡在门外。这不是一道设计出来的闸，是一次巧合。

## 改了什么

- `GitHubReleaseSource` 新增必填的 `assetNamePrefix`，Nodyssey 传 `nodyssey-`。常量落在 `NodysseyRelease`，与 `release.yml` 命名 APK 那步互为两端，注释互指。不给默认值 —— 没想过这个问题的接入方，代价是用户手机上的一次失败安装。
- 前缀和 `.apk` 两个条件都要：只看后缀会拿到兄弟 App 的包，只看前缀会拿到同名的 checksum（fixture 里正好有一个 `plaza-v1.2.0.apk.sha256`）。
- 找不到自己的包时返回 `null`，界面走「已是最新」而不是报错 —— 和「latest 没挂 APK」同一条路径。
- `release.yml` 的 tag 闸门收成 `^v[0-9]+(\.[0-9]+)*$`：`v*` 也匹配 `v2-experiment`，`workflow_dispatch` 更是输什么算什么。
- bbs1 的 tag 定为 `bbs1-v*`，`v*` 和 `nodyssey-` 归 Nodyssey；约定写进 `gradle.properties` 的注释。这条前缀还有一层顺带的好处：`versionNameOfTag("bbs1-v9.9.9")` 首段取不出数字算 0，永远比不过 Nodyssey 的版本号。

## 验证

两条新测试：兄弟 App 的 release 不被当成更新、一条 release 里两个包时挑对自己那个。把前缀检查临时删掉后这两条挂、其余五条照旧绿，确认它们拦的是这个 bug 而不是陪跑。

`spotlessCheck`、四模块 `testDebugUnitTest`、`:app:lintDebug` 全绿。

不影响已发布的 v1.2.5。

🤖 Generated with [Claude Code](https://claude.com/claude-code)