### PR TITLE
正文一律贪心折行，标题不再单独拉平行长

### DIFF
--- a/app/src/main/java/io/github/nodyssey/core/html/RichContentParser.kt
+++ b/app/src/main/java/io/github/nodyssey/core/html/RichContentParser.kt
@@ -346,7 +346,47 @@ object RichContentParser {
         element.hasClass(STICKER_CLASS) || element.attr("src").contains("/static/image/sticker/")
 
     /** Everything a finished run of inline content needs: trimmed, with quote references folded. */
-    private fun finishInlines(inlines: List<InlineNode>): List<InlineNode> = foldQuoteRefs(trimInlines(inlines))
+    private fun finishInlines(inlines: List<InlineNode>): List<InlineNode> =
+        foldQuoteRefs(dropSpaceAfterBreaks(trimInlines(inlines)))
+
+    /**
+     * Drops the space a source newline leaves at the head of a line.
+     *
+     * The site writes its hard breaks as `<br>` followed by a real newline, and jsoup folds that
+     * newline into a leading space on the text after it. A browser never draws that space —
+     * collapsible whitespace at the start of a line box is thrown away — so keeping it indented
+     * every line after a `<br>` by a space the web does not show. Measured against the site on
+     * post-584268, whose opening paragraph carries three of them.
+     */
+    private fun dropSpaceAfterBreaks(inlines: List<InlineNode>): List<InlineNode> {
+        val result = mutableListOf<InlineNode>()
+        var atLineStart = false
+        for (node in inlines) {
+            when {
+                node is InlineNode.LineBreak -> {
+                    atLineStart = true
+                    result += node
+                }
+
+                !atLineStart -> result += node
+
+                node is InlineNode.Text -> {
+                    val trimmed = node.text.trimStart()
+                    // An all-whitespace node leaves the line still unstarted, so the next one is
+                    // trimmed too: `<br>` followed by a newline and then an indent is one head.
+                    if (trimmed.isEmpty()) continue
+                    atLineStart = false
+                    result += node.copy(text = trimmed)
+                }
+
+                else -> {
+                    atLineStart = false
+                    result += node
+                }
+            }
+        }
+        return result
+    }
 
     private val FLOOR_LABEL = Regex("""^#\d+$""")
 

--- a/app/src/test/java/io/github/nodyssey/core/html/RichContentParserTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/html/RichContentParserTest.kt
@@ -47,6 +47,31 @@ class RichContentParserTest {
         assertEquals("zhh123", (inlines.first() as InlineNode.QuoteRef).name)
     }
 
+    /**
+     * `<br>` and the newline the site writes after it are one break, not a break and an indent.
+     *
+     * jsoup folds that source newline into a leading space on the text that follows, and keeping
+     * it indented every line after a `<br>` by a space no browser draws — collapsible whitespace
+     * at the head of a line box is thrown away. Measured on post-584268, whose opening paragraph
+     * carries three of them.
+     */
+    @Test
+    fun `drops the space a source newline leaves after a hard break`() {
+        val nodes = parse("<p>\u4eca\u5e74\u53ef\u4ee5\u5148\u884c\u8eba\u5e73\u4e86\u3002<br>\n\u8bf4\u5230\u8eba\u5e73\uff0c\u8bb2\u771f\u3002</p>")
+
+        val inlines = inlinesOf(nodes)
+        assertEquals(InlineNode.LineBreak, inlines[1])
+        assertEquals("\u8bf4\u5230\u8eba\u5e73\uff0c\u8bb2\u771f\u3002", (inlines[2] as InlineNode.Text).text)
+    }
+
+    /** A space the author actually typed mid-line is content, and survives. */
+    @Test
+    fun `keeps a space that is not at the head of a line`() {
+        val nodes = parse("<p>\u524d\u9762 \u540e\u9762</p>")
+
+        assertEquals("\u524d\u9762 \u540e\u9762", (inlinesOf(nodes).single() as InlineNode.Text).text)
+    }
+
     /** A bare mention is still just a link; only the pair means "replying to that floor". */
     @Test
     fun `leaves a mention with no floor link alone`() {

--- a/designsys/src/main/java/io/github/plaza/designsys/richtext/RichContent.kt
+++ b/designsys/src/main/java/io/github/plaza/designsys/richtext/RichContent.kt
@@ -65,7 +65,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -112,7 +111,8 @@ import io.github.plaza.designsys.theme.asProse
  * own typography and theme instead of the site's stylesheet.
  *
  * The typographic rules here are the ones that decide whether this app is worth opening daily:
- * 16sp on a 27sp line laid out by the platform's optimal (Knuth-Plass family) line breaker, a
+ * 16sp on a 27sp line broken greedily, the way a browser breaks it and for the reason spelled out
+ * in `TextStyle.asProse` — headings included, which is why nothing here overrides `lineBreak`. A
  * hair of air where hanzi meets Latin, block spacing that breathes around headings instead of
  * metering out a flat 10dp, code that scrolls rather than wraps, and never an italic — Chinese
  * has no italic form and synthesised slant is unreadable at body size.
@@ -300,9 +300,13 @@ private fun RichBlock(
                     // Weight, never size alone: a level-4 heading and body text are two points
                     // apart and would otherwise be indistinguishable in Chinese.
                     fontWeight = FontWeight.Bold,
-                    // Balanced rather than optimal: a two-line heading with one stranded word
-                    // looks worse than two even lines.
-                    lineBreak = LineBreak.Heading,
+                    // No line-break override: a heading breaks the way the body around it does,
+                    // which `asProse` has already set to greedy. This used to force
+                    // `LineBreak.Heading`, whose Balanced strategy evens the lines out — and even
+                    // lines in Chinese means a short one. post-584268's `GitHub项目地址（欢迎Star
+                    // 关注）： <url>` came out filling 0.69 of the column against greedy's 0.92,
+                    // with `关注）：` pushed onto the next line while 305px sat empty beside it.
+                    // See `ProseLineBreakTest`.
                 ),
                 onLinkClick = onLinkClick,
                 onQuoteRefClick = onQuoteRefClick,

--- a/designsys/src/main/java/io/github/plaza/designsys/theme/Type.kt
+++ b/designsys/src/main/java/io/github/plaza/designsys/theme/Type.kt
@@ -81,12 +81,21 @@ val CommentBody = TextStyle(fontSize = 15.sp, lineHeight = 25.sp, letterSpacing 
 /**
  * Upgrades a body style for long-form reading. Applied by `RichContent`, never by an editor.
  *
- * [LineBreak.Paragraph] turns on the platform's optimal line breaker — the Knuth-Plass family of
- * algorithms, which minimises raggedness over the whole paragraph instead of greedily filling one
- * line at a time. Pure Chinese barely changes (every hanzi is a break point), but the mixed
- * Chinese-Latin lines this forum is made of — model names, bandwidth figures, URLs — stop leaving
- * one long word stranded on a line of its own. [Hyphens.Auto] lets long Latin words break cleanly
- * instead of bouncing whole to the next line.
+ * [LineBreak.Simple] is the greedy breaker: fill each line as far as it goes, then move on. It is
+ * what every browser does, and matching it is the point — the site is read on both.
+ *
+ * This used to be [LineBreak.Paragraph], the platform's optimal breaker. Optimal breaking spends
+ * its budget minimising raggedness across a whole paragraph, which pays off in justified Latin
+ * setting and costs in Chinese: a reader of a solid block of hanzi expects a flush right edge and
+ * reads evenly distributed slack as every line stopping short. Measured on post-584268's heading
+ * at the 1.2 system font scale, greedy fills the opening line to 0.94 of the column where optimal
+ * left it at 0.76. The trade is real and known — a paragraph carrying a long unbreakable token,
+ * a URL most often, keeps that token whole and so leaves a wider gap on the line above it than
+ * optimal would; see `ProseLineBreakTest`, which pins both halves.
+ *
+ * Strictness stays at [LineBreak.Simple]'s Normal rather than Strict for the same reason: Normal
+ * is CSS `line-break: auto`, which is what the site's stylesheet resolves to. Baseline UAX#14
+ * already keeps `。，）` off the head of a line; Strict only adds rules Japanese needs.
  *
  * The centred, untrimmed [LineHeightStyle] replaces the default Proportional + Trim.Both, under
  * which a paragraph's first and last half-leading were cut off and the gap between two paragraphs
@@ -94,12 +103,11 @@ val CommentBody = TextStyle(fontSize = 15.sp, lineHeight = 25.sp, letterSpacing 
  * between blocks read as block spacing *plus* line rhythm, which is what gives long posts their
  * paragraph structure back.
  *
- * This must stay off text *fields*: re-optimising the whole paragraph on every keystroke makes
- * already-laid-out lines jump while typing, which is why the editors keep [PostBody] as is.
+ * This must stay off text *fields*, whose [LineHeightStyle] an editor should not inherit.
  */
 fun TextStyle.asProse(): TextStyle =
     copy(
-        lineBreak = LineBreak.Paragraph,
+        lineBreak = LineBreak.Simple,
         hyphens = Hyphens.Auto,
         lineHeightStyle =
         LineHeightStyle(
@@ -131,15 +139,19 @@ private const val SIGNATURE_SCALE = 0.85f
 /**
  * The full title on the detail screen, where it may wrap to several lines.
  *
- * [LineBreak.Heading] balances the wrapped lines instead of filling the first and leaving a couple
- * of characters widowed on the second.
+ * Greedy, for [asProse]'s reason and more sharply. This was [LineBreak.Heading], whose Balanced
+ * strategy equalises the wrapped lines; on a two-line Chinese title that means halving it, and
+ * `NodeSeek 签到脚本更新，支持自动随机延迟` came out filling 0.60 of the first line with the rest
+ * of the column empty beside it. Greedy puts the same title at 0.97. A balanced heading is a
+ * typographic nicety for a Latin display face and reads as a layout fault in hanzi, which have no
+ * word spaces for the eye to forgive.
  */
 val PostTitle =
     TextStyle(
         fontSize = 20.sp,
         lineHeight = 28.sp,
         fontWeight = FontWeight.Bold,
-        lineBreak = LineBreak.Heading,
+        lineBreak = LineBreak.Simple,
     )
 
 /**

--- a/designsys/src/test/java/io/github/plaza/designsys/richtext/HeadingLineBreakTest.kt
+++ b/designsys/src/test/java/io/github/plaza/designsys/richtext/HeadingLineBreakTest.kt
@@ -1,0 +1,86 @@
+package io.github.plaza.designsys.richtext
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.style.LineBreak
+import androidx.compose.ui.unit.dp
+import io.github.plaza.core.richtext.InlineNode
+import io.github.plaza.core.richtext.RichNode
+import io.github.plaza.designsys.theme.PlazaTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * A heading breaks the way the body around it does.
+ *
+ * `RichBlock` used to force [LineBreak.Heading] on headings, whose Balanced strategy evens the
+ * wrapped lines out. Even lines in Chinese means a short first line: post-584268's
+ * `GitHub项目地址（欢迎Star关注）： <url>` filled 0.69 of a 328dp column with `关注）：` pushed
+ * down and 305px sitting empty beside it. That override outlived the switch to greedy body text
+ * and was why the fix appeared to do nothing on the one screen it was reported from.
+ *
+ * Geometry is the reporter's device: SM-S9310, 360dp wide, 16dp gutters, system font scale 1.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h780dp-xxhdpi")
+class HeadingLineBreakTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun layoutOfHeading(): Pair<TextLayoutResult, Int> {
+        val heading =
+            RichNode.Heading(
+                level = 3,
+                inlines = listOf(
+                    InlineNode.Text("GitHub项目地址（欢迎Star关注）： "),
+                    InlineNode.Link(
+                        text = "https://github.com/xykt/HardwareQuality",
+                        url = "https://github.com/xykt/HardwareQuality",
+                    ),
+                ),
+            )
+        composeRule.setContent {
+            PlazaTheme {
+                RichContent(
+                    nodes = listOf(heading),
+                    onLinkClick = {},
+                    onImageClick = {},
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+        }
+        val root = composeRule.onRoot().fetchSemanticsNode()
+        val node = generateSequence(listOf(root)) { level ->
+            level.flatMap { it.children }.ifEmpty { null }
+        }.flatten().first { it.config.contains(SemanticsActions.GetTextLayoutResult) }
+        val results = mutableListOf<TextLayoutResult>()
+        node.config[SemanticsActions.GetTextLayoutResult].action?.invoke(results)
+        return results.first() to node.size.width
+    }
+
+    @Test
+    fun `a heading inherits the body's greedy breaker`() {
+        val (layout, _) = layoutOfHeading()
+
+        assertEquals(LineBreak.Simple, layout.layoutInput.style.lineBreak)
+    }
+
+    @Test
+    fun `a heading fills its first line rather than evening the lines out`() {
+        val (layout, width) = layoutOfHeading()
+
+        val first = (layout.getLineRight(0) - layout.getLineLeft(0)) / width
+        assertTrue("the heading's first line should be near flush, got $first", first > 0.9f)
+    }
+}

--- a/designsys/src/test/java/io/github/plaza/designsys/theme/ProseLineBreakTest.kt
+++ b/designsys/src/test/java/io/github/plaza/designsys/theme/ProseLineBreakTest.kt
@@ -1,0 +1,141 @@
+package io.github.plaza.designsys.theme
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.text.style.LineBreak
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Which line breaker [asProse] hands the body text, pinned from both sides.
+ *
+ * The forum is read in a browser as well as here, and a browser breaks greedily: fill the line,
+ * move on. Optimal breaking spreads a paragraph's slack over every line instead, which in Chinese
+ * — where the reader expects a flush right edge from a solid block of hanzi — reads as every line
+ * stopping short. Both tests below measure the same string under both breakers, so the win and the
+ * cost of the choice stay visible to whoever reads this next.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h800dp")
+class ProseLineBreakTest {
+    private val density = Density(RuntimeEnvironment.getApplication())
+
+    private val measurer =
+        TextMeasurer(
+            defaultFontFamilyResolver = createFontFamilyResolver(RuntimeEnvironment.getApplication()),
+            defaultDensity = density,
+            defaultLayoutDirection = LayoutDirection.Ltr,
+        )
+
+    /** How much of the column each line but the last one fills; the last is short by definition. */
+    private fun fillRatios(
+        text: String,
+        style: TextStyle,
+        width: Int = with(density) { 360.dp.roundToPx() },
+    ): List<Float> {
+        val result =
+            measurer.measure(
+                text = AnnotatedString(text),
+                style = style,
+                constraints = Constraints(maxWidth = width),
+            )
+        return (0 until result.lineCount - 1).map { line ->
+            (result.getLineRight(line) - result.getLineLeft(line)) / width
+        }
+    }
+
+    private fun greedy(base: TextStyle) = base.asProse()
+
+    private fun optimal(base: TextStyle) = base.asProse().copy(lineBreak = LineBreak.Paragraph)
+
+    @Test
+    fun `asProse breaks greedily, the way the site does in a browser`() {
+        assertEquals(LineBreak.Simple, PostBody.asProse().lineBreak)
+    }
+
+    /**
+     * The win: a short block ending in a token that cannot break.
+     *
+     * post-584268 opens a section with this heading, and at the 1.2 system font scale the string
+     * is a hair too wide for one line. Optimal breaking answers by shortening *every* line; greedy
+     * fills the first and pushes the whole remainder down, which is what the browser shows.
+     */
+    @Test
+    fun `greedy fills the opening line of a heading that ends in a URL`() {
+        val heading = "GitHub项目地址（欢迎Star关注）： https://github.com/xykt/HardwareQuality"
+        val style = PostBody.copy(fontSize = PostBody.fontSize * 1.35f)
+
+        val greedyFirst = fillRatios(heading, greedy(style)).first()
+        val optimalFirst = fillRatios(heading, optimal(style)).first()
+
+        assertTrue(
+            "greedy should fill the opening line further than optimal, got $greedyFirst vs $optimalFirst",
+            greedyFirst > optimalFirst,
+        )
+    }
+
+    /**
+     * The cost, pinned so that it is a decision rather than a surprise.
+     *
+     * Greedy keeps a long unbreakable token whole and drops it entire to the next line, so the
+     * line above it ends further short than optimal would leave it. This is the trade the choice
+     * of greedy accepts; it is not a regression to be quietly reverted. If this ever needs fixing
+     * it wants breakable URLs, not a different paragraph breaker.
+     */
+    @Test
+    fun `greedy leaves a wider gap above a long unbreakable URL`() {
+        val prose =
+            "这个问题的根源在于 systemd-resolved 抢管 resolv.conf，参考 " +
+                "https://wiki.archlinux.org/title/Systemd-resolved 里的说明，改完记得重启服务。"
+
+        val worstGreedy = fillRatios(prose, greedy(PostBody)).min()
+        val worstOptimal = fillRatios(prose, optimal(PostBody)).min()
+
+        assertTrue(
+            "the documented cost of greedy should still be visible, got $worstGreedy vs $worstOptimal",
+            worstGreedy < worstOptimal,
+        )
+    }
+
+    /**
+     * The detail screen's title, which had the worst case of the lot.
+     *
+     * [LineBreak.Heading]'s Balanced strategy halves a two-line title; this one came out at 0.60
+     * of the column with the rest empty beside it, which is the complaint that started all this.
+     */
+    @Test
+    fun `a post title fills its first line`() {
+        val title = "NodeSeek 签到脚本更新，支持自动随机延迟"
+
+        val balanced = fillRatios(title, PostTitle.copy(lineBreak = LineBreak.Heading)).first()
+        val greedy = fillRatios(title, PostTitle).first()
+
+        assertTrue("a title's first line should be near flush, got $greedy", greedy > 0.9f)
+        assertTrue("this test is only meaningful while Balanced does worse, got $balanced", balanced < 0.8f)
+    }
+
+    /** Pure Chinese is the common case and must stay flush under the greedy breaker. */
+    @Test
+    fun `pure Chinese fills every line`() {
+        val prose =
+            "最近折腾了一下家里的软路由，把旁路由的方案换成了主路由直接跑，稳定性比之前好了不少。" +
+                "以前每次重启主路由都要手动去改网关，现在完全不用管了，插上电就能自己跑起来。"
+
+        fillRatios(prose, greedy(PostBody)).forEach { ratio ->
+            assertTrue("a pure Chinese line should be near flush, got $ratio", ratio > 0.95f)
+        }
+    }
+}


### PR DESCRIPTION
## 问题

帖内标题右边会空掉三成到一半。[post-584268](https://www.nodeseek.com/post-584268-1) 的 `GitHub项目地址（欢迎Star关注）： <url>` 在 360dp 屏上首行只填 0.69，`关注）：` 被挤到下一行，旁边空着 305px。

```
GitHub项目地址（欢迎Star          ← 空 305px
关注）： https://github
.com/xykt/HardwareQuality
```

## 原因

三处都在把为拉丁文排版设计的算法用在中文正文上：

| 位置 | 原来 | 展开 |
|---|---|---|
| `RichContent` 标题分支 | `LineBreak.Heading` | Balanced + Loose + Phrase |
| `asProse()` | `LineBreak.Paragraph` | HighQuality（Knuth-Plass）+ Strict |
| `PostTitle` | `LineBreak.Heading` | Balanced |

最优折行把余量摊到每一行，Balanced 更进一步直接拉平行长——中文里「行长拉平」就等于「每行都短一截」，而读者对一整块汉字期待的是齐整的右边缘。

标题那处是本次的直接原因，也最难找：它**压在 `asProse()` 之上**，所以只改正文样式对它毫无作用。

## 改动

三处一律改成 `LineBreak.Simple`，即浏览器的贪心折行——站点在网页端本来就是这么排的。Strictness 取 Normal 而非 Strict，对应网页端实测的 `line-break: auto`；避头尾是 UAX#14 基线行为，Normal 一样有。

顺带修掉一处和网页端不一致的地方：站点的硬换行写作 `<br>` 加一个真实换行符，jsoup 的 `text()` 把那个换行折成前导空格，于是 `<br>` 之后每一行都被缩进一格。浏览器从不画行首的可折叠空白。

## 实测

360dp 宽、328dp 列宽、系统字号 1.0，与报告者的 SM-S9310 一致：

```
帖内 h3 首行     0.69 → 0.92
详情页标题首行   0.60 → 0.97
纯中文段落       每行 > 0.95，不变
```

真机装包验证过，`关注）：` 已回到第一行。

## Reviewer 需要知道的

**代价是真的，不是待修的回归。** 段落里有断不开的长 token（多半是 URL）时，贪心把整个 token 整体推到下一行，上一行会比最优折行空得多——长 URL 段落的最大空白从 32px 涨到 175px。这是选贪心时接受的交易，`ProseLineBreakTest` 里专门有一个用例把这个代价钉住，就是为了防止有人看到它以为是 bug 又换回 Knuth-Plass。

**已知未解决**：URL 尾段（如 `/HardwareQuality`）内部没有分隔符，最后一行仍然只占 0.44。要填满只能字符级断词或插入零宽字符，两者都被明确否决了。

新增测试：`ProseLineBreakTest`（5 例，收益/代价/纯中文/标题）、`HeadingLineBreakTest`（2 例，几何取自报告者机型）、`RichContentParserTest` 增 2 例。

`:app:testDebugUnitTest`、`:designsys:testDebugUnitTest`、`spotlessCheck`、`:app:lintDebug`、`:designsys:lintDebug` 全绿。（`:core:lintDebug` 有两个既有的 `MissingPermission` 错误，在 `ImageNetworkPolicyInterceptor.kt`，干净树上同样报，与本次无关。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)