### PR TITLE
视图切换用 M3 连接式按钮组，删掉「我的」里失效的在网页中打开

### DIFF
--- a/app/src/main/java/io/github/nodyssey/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/profile/ProfileScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Create
@@ -263,6 +262,9 @@ fun ProfileScreen(
                     ),
                 )
             }
+            // No 在网页中打开 row here. It pointed at the site root rather than at 个人主页 like its
+            // label claimed, and the real thing already lives where the page it opens is: 个人主页's
+            // own top bar has 在浏览器中打开, with that user's space URL.
             item(key = "settings-menu") {
                 ProfileMenuGroup(
                     items =
@@ -277,11 +279,6 @@ fun ProfileScreen(
                             Icons.Default.Settings,
                             onSettings,
                             badge = hasAppUpdate,
-                        ),
-                        ProfileMenuItem(
-                            R.string.profile_open_web,
-                            Icons.AutoMirrored.Filled.ExitToApp,
-                            onOpenWebsite,
                         ),
                     ),
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,7 +249,6 @@
     <string name="profile_attendance">今日签到 · 领鸡腿</string>
     <string name="profile_attendance_checking">正在检查今日签到…</string>
     <string name="profile_attendance_done">今日已签到 · 查看签到榜</string>
-    <string name="profile_open_web">在网页中打开个人主页</string>
     <string name="profile_account_settings">账号设置</string>
 
     <!-- Settings -->

--- a/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerScreenTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/composer/PostComposerScreenTest.kt
@@ -101,6 +101,11 @@ class PostComposerScreenTest {
         setScreen(draftState().copy(isPublishing = true))
 
         composeRule.onNodeWithText("发布中").assertIsDisplayed()
+        // 发布中… is the top bar's widest state, and the view switch shares the bar with it. Both
+        // have to survive 360dp together or the switch is the one the Row measures to nothing.
+        composeRule.onNodeWithText("内容").assertIsDisplayed()
+        composeRule.onNodeWithText("对照").assertIsDisplayed()
+        composeRule.onNodeWithText("预览").assertIsDisplayed()
     }
 
     @Test

--- a/designsys/src/main/java/io/github/plaza/designsys/editor/EditorToolbar.kt
+++ b/designsys/src/main/java/io/github/plaza/designsys/editor/EditorToolbar.kt
@@ -3,12 +3,14 @@ package io.github.plaza.designsys.editor
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -17,6 +19,8 @@ import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,7 +31,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.github.plaza.designsys.R
 import io.github.plaza.designsys.component.PlazaIcons
 import io.github.plaza.designsys.theme.Spacing
@@ -229,9 +232,18 @@ val EditorAction.labelRes: Int
 /**
  * The 内容 / 预览 / 对照 switch from 7a.
  *
- * A hand-built pill rather than `SingleChoiceSegmentedButtonRow`: the segmented button's own 40dp
- * height and check-mark affordance push the toolbar past the point where the keyboard fits, and the
- * three options here are views of one thing rather than a choice being made.
+ * A Material 3 connected button group: three `ToggleButton`s spaced by
+ * `ButtonGroupDefaults.ConnectedSpaceBetween`, with the leading/middle/trailing connected shapes.
+ * This was hand-built out of two nested `Surface`s until the switch turned out to have no motion at
+ * all — selection was a plain `if` on the container colour, so it snapped. The connected group is
+ * the component this pattern was always imitating, and it animates the shape on press and on
+ * selection for free.
+ *
+ * `SingleChoiceSegmentedButtonRow` is still the wrong one: its check-mark affordance says a choice
+ * is being made, and these three are views of one thing.
+ *
+ * [contentPadding] runs narrower than `ToggleButtonDefaults.ContentPadding`'s 16dp because the
+ * switch shares the top bar with 关闭 and 发布, and 发布 grows to 发布中… mid-flight.
  */
 @Composable
 fun <T> ViewModeSwitch(
@@ -240,43 +252,33 @@ fun <T> ViewModeSwitch(
     label: @Composable (T) -> String,
     onSelect: (T) -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp),
 ) {
-    Surface(
+    val colors = ToggleButtonDefaults.toggleButtonColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        checkedContainerColor = MaterialTheme.colorScheme.primary,
+        checkedContentColor = MaterialTheme.colorScheme.onPrimary,
+    )
+    Row(
         modifier = modifier,
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
     ) {
-        Row(
-            modifier = Modifier.padding(2.dp),
-            horizontalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            options.forEach { option ->
-                val isSelected = option == selected
-                // The selectable overload, so TalkBack announces which of the three views is
-                // active — colour is the only visual cue and reads as nothing.
-                Surface(
-                    selected = isSelected,
-                    onClick = { onSelect(option) },
-                    shape = MaterialTheme.shapes.extraLarge,
-                    color = if (isSelected) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.surfaceContainerLow
-                    },
-                    contentColor = if (isSelected) {
-                        MaterialTheme.colorScheme.onPrimary
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                ) {
-                    Text(
-                        text = label(option),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontSize = 12.sp,
-                        maxLines = 1,
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = Spacing.sm),
-                    )
-                }
+        options.forEachIndexed { index, option ->
+            ToggleButton(
+                checked = option == selected,
+                // Tapping the live view re-selects it rather than toggling off: there is no
+                // unselected state for a switch that answers "which view am I looking at".
+                onCheckedChange = { onSelect(option) },
+                shapes = when (index) {
+                    0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                    options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                    else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                },
+                colors = colors,
+                contentPadding = contentPadding,
+            ) {
+                Text(text = label(option), maxLines = 1)
             }
         }
     }


### PR DESCRIPTION
两处小改，都是从「这个控件手感不对」开始查的。

## 1. 内容/预览/对照 换成 M3 连接式按钮组

发帖界面顶栏那个三选一切换没有任何动效 —— 点下去是瞬切。原因是它整个是手搓的:两层嵌套 `Surface` 拼出胶囊，选中态只是容器色上的一个 `if`，没有 `animateColorAsState`，没有滑动指示条，也没有形状变化。

换成原生 `ToggleButton` + `ButtonGroupDefaults` 的首/中/尾连接形状，按下和选中各有一次形状形变动画。

几个确认过的细节:

- `ButtonGroupDefaults.ConnectedSpaceBetween` 实测是 2dp，和原来手写的间距一致，缝隙宽度没变
- 颜色显式覆盖成原来那套（`surfaceContainerLow` / `primary` / `onPrimary`），配色不变，变的只有动效
- 外层胶囊底去掉了，2dp 缝里透出顶栏底色 —— 这本来就是连接式按钮组的长相
- `contentPadding` 收到水平 12dp 而不是默认的 16dp:顶栏要同时装 关闭 和 发布，而 发布 在飞行中会变宽成 发布中…

`SingleChoiceSegmentedButtonRow` 仍然不合适 —— 它的打勾提示是「正在做一个选择」的语义，而这三个是同一个东西的三种视图。原注释里说分段按钮 40dp 太高，这次实测连接式按钮组的 token 高度也是 40dp，但顶栏是 64dp，装得下。

宽度是这次唯一的真实风险:字号从写死的 12sp 回到原生 `labelLarge`，内边距也变宽了。给「发布中」那条测试补了断言（顶栏最宽的状态），锁住 360dp 下三个键都还在。真机 360dp 上也跑过了。

一个取舍:原来用的是 `Surface` 的 selectable 重载，TalkBack 报「已选中」;`ToggleButton` 内部是 toggleable，报的是勾选态。M3 没有 selectable 版的 `ToggleButton`，官方的连接式按钮组本身就是这个语义，所以没绕。

## 2. 删掉「我的」里的 在网页中打开个人主页

这一行点了像是没反应。查出来是标签说了假话:它接的是 `openWebUrl(NodeSeekSite.BASE_URL)`，打开的是**站点首页**，不是个人主页。

而真正的入口已经在它该在的地方了 —— `UserSpaceScreen` 的 `SpaceOverflowMenu`，个人主页顶栏右上角，菜单项是 在浏览器中打开，带的是那个用户自己的 space URL。所以这是删掉一个说谎的重复入口，不是丢功能。

`onOpenWebsite` 这个参数留着没动:站点整体报错时的 `SiteErrorState` 还在用它做「去浏览器看看」的兜底，那个场景打开站点首页是合理的。

## 验证

`:designsys:compileDebugKotlin`、`:app:compileDebugKotlin`、`:app:testDebugUnitTest`、`:designsys:testDebugUnitTest`、`:app:lintDebug`、`spotlessApply` 全过。切换的动效在真机（1080x2340 / 480dpi，即 360dp 宽）上确认过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)