### PR TITLE
帖子详情和通知支持刷新，通知进页与回前台自动更新

### DIFF
--- a/app/src/main/java/io/github/nodyssey/Navigation.kt
+++ b/app/src/main/java/io/github/nodyssey/Navigation.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
@@ -155,6 +156,13 @@ fun MainNavigation(
     val notificationsViewModel: NotificationsViewModel =
         viewModel(factory = NotificationsViewModel.factory(container))
     val notificationsState by notificationsViewModel.uiState.collectAsStateWithLifecycle()
+    // The tab badge is only as fresh as the last count fetch, and nothing used to fetch again once
+    // the app was running. This root outlives every tab, so its ON_RESUME is "the app came back to
+    // the foreground" — the moment a badge grown stale overnight is most visibly wrong.
+    LifecycleResumeEffect(Unit) {
+        notificationsViewModel.refreshIfStale()
+        onPauseOrDispose {}
+    }
 
     /*
      * One back stack per tab, rather than one shared stack that gets cleared on every switch.

--- a/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -44,6 +45,7 @@ import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.nodyssey.R
 import io.github.nodyssey.data.ForumNotification
@@ -74,6 +76,13 @@ fun NotificationsRoute(
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    // Coming back into view is the refresh trigger this screen was missing: the view model outlives
+    // every tab switch, so nothing recreates it, and ON_RESUME is the one signal that covers all the
+    // ways back — the tab bar, Back from a thread, the app returning to the foreground.
+    LifecycleResumeEffect(Unit) {
+        viewModel.refreshIfStale()
+        onPauseOrDispose {}
+    }
     NotificationsScreen(
         state = state,
         onSignIn = onSignIn,
@@ -179,7 +188,14 @@ fun NotificationsScreen(
                 }
             }
 
-            Box(Modifier.fillMaxSize()) {
+            // `isEmpty` keeps the first load out of the indicator: that one already draws
+            // [LoadingState] in the middle of the screen, and a spinner above a spinner reads as two
+            // different loads.
+            PullToRefreshBox(
+                isRefreshing = state.isLoading && !state.isEmpty,
+                onRefresh = onRetry,
+                modifier = Modifier.fillMaxSize(),
+            ) {
                 when {
                     !state.isSignedIn -> SignedOutState(onSignIn = onSignIn)
 

--- a/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/notifications/NotificationsViewModel.kt
@@ -107,6 +107,22 @@ class NotificationsViewModel(
     }
 
     /**
+     * [refresh], unless what is on screen is recent enough to stand.
+     *
+     * Called every time the screen comes back into view — the tab bar, Back from a thread, the app
+     * returning to the foreground. This view model lives at the navigation root and survives all of
+     * those, so nothing recreates it and init's one refresh was the only load a session ever ran.
+     * The throttle is what keeps tab-hopping from turning into a request per tap; only a successful
+     * load stamps [NotificationsUiState.nowMillis], so a failed one retries on the next return
+     * instead of waiting out the interval.
+     */
+    fun refreshIfStale() {
+        if (loadJob?.isActive == true) return
+        if (clock.nowMillis() - _uiState.value.nowMillis < REFRESH_THROTTLE_MILLIS) return
+        refresh()
+    }
+
+    /**
      * Clears the group, optimistically and then for real.
      *
      * The local update lands first because the button should not feel like a network round trip; the
@@ -231,6 +247,9 @@ class NotificationsViewModel(
     )
 
     companion object {
+        /** How recent "recent enough" is; see [refreshIfStale]. */
+        private const val REFRESH_THROTTLE_MILLIS = 30_000L
+
         fun factory(container: AppContainer): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {

--- a/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -162,6 +163,8 @@ fun PostDetailRoute(
         onVerify = { onVerify(postUrl) },
         onImageClick = { url -> onImageClick(images.ifEmpty { listOf(url) }, url) },
         onRetry = viewModel::refresh,
+        onPullRefresh = viewModel::pullRefresh,
+        onRefreshPage = viewModel::refreshPage,
         onLoadMore = viewModel::loadNextPage,
         onLoadPage = viewModel::loadPage,
         onJumpToFloor = viewModel::jumpToFloor,
@@ -217,6 +220,10 @@ fun PostDetailScreen(
     onRetry: () -> Unit,
     onLoadMore: () -> Unit,
     modifier: Modifier = Modifier,
+    /** [onRetry] as a pull gesture; separate so the view model can route it to its own indicator. */
+    onPullRefresh: () -> Unit = onRetry,
+    /** Re-fetches the given page in place — the 刷新 menu item, aimed at the page on screen. */
+    onRefreshPage: (Int) -> Unit = { onRetry() },
     onLoadPage: (Int) -> Unit = { onLoadMore() },
     /** Scrolls to a floor, fetching its page first when that floor is not loaded. */
     onJumpToFloor: (String) -> Unit = {},
@@ -381,6 +388,7 @@ fun PostDetailScreen(
                 postUrl = postUrl,
                 onBack = onBack,
                 onOpenInBrowser = { onOpenBrowser(postUrl) },
+                onRefresh = { onRefreshPage(visiblePage) },
                 showBackButton = showBackButton,
             )
         },
@@ -408,60 +416,66 @@ fun PostDetailScreen(
                     )
 
                 else ->
-                    ThreadList(
-                        state = state,
-                        listState = listState,
-                        onOpenBrowser = onLinkClick,
-                        onImageClick = onImageClick,
-                        onJumpToFloor = { floor ->
-                            // A quote can point anywhere in the thread, including pages nobody has
-                            // opened. Scroll when it is here, fetch its page when it is not.
-                            val index = state.indexOfFloor(floor)
-                            if (index != null) {
-                                scope.launch { listState.animateScrollToItem(index) }
-                            } else {
-                                onJumpToFloor(floor)
-                            }
-                        },
-                        onReact = { content, action ->
-                            val commentId = content.commentId
-                            when {
-                                // Same rule as the editor: the account has to exist before the
-                                // action, not after a rejection that also spent the tap.
-                                !state.isSignedIn -> onSignIn()
-
-                                commentId == null -> Unit
-
-                                // 点赞 costs nothing and the site does not confirm it either.
-                                action == ReactionAction.Upvote -> onReact(commentId, action)
-
-                                else -> {
-                                    confirmTarget = ReactionConfirm(content, commentId, action)
-                                    if (action == ReactionAction.ChickenLeg) onLoadFreeChickenLegs()
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = onPullRefresh,
+                    ) {
+                        ThreadList(
+                            state = state,
+                            listState = listState,
+                            onOpenBrowser = onLinkClick,
+                            onImageClick = onImageClick,
+                            onJumpToFloor = { floor ->
+                                // A quote can point anywhere in the thread, including pages nobody
+                                // has opened. Scroll when it is here, fetch its page when it is not.
+                                val index = state.indexOfFloor(floor)
+                                if (index != null) {
+                                    scope.launch { listState.animateScrollToItem(index) }
+                                } else {
+                                    onJumpToFloor(floor)
                                 }
-                            }
-                        },
-                        onReplyToFloor = onReply,
-                        onQuoteFloor = onQuote,
-                        onAuthorClick = onAuthorClick,
-                        // Same gate as the editor and the marks: the account has to exist before the
-                        // action, not after a rejection that also spent the tap.
-                        onCollect = { if (state.isSignedIn) onCollect() else onSignIn() },
-                        voteContent = voteContent,
-                        stardustContent = stardustContent,
-                        modifier =
-                        Modifier.floatingToolbarVerticalNestedScroll(
-                            expanded = toolbarExpanded,
-                            onExpand = { pageToolbarExpanded = true },
-                            onCollapse = { pageToolbarExpanded = false },
-                        ),
-                    )
+                            },
+                            onReact = { content, action ->
+                                val commentId = content.commentId
+                                when {
+                                    // Same rule as the editor: the account has to exist before the
+                                    // action, not after a rejection that also spent the tap.
+                                    !state.isSignedIn -> onSignIn()
+
+                                    commentId == null -> Unit
+
+                                    // 点赞 costs nothing and the site does not confirm it either.
+                                    action == ReactionAction.Upvote -> onReact(commentId, action)
+
+                                    else -> {
+                                        confirmTarget = ReactionConfirm(content, commentId, action)
+                                        if (action == ReactionAction.ChickenLeg) onLoadFreeChickenLegs()
+                                    }
+                                }
+                            },
+                            onReplyToFloor = onReply,
+                            onQuoteFloor = onQuote,
+                            onAuthorClick = onAuthorClick,
+                            // Same gate as the editor and the marks: the account has to exist before
+                            // the action, not after a rejection that also spent the tap.
+                            onCollect = { if (state.isSignedIn) onCollect() else onSignIn() },
+                            voteContent = voteContent,
+                            stardustContent = stardustContent,
+                            modifier =
+                            Modifier.floatingToolbarVerticalNestedScroll(
+                                expanded = toolbarExpanded,
+                                onExpand = { pageToolbarExpanded = true },
+                                onCollapse = { pageToolbarExpanded = false },
+                            ),
+                        )
+                    }
             }
 
             // A jump replaces the whole list, so the append spinner at its foot would be pointing at
             // content that is on its way out. This says "a different page is coming" where the reader
             // is already looking — and it is the only feedback between the tap and the new page.
-            if (state.isLoading && state.body != null) {
+            // A pull-to-refresh is the one load excused: its own indicator is already saying it.
+            if (state.isLoading && !state.isRefreshing && state.body != null) {
                 LinearProgressIndicator(
                     modifier = Modifier.fillMaxWidth().align(Alignment.TopCenter),
                 )
@@ -603,6 +617,7 @@ private fun DetailTopBar(
     postUrl: String,
     onBack: () -> Unit,
     onOpenInBrowser: () -> Unit,
+    onRefresh: () -> Unit,
     showBackButton: Boolean,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
@@ -647,6 +662,15 @@ private fun DetailTopBar(
                     )
                 }
                 DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    // The menu twin of pull-to-refresh, for the reader who is thirty floors down and
+                    // not about to scroll back up to pull.
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.action_refresh)) },
+                        onClick = {
+                            menuOpen = false
+                            onRefresh()
+                        },
+                    )
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.action_copy_link)) },
                         onClick = {

--- a/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/postdetail/PostDetailViewModel.kt
@@ -204,6 +204,26 @@ class PostDetailViewModel(
     fun refresh() = load(page = _uiState.value.firstLoadedPage, replacesWindow = true)
 
     /**
+     * [refresh], with the pull indicator owning the feedback instead of the bar under the app bar.
+     *
+     * Same load, different announcement: the reader's finger is already on the indicator, so also
+     * drawing the jump-style progress bar would show one gesture as two loads.
+     */
+    fun pullRefresh() {
+        _uiState.update { it.copy(isRefreshing = true) }
+        refresh()
+    }
+
+    /**
+     * Re-fetches [page] as the whole window.
+     *
+     * The 刷新 menu item, aimed at the page on screen rather than the window's first: a reader deep
+     * in a thread is asking for the newest state of what they are looking at — at the thread's end,
+     * the replies that arrived since — not to be carried back to where the window began.
+     */
+    fun refreshPage(page: Int) = load(page = page.coerceAtLeast(1), replacesWindow = true)
+
+    /**
      * Comments are paginated on the site but read as one thread on a phone, so the next page is
      * appended to the same list rather than replacing it. The append itself happens in the database.
      */
@@ -413,6 +433,7 @@ class PostDetailViewModel(
                         it.copy(
                             isLoading = false,
                             isAppending = false,
+                            isRefreshing = false,
                             pendingScroll = scrollTo ?: it.pendingScroll,
                         )
                     }
@@ -421,6 +442,7 @@ class PostDetailViewModel(
                         it.copy(
                             isLoading = false,
                             isAppending = false,
+                            isRefreshing = false,
                             error = throwable.toSiteError(),
                         )
                     }
@@ -475,6 +497,8 @@ data class PostDetailUiState(
     val hasNextPage: Boolean = false,
     val isLoading: Boolean = false,
     val isAppending: Boolean = false,
+    /** The load is a pull-to-refresh; its own indicator shows it, so no other progress bar should. */
+    val isRefreshing: Boolean = false,
     val isSignedIn: Boolean = false,
     /** 临时显示被屏蔽内容 — draws the blocked floors instead of collapsing them. */
     val showBlockedContent: Boolean = false,

--- a/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsViewModelTest.kt
@@ -101,9 +101,35 @@ class NotificationsViewModelTest {
             assertEquals(3, viewModel.uiState.value.counts.messages)
         }
 
+    /**
+     * Every return to the screen calls this, so the throttle carries the difference between "timely"
+     * and "a request per tab tap": straight back is served from what is showing, a stale return
+     * re-reads the server.
+     */
+    @Test
+    fun `coming back into view refreshes only once the last load is stale`() =
+        runTest(dispatcher) {
+            var now = 1_785_000_000_000L
+            val api = FakeApi(counts = """{"atMe":2}""")
+            val viewModel = viewModel(api, clock = { now })
+            advanceUntilIdle()
+            assertEquals(2, viewModel.uiState.value.counts.mentions)
+
+            api.counts = """{"atMe":5}"""
+            viewModel.refreshIfStale()
+            advanceUntilIdle()
+            assertEquals(2, viewModel.uiState.value.counts.mentions)
+
+            now += 30_000L
+            viewModel.refreshIfStale()
+            advanceUntilIdle()
+            assertEquals(5, viewModel.uiState.value.counts.mentions)
+        }
+
     private fun viewModel(
         api: FakeApi,
         unread: Boolean = true,
+        clock: AppClock = AppClock { 1_785_000_000_000L },
     ): NotificationsViewModel {
         val notifications = NotificationRepository(api)
         api.mentionUnread = unread
@@ -112,7 +138,7 @@ class NotificationsViewModelTest {
             messages = NoMessages,
             search = NoSearch,
             session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
-            clock = AppClock { 1_785_000_000_000L },
+            clock = clock,
         )
     }
 }

--- a/app/src/test/java/io/github/nodyssey/ui/postdetail/PostDetailViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/postdetail/PostDetailViewModelTest.kt
@@ -180,6 +180,55 @@ class PostDetailViewModelTest {
             assertEquals(before, remote.detailRequests.size)
         }
 
+    /** The pull gesture's indicator is its own feedback; it must rise with the load and fall with it. */
+    @Test
+    fun `a pull refresh raises its indicator and lowers it when the load lands`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+
+            vm.pullRefresh()
+            assertTrue(vm.uiState.value.isRefreshing)
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isRefreshing)
+            assertNull(vm.uiState.value.error)
+        }
+
+    @Test
+    fun `a failed pull refresh lowers the indicator and reports the error`() =
+        runTest(dispatcher) {
+            val vm = viewModel()
+            advanceUntilIdle()
+            remote.detailError = SiteException(SiteError.Network)
+
+            vm.pullRefresh()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isRefreshing)
+            assertEquals(SiteError.Network, vm.uiState.value.error)
+        }
+
+    /** 刷新 aims at the page on screen, not at the window's first — see [PostDetailViewModel.refreshPage]. */
+    @Test
+    fun `refreshing a page re-fetches that page rather than the window's first`() =
+        runTest(dispatcher) {
+            remote.detailResult = { postId, page ->
+                FakePostRemoteDataSource.detail(postId, page, commentCount = 2, totalPages = 3)
+            }
+            val vm = viewModel()
+            advanceUntilIdle()
+            vm.loadNextPage()
+            advanceUntilIdle()
+
+            vm.refreshPage(2)
+            advanceUntilIdle()
+
+            assertEquals(42L to 2, remote.detailRequests.last())
+            assertEquals(2, vm.uiState.value.firstLoadedPage)
+            assertEquals(2, vm.uiState.value.lastLoadedPage)
+        }
+
     /**
      * The point of phase two: a thread read moments ago paints from the database and issues no
      * request at all.


### PR DESCRIPTION
## 背景

帖子详情和通知页此前都没有任何刷新入口；通知更新还不及时——`NotificationsViewModel` 挂在导航根部全程存活，只在冷启动/登录变化时拉一次数据，切 tab、从帖子返回、App 回前台都不会重新拉取，后台轮询又默认关闭。

## 改动

**帖子详情**
- 内容区下拉刷新（复用首页同款 `PullToRefreshBox`），指示器自带反馈，刷新期间不再叠顶部进度条（`isRefreshing` 与跳页的 `isLoading` 区分开）。
- 溢出菜单新增「刷新」，给读到深处不想滚回顶部的场景：新的 `refreshPage(visiblePage)` 刷新**当前正在看的页**而不是窗口第一页，追楼能直接拉到新回复，也不会把读者拽回开头。

**通知页**
- 列表下拉刷新，@我 / 回复主题 / 私信三个分组都有效；首次加载仍走居中的 `LoadingState`，不会出现双转圈。
- 新增 `refreshIfStale()`：每次回到页面（`LifecycleResumeEffect`，覆盖切 tab、从帖子返回、App 回前台）自动重拉，30 秒节流防止 tab 来回切换变成一次一个请求；失败的加载不盖时间戳，下次回来会重试。
- 导航根部同样在 ON_RESUME 时调 `refreshIfStale()`，底栏未读角标不再只靠启动那一次。

## 验证

- 新增 4 个单测：拉动刷新指示器的起落（成功/失败各一）、`refreshPage` 请求的是屏上页、`refreshIfStale` 的节流窗口。
- 全量 `testDebugUnitTest`、`:app:lintDebug`、`spotlessCheck` 全绿。
- 真机（SM-S9310）冒烟：详情页下拉确实拉到新回复（评论 2→4）、菜单刷新就位、切到通知 tab 瞬间自动刷新在转、通知列表下拉正常。

## 审阅提示

- `PostDetailScreen.kt` 的 diff 大半是 `ThreadList` 包进 `PullToRefreshBox` 带来的整块缩进，实际逻辑改动集中在包裹本身、`LinearProgressIndicator` 条件和顶栏菜单。
- 菜单「刷新」与下拉共用 `load(replacesWindow = true)` 路径，只是目标页不同；未动分页窗口的既有语义。

🤖 Generated with [Claude Code](https://claude.com/claude-code)