### PR TITLE
KMP-ready 第一阶段：把业务核心从 Android 和 JVM 库实现上摘下来

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         应用内更新. This app is published as an APK on GitHub Releases, not through a store, so the
         update it offers is an APK it downloaded and handed to the platform installer. Declaring the
         permission does not grant it: the user still turns "allow from this source" on per app, and
-        the system still shows its own install confirmation. See data/update/ApkInstaller.kt.
+        the system still shows its own install confirmation. See platform/ApkInstaller.kt.
     -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
@@ -98,7 +98,7 @@
             the outcome on the way back. Not exported — the only sender is our own PendingIntent.
         -->
         <receiver
-            android:name=".data.update.ApkInstallResultReceiver"
+            android:name=".platform.ApkInstallResultReceiver"
             android:exported="false" />
 
         <!-- WorkManager initializes on demand via NodysseyApp (Configuration.Provider). -->

--- a/app/src/main/java/io/github/nodyssey/NodysseyApp.kt
+++ b/app/src/main/java/io/github/nodyssey/NodysseyApp.kt
@@ -18,6 +18,7 @@ import io.github.nodyssey.di.DefaultAppContainer
 import io.github.nodyssey.notifications.NotificationChannels
 import io.github.nodyssey.notifications.NotificationPollScheduler
 import io.github.plaza.core.image.ImageNetworkPolicyInterceptor
+import io.github.plaza.core.image.hasValidatedUnmeteredNetwork
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -99,10 +100,11 @@ open class NodysseyApp :
             .components {
                 add(
                     ImageNetworkPolicyInterceptor(
-                        context = context,
-                        // The interceptor is `:core`'s and knows nothing about this app's
-                        // settings; which key means 仅 Wi-Fi 加载图片 is decided here.
+                        // The interceptor is `:core`'s and knows neither this app's settings nor this
+                        // platform: which key means 仅 Wi-Fi 加载图片, and what counts as Wi-Fi, are
+                        // both decided here.
                         imagesOnWifiOnly = container.settingsRepository.settings.map { it.imagesOnWifiOnly },
+                        hasUnmeteredNetwork = context::hasValidatedUnmeteredNetwork,
                     ),
                 )
                 add(

--- a/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
+++ b/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
@@ -4,10 +4,7 @@ import io.github.nodyssey.core.html.Selectors
 import io.github.nodyssey.model.FeedSort
 import io.github.plaza.core.net.PageMarkers
 import io.github.plaza.core.net.SiteConfig
-import java.net.URI
-import java.net.URLDecoder
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
+import io.github.plaza.core.net.WebUrl
 
 /**
  * Everything we know about the shape of nodeseek.com lives here.
@@ -396,10 +393,10 @@ object NodeSeekSite {
     fun isTelegramOAuthUrl(url: String): Boolean = isHttpsHost(url, TELEGRAM_OAUTH_HOSTS)
 
     private fun isHttpsHost(url: String, hosts: Set<String>): Boolean =
-        parseWebUri(url)?.let { uri ->
-            uri.scheme.equals("https", ignoreCase = true) &&
-                uri.host?.lowercase() in hosts &&
-                (uri.port == -1 || uri.port == 443)
+        parseWebUrl(url)?.let { url ->
+            url.scheme == "https" &&
+                url.host?.lowercase() in hosts &&
+                (url.port == -1 || url.port == 443)
         } == true
 
     /**
@@ -412,25 +409,24 @@ object NodeSeekSite {
      * must still resolve internally instead of falling through to the browser.
      */
     private fun isOwnSiteUrl(url: String): Boolean =
-        parseWebUri(url)?.let { uri ->
-            (uri.scheme.equals("https", ignoreCase = true) || uri.scheme.equals("http", ignoreCase = true)) &&
-                uri.host?.lowercase() in TRUSTED_WEBVIEW_HOSTS
+        parseWebUrl(url)?.let { parsed ->
+            (parsed.scheme == "https" || parsed.scheme == "http") &&
+                parsed.host?.lowercase() in TRUSTED_WEBVIEW_HOSTS
         } == true
 
     /** Ordinary links leave the app and are accepted only when they are normal web URLs. */
     fun isExternalWebUrl(url: String): Boolean =
-        parseWebUri(url)?.let { uri ->
-            uri.host != null &&
-                (
-                    uri.scheme.equals("https", ignoreCase = true) ||
-                        uri.scheme.equals("http", ignoreCase = true)
-                    )
+        parseWebUrl(url)?.let { parsed ->
+            parsed.host != null && (parsed.scheme == "https" || parsed.scheme == "http")
         } == true
 
-    private fun parseWebUri(url: String): URI? =
-        runCatching { URI(url.trim()) }
-            .getOrNull()
-            ?.takeIf { it.isAbsolute && it.userInfo == null }
+    /**
+     * The link as something with a host, or null when it is not a URL worth deciding about.
+     *
+     * A `userInfo` is refused rather than ignored: `https://www.nodeseek.com@evil.example/` names
+     * `evil.example`, and every rule below is a rule about the host.
+     */
+    private fun parseWebUrl(url: String): WebUrl? = WebUrl.parse(url)?.takeIf { it.userInfo == null }
 
     private val POST_PATH = Regex("""/post-(\d+)(?:-(\d+))?""")
     private val SPACE_PATH = Regex("""/space/(\d+)""")
@@ -504,9 +500,9 @@ object NodeSeekSite {
      * `#/message` with no `to` is the conversation list, which is a group of the same screen.
      */
     private fun parseNotificationRoute(url: String): InternalRoute? {
-        val uri = parseWebUri(url) ?: return null
-        if (uri.path?.trimEnd('/').orEmpty() != NOTIFICATION_PATH) return null
-        val fragment = uri.fragment.orEmpty()
+        val parsed = parseWebUrl(url) ?: return null
+        if (parsed.path?.trimEnd('/').orEmpty() != NOTIFICATION_PATH) return null
+        val fragment = parsed.fragment.orEmpty()
         val name = fragment.substringBefore('?').trim('/')
         return when {
             name.equals("atMe", ignoreCase = true) ->
@@ -520,7 +516,7 @@ object NodeSeekSite {
         }
     }
 
-    /** The query half of a hash route — `#/message?mode=talk&to=5230` — which is not [URI.rawQuery]. */
+    /** The query half of a hash route — `#/message?mode=talk&to=5230` — which is not [WebUrl.rawQuery]. */
     private fun String.fragmentParameter(name: String): String? =
         substringAfter('?', missingDelimiterValue = "")
             .split('&')
@@ -534,27 +530,46 @@ object NodeSeekSite {
      * destination instead of the interstitial.
      */
     fun unwrapJumpUrl(url: String): String {
-        val uri = parseWebUri(url) ?: return url
-        if (uri.host?.lowercase() !in TRUSTED_WEBVIEW_HOSTS || uri.path != "/jump") return url
-        val target = uri.queryParameter("to") ?: return url
+        val parsed = parseWebUrl(url) ?: return url
+        if (parsed.host?.lowercase() !in TRUSTED_WEBVIEW_HOSTS || parsed.path != "/jump") return url
+        val target = parsed.queryParameter("to") ?: return url
         return target.ifBlank { url }
     }
 
     private fun parseMemberName(url: String): String? =
-        parseWebUri(url)
+        parseWebUrl(url)
             ?.takeIf { it.path == "/member" }
             ?.queryParameter("t")
             ?.ifBlank { null }
 
-    private fun URI.queryParameter(name: String): String? =
-        rawQuery
-            ?.split('&')
-            ?.firstOrNull { it.substringBefore('=') == name }
-            ?.substringAfter('=', missingDelimiterValue = "")
-            ?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
+    /**
+     * A value going *into* one of the paths above, encoded the way `URLEncoder` encoded it.
+     *
+     * The unreserved set is `URLEncoder`'s and not `encodeURIComponent`'s — they differ over
+     * `~!'()`, and these strings become search URLs the app has been building for releases. Written
+     * out rather than delegated because `java.net.URLEncoder` is JVM API; the `+` it writes for a
+     * space was already being corrected to `%20` at every call site, so that is simply done here.
+     *
+     * `StardustReceiveMarkup` has a near-twin of this with a different set, deliberately: that one
+     * has to match the site's own editor character for character, and this one has to match the URLs
+     * already in use.
+     */
+    private fun String.urlEncode(): String = buildString {
+        for (byte in encodeToByteArray()) {
+            val octet = byte.toInt() and 0xFF
+            val char = octet.toChar()
+            if (octet < 0x80 && (char in 'A'..'Z' || char in 'a'..'z' || char in '0'..'9' || char in URL_ENCODER_SAFE)) {
+                append(char)
+            } else {
+                append('%')
+                append(HEX[octet shr 4])
+                append(HEX[octet and 0xF])
+            }
+        }
+    }
 
-    private fun String.urlEncode(): String =
-        URLEncoder.encode(this, StandardCharsets.UTF_8.toString()).replace("+", "%20")
+    private const val URL_ENCODER_SAFE = ".-*_"
+    private const val HEX = "0123456789ABCDEF"
 }
 
 /**

--- a/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
+++ b/app/src/main/java/io/github/nodyssey/core/NodeSeekSite.kt
@@ -4,8 +4,6 @@ import io.github.nodyssey.core.html.Selectors
 import io.github.nodyssey.model.FeedSort
 import io.github.plaza.core.net.PageMarkers
 import io.github.plaza.core.net.SiteConfig
-import io.github.plaza.core.net.resolveUserAgent
-import io.github.plaza.designsys.component.UserAvatar
 import java.net.URI
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -191,7 +189,7 @@ object NodeSeekSite {
     const val SETTING_PREFERENCE = "preference"
     const val SETTING_HOMEPAGE = "homepage"
 
-    /** Accounts without an upload 404 here; [UserAvatar] draws the initial instead. */
+    /** Accounts without an upload 404 here; `UserAvatar` draws the initial instead. */
     fun avatarUrl(uid: Long): String? = absoluteUrl("/avatar/$uid.png")
 
     /**

--- a/app/src/main/java/io/github/nodyssey/core/StardustReceiveMarkup.kt
+++ b/app/src/main/java/io/github/nodyssey/core/StardustReceiveMarkup.kt
@@ -1,8 +1,6 @@
 package io.github.nodyssey.core
 
 import io.github.plaza.core.richtext.RichNode
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 import kotlin.random.Random
 
 /**
@@ -117,12 +115,51 @@ object StardustReceiveMarkup {
      */
     private fun decode(value: String): String =
         try {
-            // The `String` charset overload, not the `Charset` one: that is API 33 and this app runs
-            // from 26.
-            URLDecoder.decode(value, StandardCharsets.UTF_8.name())
+            percentDecode(value)
         } catch (exception: IllegalArgumentException) {
             value
         }
+
+    /**
+     * `URLDecoder.decode(value, "UTF-8")`, spelled out.
+     *
+     * Written here rather than delegated because `java.net.URLDecoder` is JVM API while the markup
+     * this file reads is a fact about the site. The behaviour copied is exact, including the part
+     * that looks like a bug: **`+` still decodes to a space.** That is form encoding rather than URL
+     * encoding, and the site's editor has been writing it into 收款码 markers for as long as they
+     * have existed — reading only `%XX` would shift every space in every card already posted.
+     *
+     * A run of escapes is decoded as one byte sequence, so a character split across `%E4%B8%AD`
+     * comes back whole. Characters that were never escaped are copied as they are, which is what
+     * keeps an emoji in a 备注 from being taken apart into two unpaired surrogates.
+     */
+    private fun percentDecode(value: String): String = buildString(value.length) {
+        val escaped = ByteArray(value.length / 3 + 1)
+        var index = 0
+        while (index < value.length) {
+            when (value[index]) {
+                '+' -> {
+                    append(' ')
+                    index++
+                }
+
+                '%' -> {
+                    var count = 0
+                    while (index < value.length && value[index] == '%') {
+                        require(index + 3 <= value.length) { "incomplete trailing escape at $index" }
+                        escaped[count++] = (
+                            value.substring(index + 1, index + 3).toIntOrNull(radix = 16)
+                                ?: throw IllegalArgumentException("malformed escape at $index")
+                            ).toByte()
+                        index += 3
+                    }
+                    append(escaped.decodeToString(endIndex = count))
+                }
+
+                else -> append(value[index++])
+            }
+        }
+    }
 
     /**
      * JavaScript's `encodeURIComponent`, which is what the site's editor applies to every value.
@@ -133,7 +170,7 @@ object StardustReceiveMarkup {
      */
     private fun encodeUriComponent(value: String): String =
         buildString {
-            for (byte in value.toByteArray(StandardCharsets.UTF_8)) {
+            for (byte in value.encodeToByteArray()) {
                 val octet = byte.toInt() and 0xFF
                 val char = octet.toChar()
                 if (octet < 0x80 && (char in 'A'..'Z' || char in 'a'..'z' || char in '0'..'9' || char in UNRESERVED)) {
@@ -147,6 +184,7 @@ object StardustReceiveMarkup {
         }
 
     private const val UNRESERVED = "-_.!~*'()"
+
     private const val HEX = "0123456789ABCDEF"
 
     /** `1e8` in the site's expression. */

--- a/app/src/main/java/io/github/nodyssey/core/html/SiteBootstrap.kt
+++ b/app/src/main/java/io/github/nodyssey/core/html/SiteBootstrap.kt
@@ -4,8 +4,7 @@ import io.github.plaza.core.net.SiteError
 import io.github.plaza.core.net.SiteException
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import java.nio.charset.StandardCharsets
-import java.util.Base64
+import kotlin.io.encoding.Base64
 
 /**
  * The base64 `__config__` record NodeSeek server-renders into every page.
@@ -60,5 +59,15 @@ internal object SiteBootstrap {
 
     private fun encodedText(document: Document): String = document.getElementById(ELEMENT_ID)?.data()?.trim().orEmpty()
 
-    private fun decodeBase64(encoded: String): String = String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8)
+    /**
+     * `kotlin.io.encoding.Base64` rather than `java.util.Base64`: same RFC 4648 alphabet, no JVM.
+     *
+     * [Base64.PaddingOption.PRESENT_OPTIONAL] is not a relaxation, it is what the Java decoder did —
+     * that one accepts a payload with the trailing `=` and one without. `btoa`, which is what writes
+     * this element, always pads, so the difference has never shown up in a capture; matching it
+     * anyway keeps a hand-trimmed blob from becoming an [SiteError.Unparsable] it never was.
+     */
+    private val base64 = Base64.withPadding(Base64.PaddingOption.PRESENT_OPTIONAL)
+
+    private fun decodeBase64(encoded: String): String = base64.decode(encoded).decodeToString()
 }

--- a/app/src/main/java/io/github/nodyssey/data/AppCacheStore.kt
+++ b/app/src/main/java/io/github/nodyssey/data/AppCacheStore.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.data
 
-import coil3.ImageLoader
 import io.github.plaza.core.AppDispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -25,14 +24,35 @@ interface AppCacheStore {
 }
 
 /**
- * @param imageLoader resolved per call rather than held: the singleton loader builds its disk cache
+ * The image caches, as much of the loader as 清除缓存 has any business with.
+ *
+ * Narrower than the `ImageLoader` this used to be handed, and narrower on purpose: emptying two
+ * caches is the whole interaction, and asking for the loader meant the only way to exercise this
+ * class was to build a real one — which on Android needs a `Context`, and turned a test about files
+ * on disk into a test that needed a device.
+ */
+interface ImageCaches {
+    fun clearMemory()
+
+    /**
+     * Empties the disk cache through its own API and returns the directory it kept.
+     *
+     * Null when there is no disk cache. The directory comes back because it must *not* then be
+     * deleted: the cache's journal is open in this process, and removing the directory underneath a
+     * live cache is a different thing from telling it to empty.
+     */
+    fun clearDisk(): File?
+}
+
+/**
+ * @param imageCaches resolved per call rather than held: the singleton loader builds its disk cache
  *   on first touch, and this store is constructed with the rest of the graph, long before any
  *   screen has asked for an image.
  */
 class DefaultAppCacheStore(
     private val cacheDirectory: File,
     private val dispatchers: AppDispatchers,
-    private val imageLoader: () -> ImageLoader,
+    private val imageCaches: () -> ImageCaches,
 ) : AppCacheStore {
     override suspend fun sizeBytes(): Long =
         withContext(dispatchers.io) {
@@ -41,15 +61,10 @@ class DefaultAppCacheStore(
 
     override suspend fun clear() {
         withContext(dispatchers.io) {
-            val loader = imageLoader()
-            loader.memoryCache?.clear()
-            // Coil goes through its own API: its journal is open in this process, and deleting the
-            // directory underneath a live cache is a different thing from telling it to empty.
-            val imageCacheDirectory =
-                loader.diskCache?.let { cache ->
-                    cache.clear()
-                    File(cache.directory.toString())
-                }
+            val caches = imageCaches()
+            caches.clearMemory()
+            // Coil goes through its own API — see [ImageCaches.clearDisk].
+            val imageCacheDirectory = caches.clearDisk()
             // Everything else goes by deletion. WebView's cache has no API that does not mean
             // constructing a WebView on the main thread from the data layer, and `updates` is ours
             // to begin with. Deleting a running app's cache files is what the platform's own

--- a/app/src/main/java/io/github/nodyssey/data/CoilImageCaches.kt
+++ b/app/src/main/java/io/github/nodyssey/data/CoilImageCaches.kt
@@ -1,0 +1,17 @@
+package io.github.nodyssey.data
+
+import coil3.ImageLoader
+import java.io.File
+
+/** [ImageCaches] on the singleton Coil loader — the two caches it owns and nothing else. */
+class CoilImageCaches(private val loader: ImageLoader) : ImageCaches {
+    override fun clearMemory() {
+        loader.memoryCache?.clear()
+    }
+
+    override fun clearDisk(): File? =
+        loader.diskCache?.let { cache ->
+            cache.clear()
+            File(cache.directory.toString())
+        }
+}

--- a/app/src/main/java/io/github/nodyssey/data/composer/CommentComposerRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/composer/CommentComposerRepository.kt
@@ -1,11 +1,9 @@
 package io.github.nodyssey.data.composer
 
-import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.html.Selectors
 import io.github.plaza.core.AppClock
@@ -27,10 +25,6 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 import java.util.UUID
-
-private val Context.commentComposerDataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "comment-composer",
-)
 
 /**
  * An unsent reply.
@@ -92,12 +86,11 @@ interface CommentComposerRepository {
  * this layer could infer (it also carries the duplicate-reply and rate-limit refusals).
  */
 class DefaultCommentComposerRepository(
-    context: Context,
+    private val dataStore: DataStore<Preferences>,
     private val okHttpClient: OkHttpClient,
     private val dispatchers: AppDispatchers,
     private val clock: AppClock,
 ) : CommentComposerRepository {
-    private val dataStore = context.applicationContext.commentComposerDataStore
     private val json = Json { ignoreUnknownKeys = true }
 
     override fun draft(postId: Long): Flow<CommentDraft?> = dataStore.data.map { preferences ->

--- a/app/src/main/java/io/github/nodyssey/data/composer/ImagePreparer.kt
+++ b/app/src/main/java/io/github/nodyssey/data/composer/ImagePreparer.kt
@@ -1,119 +1,16 @@
 package io.github.nodyssey.data.composer
 
-import android.content.ContentResolver
-import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.net.Uri
-import android.os.Build
-import androidx.core.graphics.scale
-import androidx.core.net.toUri
-import io.github.nodyssey.data.imagehost.ImageHostError
-import io.github.nodyssey.data.imagehost.ImageHostException
 import io.github.nodyssey.data.imagehost.ImageHostUpload
-import io.github.plaza.core.AppDispatchers
-import kotlinx.coroutines.withContext
-import java.io.ByteArrayOutputStream
-import kotlin.math.max
-
-/** Turns whatever the photo picker handed back into bytes an image host will take. */
-fun interface ImagePreparer {
-    suspend fun prepare(source: String, displayName: String): ImageHostUpload
-}
 
 /**
- * Decodes a `content://` URI at a bounded size and re-encodes it as WebP.
+ * Turns whatever the photo picker handed back into bytes an image host will take.
  *
- * The two-pass `inJustDecodeBounds` read is what keeps a settings-screen-sized heap from meeting a
- * 50-megapixel photo: the second pass subsamples during decode, so the full-resolution bitmap never
- * exists. WebP rather than JPEG because it is the smallest format all six hosts accept, and because
- * nodeimage.com re-encodes to it regardless (its own uploader renames every file to `.webp`) — a
- * JPEG would simply be encoded twice for nothing.
- *
- * Animated GIFs are the deliberate exception and pass through untouched — decoding one to a Bitmap
- * would silently upload a still frame, which is worse than uploading a large file.
+ * [source] is a string rather than a `Uri` because what the picker hands back is the platform's
+ * business: the implementation that reads a `content://` URI lives in `platform/`, and everything
+ * from here to the upload only needs bytes, a name and a type.
  */
-class DefaultImagePreparer(
-    context: Context,
-    private val dispatchers: AppDispatchers,
-) : ImagePreparer {
-    private val resolver: ContentResolver = context.applicationContext.contentResolver
-
-    override suspend fun prepare(source: String, displayName: String): ImageHostUpload =
-        withContext(dispatchers.io) {
-            val uri = runCatching { source.toUri() }.getOrNull()
-                ?: throw ImageHostException(ImageHostError.Unparsable, detail = displayName)
-            val mimeType = runCatching { resolver.getType(uri) }.getOrNull().orEmpty()
-
-            if (mimeType == MIME_GIF) {
-                val bytes = readAll(uri, displayName)
-                return@withContext ImageHostUpload(bytes, displayName.withExtension("gif"), MIME_GIF)
-            }
-
-            val bitmap = decodeBounded(uri)
-                ?: return@withContext readAll(uri, displayName).let { bytes ->
-                    // Undecodable but readable: hand the original over and let the host judge it.
-                    ImageHostUpload(bytes, displayName, mimeType.ifBlank { MIME_OCTET })
-                }
-
-            ImageHostUpload(
-                bytes = bitmap.encodeWebp(),
-                fileName = displayName.withExtension("webp"),
-                mimeType = MIME_WEBP,
-            )
-        }
-
-    private fun readAll(uri: Uri, displayName: String): ByteArray =
-        runCatching { resolver.openInputStream(uri)?.use { it.readBytes() } }
-            .getOrNull()
-            ?: throw ImageHostException(ImageHostError.Unparsable, detail = displayName)
-
-    private fun decodeBounded(uri: Uri): Bitmap? = runCatching {
-        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
-        val longestEdge = max(bounds.outWidth, bounds.outHeight)
-        if (longestEdge <= 0) return null
-
-        val options = BitmapFactory.Options().apply {
-            inSampleSize = generateSequence(1) { it * 2 }.first { longestEdge / it <= MAX_EDGE_PX }
-        }
-        val decoded = resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
-        decoded?.scaledToBound()
-    }.getOrNull()
-
-    private fun Bitmap.scaledToBound(): Bitmap {
-        val longestEdge = max(width, height)
-        if (longestEdge <= MAX_EDGE_PX) return this
-        val ratio = MAX_EDGE_PX.toFloat() / longestEdge
-        return scale(
-            width = (width * ratio).toInt().coerceAtLeast(1),
-            height = (height * ratio).toInt().coerceAtLeast(1),
-        )
-    }
-
-    private fun Bitmap.encodeWebp(): ByteArray =
-        ByteArrayOutputStream().use { stream ->
-            @Suppress("DEPRECATION")
-            val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                Bitmap.CompressFormat.WEBP_LOSSY
-            } else {
-                Bitmap.CompressFormat.WEBP
-            }
-            compress(format, WEBP_QUALITY, stream)
-            stream.toByteArray()
-        }
-
-    private companion object {
-        /**
-         * Forum images are read on a phone and, at most, on a laptop. 2048 covers a full-width image
-         * on a retina display; beyond that the extra bytes buy nothing anyone will see.
-         */
-        const val MAX_EDGE_PX = 2048
-        const val WEBP_QUALITY = 86
-        const val MIME_WEBP = "image/webp"
-        const val MIME_GIF = "image/gif"
-        const val MIME_OCTET = "application/octet-stream"
-    }
+fun interface ImagePreparer {
+    suspend fun prepare(source: String, displayName: String): ImageHostUpload
 }
 
 /** `IMG_0421.HEIC` → `IMG_0421.webp`; a name with no extension just gains one. */

--- a/app/src/main/java/io/github/nodyssey/data/composer/PostComposerRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/composer/PostComposerRepository.kt
@@ -1,11 +1,9 @@
 package io.github.nodyssey.data.composer
 
-import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.html.PostListParser
 import io.github.nodyssey.core.html.Selectors
@@ -38,10 +36,6 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 import java.util.UUID
-
-private val Context.postComposerDataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "post-composer",
-)
 
 /** User-authored draft and publish contract for the native post editor. */
 @Serializable
@@ -153,12 +147,11 @@ interface PostComposerRepository {
 }
 
 class DefaultPostComposerRepository(
-    context: Context,
+    private val dataStore: DataStore<Preferences>,
     private val okHttpClient: OkHttpClient,
     private val dispatchers: AppDispatchers,
     private val clock: AppClock,
 ) : PostComposerRepository {
-    private val dataStore = context.applicationContext.postComposerDataStore
     private val json = Json { ignoreUnknownKeys = true }
 
     override val draft: Flow<PostDraft?> = dataStore.data.map { preferences ->

--- a/app/src/main/java/io/github/nodyssey/data/imagehost/ImageHostSettings.kt
+++ b/app/src/main/java/io/github/nodyssey/data/imagehost/ImageHostSettings.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.data.imagehost
 
-import android.content.Context
 import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
@@ -8,52 +7,11 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import io.github.nodyssey.data.security.KeystoreSecretCipher
 import io.github.nodyssey.data.security.SecretCipher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.io.IOException
-
-/**
- * Which host is selected, and the credentials for each.
- *
- * All six live in one store, keyed by [ImageHostProvider.id], so switching hosts does not mean
- * re-pasting a token: the one that was there before is still there when the user switches back.
- * That is the whole reason the configs are kept per provider rather than as a single current record.
- *
- * Nothing here leaves the device — except that a DataStore file is part of the cloud backup, which
- * `data_extraction_rules.xml` only holds the Room database and the WebView cookies out of. So the
- * credentials go in encrypted: see [ImageHostSecretKeys] for which values those are and
- * [io.github.nodyssey.data.security.SecretCipher] for what encrypted means here. These are the user's
- * own credentials on services this app does not run, and the only place they are ever sent is the
- * host they belong to.
- */
-private val Context.imageHostDataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "imagehost",
-    produceMigrations = { context ->
-        listOf(
-            LegacyNodeImageKeyMigration {
-                context.legacyNodeImageDataStore.data.first()[LEGACY_NODE_IMAGE_KEY]
-            },
-            // After the one above, not before: the key it copies in arrives in plaintext, and this is
-            // what turns it into ciphertext on the same first read.
-            ImageHostSecretEncryptionMigration(KeystoreSecretCipher()),
-        )
-    },
-)
-
-/**
- * Where the NodeImage key lived when nodeimage.com was the only host the app could talk to.
- *
- * Kept declared for exactly one reason: [LegacyNodeImageKeyMigration] reads it once. Deleting the
- * declaration would make every existing install look like a fresh one with no host connected.
- */
-private val Context.legacyNodeImageDataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "nodeimage",
-)
 
 /**
  * Carries a pre-existing NodeImage key into the multi-host store, once.
@@ -85,7 +43,13 @@ internal class LegacyNodeImageKeyMigration(
     override suspend fun cleanUp() = Unit
 }
 
-private val LEGACY_NODE_IMAGE_KEY = stringPreferencesKey("api-key")
+/**
+ * Where the NodeImage key lived when nodeimage.com was the only host the app could talk to.
+ *
+ * Named here rather than at the store that still holds it, because [LegacyNodeImageKeyMigration] is
+ * the only reader left and this is the file that says why the read happens at all.
+ */
+internal val LEGACY_NODE_IMAGE_KEY = stringPreferencesKey("api-key")
 
 internal object ImageHostKeys {
     val SELECTED = stringPreferencesKey("selected")
@@ -160,13 +124,25 @@ interface ImageHostSettings {
     suspend fun disconnect(provider: ImageHostProvider)
 }
 
+/**
+ * Which host is selected, and the credentials for each.
+ *
+ * All six live in one store, keyed by [ImageHostProvider.id], so switching hosts does not mean
+ * re-pasting a token: the one that was there before is still there when the user switches back.
+ * That is the whole reason the configs are kept per provider rather than as a single current record.
+ *
+ * Nothing here leaves the device — except that a DataStore file is part of the cloud backup, which
+ * `data_extraction_rules.xml` only holds the Room database and the WebView cookies out of. So the
+ * credentials go in encrypted: see [ImageHostSecretKeys] for which values those are and
+ * [io.github.nodyssey.data.security.SecretCipher] for what encrypted means here. These are the user's
+ * own credentials on services this app does not run, and the only place they are ever sent is the
+ * host they belong to.
+ */
 class DataStoreImageHostSettings(
-    context: Context,
+    private val dataStore: DataStore<Preferences>,
     /** The same cipher [ImageHostSecretEncryptionMigration] runs with, unless a test says otherwise. */
-    private val cipher: SecretCipher = KeystoreSecretCipher(),
+    private val cipher: SecretCipher,
 ) : ImageHostSettings {
-    private val dataStore = context.applicationContext.imageHostDataStore
-
     private val preferences: Flow<Preferences> = dataStore.data
         .catch { throwable -> if (throwable is IOException) emit(emptyPreferences()) else throw throwable }
 

--- a/app/src/main/java/io/github/nodyssey/data/local/NodeSeekDatabase.kt
+++ b/app/src/main/java/io/github/nodyssey/data/local/NodeSeekDatabase.kt
@@ -1,8 +1,6 @@
 package io.github.nodyssey.data.local
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.migration.Migration
@@ -46,25 +44,6 @@ abstract class NodeSeekDatabase : RoomDatabase() {
     abstract fun cacheSessionDao(): CacheSessionDao
 
     abstract fun profileDao(): ProfileDao
-
-    companion object {
-        fun create(context: Context): NodeSeekDatabase =
-            Room
-                .databaseBuilder(context, NodeSeekDatabase::class.java, "nodeseek.db")
-                // Known upgrades preserve local state explicitly. The fallback remains for unknown
-                // legacy versions whose downloaded content can be rebuilt; schemas stay checked in.
-                .addMigrations(
-                    MIGRATION_3_4,
-                    MIGRATION_4_5,
-                    MIGRATION_5_6,
-                    MIGRATION_6_7,
-                    MIGRATION_7_8,
-                    MIGRATION_8_9,
-                    MIGRATION_9_10,
-                )
-                .fallbackToDestructiveMigration(dropAllTables = true)
-                .build()
-    }
 }
 
 /** Adds the signed-in profile cache without disturbing existing posts or read marks. */
@@ -205,3 +184,20 @@ internal val MIGRATION_9_10 =
             db.execSQL("ALTER TABLE `post_details` ADD COLUMN `isAwarded` INTEGER DEFAULT NULL")
         }
     }
+
+/**
+ * Every migration this schema has, in order — the list `createNodeSeekDatabase` opens the file with.
+ *
+ * Named here, beside the migrations themselves, rather than at the builder: which upgrades are known
+ * is a fact about the schema, and leaving one out is how a device with real content in it takes the
+ * destructive fallback instead.
+ */
+internal val NODESEEK_MIGRATIONS = arrayOf(
+    MIGRATION_3_4,
+    MIGRATION_4_5,
+    MIGRATION_5_6,
+    MIGRATION_6_7,
+    MIGRATION_7_8,
+    MIGRATION_8_9,
+    MIGRATION_9_10,
+)

--- a/app/src/main/java/io/github/nodyssey/data/proxy/ProxySettings.kt
+++ b/app/src/main/java/io/github/nodyssey/data/proxy/ProxySettings.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.data.proxy
 
-import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -8,8 +7,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import io.github.nodyssey.data.security.KeystoreSecretCipher
 import io.github.nodyssey.data.security.SecretCipher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -70,8 +67,6 @@ fun ProxyConfig.problem(): ProxyConfigProblem? {
     return null
 }
 
-private val Context.proxyDataStore: DataStore<Preferences> by preferencesDataStore(name = "proxy")
-
 private object ProxyKeys {
     val ENABLED = booleanPreferencesKey("enabled")
     val TYPE = stringPreferencesKey("type")
@@ -100,11 +95,9 @@ interface ProxySettings {
  * thing that happens when the user has not typed one.
  */
 class DataStoreProxySettings(
-    context: Context,
-    private val cipher: SecretCipher = KeystoreSecretCipher(),
+    private val dataStore: DataStore<Preferences>,
+    private val cipher: SecretCipher,
 ) : ProxySettings {
-    private val dataStore = context.applicationContext.proxyDataStore
-
     override val config: Flow<ProxyConfig> = dataStore.data
         .catch { throwable -> if (throwable is IOException) emit(emptyPreferences()) else throw throwable }
         .map { preferences ->

--- a/app/src/main/java/io/github/nodyssey/data/security/SecretCipher.kt
+++ b/app/src/main/java/io/github/nodyssey/data/security/SecretCipher.kt
@@ -1,14 +1,5 @@
 package io.github.nodyssey.data.security
 
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
-import android.util.Base64
-import java.security.KeyStore
-import javax.crypto.Cipher
-import javax.crypto.KeyGenerator
-import javax.crypto.SecretKey
-import javax.crypto.spec.GCMParameterSpec
-
 /**
  * Encrypts one short secret at a time, so a credential can live in DataStore without living there in
  * plaintext.
@@ -22,7 +13,12 @@ interface SecretCipher {
     /** Empty for empty input; `null` when this device could not encrypt, which callers store as nothing. */
     fun encrypt(plaintext: String): String?
 
-    /** Empty when [stored] cannot be read back — see [KeystoreSecretCipher] for when that happens. */
+    /**
+     * Empty when [stored] cannot be read back — see `KeystoreSecretCipher` for when that happens.
+     *
+     * That implementation lives in `platform/` rather than beside this interface: a keystore is a
+     * device, and what this layer needs to know about encryption is only that it can fail.
+     */
     fun decrypt(stored: String): String
 
     companion object {
@@ -37,64 +33,5 @@ interface SecretCipher {
         const val MARKER = "enc1:"
 
         fun isEncrypted(stored: String): Boolean = stored.startsWith(MARKER)
-    }
-}
-
-/**
- * AES-GCM under a key held by the platform keystore, where the key material itself is never readable
- * by this process and never leaves the device.
- *
- * That last part is the reason [decrypt] answers an unreadable value with an empty string rather than
- * an exception: a restored backup carries the ciphertext to a phone whose keystore has no key for it,
- * and so does a keystore the system reset. Both are ordinary events, and both mean the same thing to
- * the user — the address and port are still there, the password has to be typed again.
- */
-class KeystoreSecretCipher(private val alias: String = DEFAULT_ALIAS) : SecretCipher {
-    override fun encrypt(plaintext: String): String? {
-        if (plaintext.isEmpty()) return ""
-        return runCatching {
-            val cipher = Cipher.getInstance(TRANSFORMATION)
-            cipher.init(Cipher.ENCRYPT_MODE, key())
-            val ciphertext = cipher.doFinal(plaintext.toByteArray())
-            // The IV is generated per encryption by the cipher itself and is not a secret; prefixing it
-            // keeps a stored value self-describing, so decryption needs nothing but the key.
-            SecretCipher.MARKER + Base64.encodeToString(cipher.iv + ciphertext, Base64.NO_WRAP)
-        }.getOrNull()
-    }
-
-    override fun decrypt(stored: String): String {
-        if (!SecretCipher.isEncrypted(stored)) return ""
-        return runCatching {
-            val bytes = Base64.decode(stored.removePrefix(SecretCipher.MARKER), Base64.NO_WRAP)
-            val cipher = Cipher.getInstance(TRANSFORMATION)
-            cipher.init(Cipher.DECRYPT_MODE, key(), GCMParameterSpec(TAG_BITS, bytes, 0, IV_BYTES))
-            String(cipher.doFinal(bytes, IV_BYTES, bytes.size - IV_BYTES))
-        }.getOrDefault("")
-    }
-
-    /** Created on first use and kept by the keystore from then on; nothing here holds it in a field. */
-    private fun key(): SecretKey {
-        val store = KeyStore.getInstance(PROVIDER).apply { load(null) }
-        (store.getEntry(alias, null) as? KeyStore.SecretKeyEntry)?.secretKey?.let { return it }
-        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, PROVIDER)
-        generator.init(
-            KeyGenParameterSpec
-                .Builder(alias, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
-                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                // No user-authentication requirement: the forum's own requests run while the screen is
-                // off, and a proxy the app cannot reach without an unlock is a proxy that breaks
-                // background refreshes.
-                .build(),
-        )
-        return generator.generateKey()
-    }
-
-    private companion object {
-        const val PROVIDER = "AndroidKeyStore"
-        const val TRANSFORMATION = "AES/GCM/NoPadding"
-        const val DEFAULT_ALIAS = "nodyssey.secret.v1"
-        const val IV_BYTES = 12
-        const val TAG_BITS = 128
     }
 }

--- a/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt
@@ -15,7 +15,6 @@ import io.github.nodyssey.model.SearchHistoryEntry
 import io.github.nodyssey.model.SearchTarget
 import io.github.plaza.core.update.AppRelease
 import io.github.plaza.core.update.UpdateCheckRecord
-import io.github.plaza.designsys.editor.EditorAction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/io/github/nodyssey/data/update/AppUpdateRepository.kt
+++ b/app/src/main/java/io/github/nodyssey/data/update/AppUpdateRepository.kt
@@ -1,12 +1,11 @@
 package io.github.nodyssey.data.update
 
-import android.content.pm.PackageInstaller
 import io.github.plaza.core.AppClock
 import io.github.plaza.core.AppDispatchers
 import io.github.plaza.core.update.AppRelease
 import io.github.plaza.core.update.AppUpdateException
 import io.github.plaza.core.update.AppUpdateState
-import io.github.plaza.core.update.InstallFailure
+import io.github.plaza.core.update.InstallOutcome
 import io.github.plaza.core.update.ReleaseNote
 import io.github.plaza.core.update.ReleaseSource
 import io.github.plaza.core.update.UpdateCheck
@@ -105,8 +104,13 @@ interface AppUpdateRepository {
      */
     suspend fun releaseNotes(force: Boolean = false): List<ReleaseNote>
 
-    /** Reports a `PackageInstaller.STATUS_*` back from [ApkInstallResultReceiver]. */
-    fun onInstallStatus(status: Int)
+    /**
+     * Reports how the install session ended.
+     *
+     * An [InstallOutcome] rather than the platform's own status integer: which number meant "the
+     * user said no" is a fact about `PackageInstaller`, and it is read where the broadcast arrives.
+     */
+    fun onInstallOutcome(outcome: InstallOutcome)
 }
 
 class DefaultAppUpdateRepository(
@@ -254,9 +258,9 @@ class DefaultAppUpdateRepository(
         mutableState.update { it.copy(download = UpdateDownload.Idle) }
     }
 
-    override fun onInstallStatus(status: Int) {
-        when (status) {
-            PackageInstaller.STATUS_SUCCESS -> {
+    override fun onInstallOutcome(outcome: InstallOutcome) {
+        when (outcome) {
+            InstallOutcome.Installed -> {
                 // The new build is in; this process is about to be replaced. Drop the APK rather than
                 // leaving a copy of the previous download sitting in the cache forever.
                 scope.launch { withContext(dispatchers.io) { downloadDirectory.deleteRecursively() } }
@@ -266,10 +270,9 @@ class DefaultAppUpdateRepository(
             }
 
             // Backing out of the system dialog is an answer, not a fault.
-            PackageInstaller.STATUS_FAILURE_ABORTED ->
-                mutableState.update { it.copy(installFailure = null) }
+            InstallOutcome.Abandoned -> mutableState.update { it.copy(installFailure = null) }
 
-            else -> mutableState.update { it.copy(installFailure = installFailureOf(status)) }
+            is InstallOutcome.Failed -> mutableState.update { it.copy(installFailure = outcome.failure) }
         }
     }
 
@@ -339,15 +342,5 @@ class DefaultAppUpdateRepository(
         const val CHECK_INTERVAL_MILLIS = 24 * 60 * 60 * 1000L
 
         private const val PART_SUFFIX = ".part"
-
-        private fun installFailureOf(status: Int): InstallFailure =
-            when (status) {
-                PackageInstaller.STATUS_FAILURE_BLOCKED -> InstallFailure.BLOCKED
-                PackageInstaller.STATUS_FAILURE_CONFLICT -> InstallFailure.CONFLICT
-                PackageInstaller.STATUS_FAILURE_INCOMPATIBLE -> InstallFailure.INCOMPATIBLE
-                PackageInstaller.STATUS_FAILURE_STORAGE -> InstallFailure.STORAGE
-                PackageInstaller.STATUS_FAILURE_INVALID -> InstallFailure.INVALID
-                else -> InstallFailure.UNKNOWN
-            }
     }
 }

--- a/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
@@ -83,6 +83,7 @@ import io.github.plaza.core.net.CrossOriginRefererInterceptor
 import io.github.plaza.core.net.SiteHtmlClient
 import io.github.plaza.core.net.UserAgent
 import io.github.plaza.core.net.WebViewCookieJar
+import io.github.plaza.core.net.WebViewCookieStore
 import io.github.plaza.core.net.deviceAcceptLanguage
 import io.github.plaza.core.net.resolveUserAgent
 import io.github.plaza.core.readAppVersion
@@ -187,7 +188,7 @@ class DefaultAppContainer(
 ) : AppContainer {
     private val appContext = context.applicationContext
 
-    override val cookieJar: WebViewCookieJar by lazy { WebViewCookieJar(NodeSeekSite.CONFIG) }
+    override val cookieJar: WebViewCookieJar by lazy { WebViewCookieJar(NodeSeekSite.CONFIG, WebViewCookieStore()) }
 
     override val userAgent: UserAgent by lazy { resolveUserAgent(appContext, NodeSeekSite.CONFIG) }
 

--- a/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
@@ -3,7 +3,6 @@ package io.github.nodyssey.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
 import coil3.SingletonImageLoader
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.NodysseyRelease
@@ -70,6 +69,7 @@ import io.github.nodyssey.data.proxy.DataStoreProxySettings
 import io.github.nodyssey.data.proxy.NetworkProxyConnectionTester
 import io.github.nodyssey.data.proxy.ProxyConnectionTester
 import io.github.nodyssey.data.proxy.ProxySettings
+import io.github.nodyssey.data.security.KeystoreSecretCipher
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.nodyssey.data.settings.SettingsRepository
 import io.github.nodyssey.data.update.ApkInstaller
@@ -180,10 +180,6 @@ interface AppContainer {
     val proxyConnectionTester: ProxyConnectionTester
 }
 
-private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "settings",
-)
-
 class DefaultAppContainer(
     context: Context,
     override val dispatchers: AppDispatchers = AppDispatchers(),
@@ -211,7 +207,9 @@ class DefaultAppContainer(
      */
     private val appScope = CoroutineScope(SupervisorJob() + dispatchers.default)
 
-    override val proxySettings: ProxySettings by lazy { DataStoreProxySettings(appContext) }
+    override val proxySettings: ProxySettings by lazy {
+        DataStoreProxySettings(appContext.proxyDataStore, KeystoreSecretCipher())
+    }
 
     /**
      * One pool behind all three clients.
@@ -336,7 +334,7 @@ class DefaultAppContainer(
     }
 
     override val postComposerRepository: PostComposerRepository by lazy {
-        DefaultPostComposerRepository(appContext, okHttpClient, dispatchers, clock)
+        DefaultPostComposerRepository(appContext.postComposerDataStore, okHttpClient, dispatchers, clock)
     }
 
     override val accountSettingsRepository: AccountSettingsRepository by lazy {
@@ -390,7 +388,7 @@ class DefaultAppContainer(
     }
 
     override val commentComposerRepository: CommentComposerRepository by lazy {
-        DefaultCommentComposerRepository(appContext, okHttpClient, dispatchers, clock)
+        DefaultCommentComposerRepository(appContext.commentComposerDataStore, okHttpClient, dispatchers, clock)
     }
 
     override val postEditor: PostEditor by lazy {
@@ -443,7 +441,7 @@ class DefaultAppContainer(
 
     override val imageHostRepository: ImageHostRepository by lazy {
         DefaultImageHostRepository(
-            settings = DataStoreImageHostSettings(appContext),
+            settings = DataStoreImageHostSettings(appContext.imageHostDataStore, KeystoreSecretCipher()),
             http = imageHostClient,
             dispatchers = dispatchers,
         )

--- a/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
@@ -54,7 +54,6 @@ import io.github.nodyssey.data.account.AccountSettingsRepository
 import io.github.nodyssey.data.account.NetworkAccountSettingsRepository
 import io.github.nodyssey.data.composer.CommentComposerRepository
 import io.github.nodyssey.data.composer.DefaultCommentComposerRepository
-import io.github.nodyssey.data.composer.DefaultImagePreparer
 import io.github.nodyssey.data.composer.DefaultPostComposerRepository
 import io.github.nodyssey.data.composer.DefaultPostEditor
 import io.github.nodyssey.data.composer.ImageHostUploader
@@ -64,17 +63,18 @@ import io.github.nodyssey.data.composer.PostEditor
 import io.github.nodyssey.data.imagehost.DataStoreImageHostSettings
 import io.github.nodyssey.data.imagehost.DefaultImageHostRepository
 import io.github.nodyssey.data.imagehost.ImageHostRepository
-import io.github.nodyssey.data.local.NodeSeekDatabase
 import io.github.nodyssey.data.proxy.DataStoreProxySettings
 import io.github.nodyssey.data.proxy.NetworkProxyConnectionTester
 import io.github.nodyssey.data.proxy.ProxyConnectionTester
 import io.github.nodyssey.data.proxy.ProxySettings
-import io.github.nodyssey.data.security.KeystoreSecretCipher
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.nodyssey.data.settings.SettingsRepository
-import io.github.nodyssey.data.update.ApkInstaller
 import io.github.nodyssey.data.update.AppUpdateRepository
 import io.github.nodyssey.data.update.DefaultAppUpdateRepository
+import io.github.nodyssey.platform.ApkInstaller
+import io.github.nodyssey.platform.DefaultImagePreparer
+import io.github.nodyssey.platform.KeystoreSecretCipher
+import io.github.nodyssey.platform.createNodeSeekDatabase
 import io.github.plaza.core.AppClock
 import io.github.plaza.core.AppDispatchers
 import io.github.plaza.core.AppVersion
@@ -272,7 +272,7 @@ class DefaultAppContainer(
     }
 
     /** The offline-first SSOT. Everything below reads from it; only the data sources write to it. */
-    private val database by lazy { NodeSeekDatabase.create(appContext) }
+    private val database by lazy { createNodeSeekDatabase(appContext) }
 
     private val remotePosts by lazy { NetworkPostDataSource(htmlClient, dispatchers, clock) }
 

--- a/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
+++ b/app/src/main/java/io/github/nodyssey/di/AppContainer.kt
@@ -17,6 +17,7 @@ import io.github.nodyssey.data.AppCacheStore
 import io.github.nodyssey.data.AssetsRepository
 import io.github.nodyssey.data.AwardRepository
 import io.github.nodyssey.data.CategoryRepository
+import io.github.nodyssey.data.CoilImageCaches
 import io.github.nodyssey.data.CommunityRepository
 import io.github.nodyssey.data.CreditRepository
 import io.github.nodyssey.data.DefaultAppCacheStore
@@ -512,7 +513,7 @@ class DefaultAppContainer(
         DefaultAppCacheStore(
             cacheDirectory = appContext.cacheDir,
             dispatchers = dispatchers,
-            imageLoader = { SingletonImageLoader.get(appContext) },
+            imageCaches = { CoilImageCaches(SingletonImageLoader.get(appContext)) },
         )
     }
 }

--- a/app/src/main/java/io/github/nodyssey/di/PreferenceStores.kt
+++ b/app/src/main/java/io/github/nodyssey/di/PreferenceStores.kt
@@ -7,7 +7,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import io.github.nodyssey.data.imagehost.ImageHostSecretEncryptionMigration
 import io.github.nodyssey.data.imagehost.LEGACY_NODE_IMAGE_KEY
 import io.github.nodyssey.data.imagehost.LegacyNodeImageKeyMigration
-import io.github.nodyssey.data.security.KeystoreSecretCipher
+import io.github.nodyssey.platform.KeystoreSecretCipher
 import kotlinx.coroutines.flow.first
 
 /**

--- a/app/src/main/java/io/github/nodyssey/di/PreferenceStores.kt
+++ b/app/src/main/java/io/github/nodyssey/di/PreferenceStores.kt
@@ -1,0 +1,63 @@
+package io.github.nodyssey.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import io.github.nodyssey.data.imagehost.ImageHostSecretEncryptionMigration
+import io.github.nodyssey.data.imagehost.LEGACY_NODE_IMAGE_KEY
+import io.github.nodyssey.data.imagehost.LegacyNodeImageKeyMigration
+import io.github.nodyssey.data.security.KeystoreSecretCipher
+import kotlinx.coroutines.flow.first
+
+/**
+ * Every `DataStore` file the app owns, and the only place a `Context` is needed to open one.
+ *
+ * They are gathered here rather than sitting beside the repositories that read them because opening
+ * a file is the one part of storing a setting that is about Android: `preferencesDataStore` is a
+ * `Context` extension, it decides where on the filesystem the file goes, and it enforces one
+ * instance per name per process. What is *in* the file — the keys, the defaults, the migrations —
+ * is a fact about the app, and that stayed with the repository.
+ *
+ * The names are load-bearing. Each one is an existing file on every installed device; renaming one
+ * is indistinguishable, from the app's side, from the user never having opened the screen.
+ */
+internal val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "settings",
+)
+
+internal val Context.proxyDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "proxy",
+)
+
+internal val Context.postComposerDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "post-composer",
+)
+
+internal val Context.commentComposerDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "comment-composer",
+)
+
+internal val Context.imageHostDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "imagehost",
+    produceMigrations = { context ->
+        listOf(
+            LegacyNodeImageKeyMigration {
+                context.legacyNodeImageDataStore.data.first()[LEGACY_NODE_IMAGE_KEY]
+            },
+            // After the one above, not before: the key it copies in arrives in plaintext, and this is
+            // what turns it into ciphertext on the same first read.
+            ImageHostSecretEncryptionMigration(KeystoreSecretCipher()),
+        )
+    },
+)
+
+/**
+ * Where the NodeImage key lived when nodeimage.com was the only host the app could talk to.
+ *
+ * Kept declared for exactly one reason: [LegacyNodeImageKeyMigration] reads it once. Deleting the
+ * declaration would make every existing install look like a fresh one with no host connected.
+ */
+private val Context.legacyNodeImageDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "nodeimage",
+)

--- a/app/src/main/java/io/github/nodyssey/platform/ApkInstaller.kt
+++ b/app/src/main/java/io/github/nodyssey/platform/ApkInstaller.kt
@@ -1,4 +1,4 @@
-package io.github.nodyssey.data.update
+package io.github.nodyssey.platform
 
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
@@ -12,6 +12,8 @@ import androidx.core.content.IntentCompat
 import androidx.core.net.toUri
 import io.github.nodyssey.NodysseyApp
 import io.github.plaza.core.AppDispatchers
+import io.github.plaza.core.update.InstallFailure
+import io.github.plaza.core.update.InstallOutcome
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
@@ -127,10 +129,29 @@ class ApkInstallResultReceiver : BroadcastReceiver() {
         (context.applicationContext as? NodysseyApp)
             ?.container
             ?.appUpdateRepository
-            ?.onInstallStatus(status)
+            ?.onInstallOutcome(outcomeOf(status))
     }
 
     companion object {
         const val ACTION_INSTALL_STATUS = "io.github.nodyssey.INSTALL_STATUS"
+
+        /**
+         * `PackageInstaller.STATUS_*` in the vocabulary the update repository speaks.
+         *
+         * Here rather than there because this is the only place the platform's integers arrive, and
+         * because an unrecognised one has to mean [InstallFailure.UNKNOWN] rather than a crash: the
+         * list has grown before and the system is free to send a status this build has never seen.
+         */
+        internal fun outcomeOf(status: Int): InstallOutcome =
+            when (status) {
+                PackageInstaller.STATUS_SUCCESS -> InstallOutcome.Installed
+                PackageInstaller.STATUS_FAILURE_ABORTED -> InstallOutcome.Abandoned
+                PackageInstaller.STATUS_FAILURE_BLOCKED -> InstallOutcome.Failed(InstallFailure.BLOCKED)
+                PackageInstaller.STATUS_FAILURE_CONFLICT -> InstallOutcome.Failed(InstallFailure.CONFLICT)
+                PackageInstaller.STATUS_FAILURE_INCOMPATIBLE -> InstallOutcome.Failed(InstallFailure.INCOMPATIBLE)
+                PackageInstaller.STATUS_FAILURE_STORAGE -> InstallOutcome.Failed(InstallFailure.STORAGE)
+                PackageInstaller.STATUS_FAILURE_INVALID -> InstallOutcome.Failed(InstallFailure.INVALID)
+                else -> InstallOutcome.Failed(InstallFailure.UNKNOWN)
+            }
     }
 }

--- a/app/src/main/java/io/github/nodyssey/platform/DefaultImagePreparer.kt
+++ b/app/src/main/java/io/github/nodyssey/platform/DefaultImagePreparer.kt
@@ -1,0 +1,114 @@
+package io.github.nodyssey.platform
+
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import androidx.core.graphics.scale
+import androidx.core.net.toUri
+import io.github.nodyssey.data.composer.ImagePreparer
+import io.github.nodyssey.data.composer.withExtension
+import io.github.nodyssey.data.imagehost.ImageHostError
+import io.github.nodyssey.data.imagehost.ImageHostException
+import io.github.nodyssey.data.imagehost.ImageHostUpload
+import io.github.plaza.core.AppDispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import kotlin.math.max
+
+/**
+ * Decodes a `content://` URI at a bounded size and re-encodes it as WebP.
+ *
+ * The two-pass `inJustDecodeBounds` read is what keeps a settings-screen-sized heap from meeting a
+ * 50-megapixel photo: the second pass subsamples during decode, so the full-resolution bitmap never
+ * exists. WebP rather than JPEG because it is the smallest format all six hosts accept, and because
+ * nodeimage.com re-encodes to it regardless (its own uploader renames every file to `.webp`) — a
+ * JPEG would simply be encoded twice for nothing.
+ *
+ * Animated GIFs are the deliberate exception and pass through untouched — decoding one to a Bitmap
+ * would silently upload a still frame, which is worse than uploading a large file.
+ */
+class DefaultImagePreparer(
+    context: Context,
+    private val dispatchers: AppDispatchers,
+) : ImagePreparer {
+    private val resolver: ContentResolver = context.applicationContext.contentResolver
+
+    override suspend fun prepare(source: String, displayName: String): ImageHostUpload =
+        withContext(dispatchers.io) {
+            val uri = runCatching { source.toUri() }.getOrNull()
+                ?: throw ImageHostException(ImageHostError.Unparsable, detail = displayName)
+            val mimeType = runCatching { resolver.getType(uri) }.getOrNull().orEmpty()
+
+            if (mimeType == MIME_GIF) {
+                val bytes = readAll(uri, displayName)
+                return@withContext ImageHostUpload(bytes, displayName.withExtension("gif"), MIME_GIF)
+            }
+
+            val bitmap = decodeBounded(uri)
+                ?: return@withContext readAll(uri, displayName).let { bytes ->
+                    // Undecodable but readable: hand the original over and let the host judge it.
+                    ImageHostUpload(bytes, displayName, mimeType.ifBlank { MIME_OCTET })
+                }
+
+            ImageHostUpload(
+                bytes = bitmap.encodeWebp(),
+                fileName = displayName.withExtension("webp"),
+                mimeType = MIME_WEBP,
+            )
+        }
+
+    private fun readAll(uri: Uri, displayName: String): ByteArray =
+        runCatching { resolver.openInputStream(uri)?.use { it.readBytes() } }
+            .getOrNull()
+            ?: throw ImageHostException(ImageHostError.Unparsable, detail = displayName)
+
+    private fun decodeBounded(uri: Uri): Bitmap? = runCatching {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+        val longestEdge = max(bounds.outWidth, bounds.outHeight)
+        if (longestEdge <= 0) return null
+
+        val options = BitmapFactory.Options().apply {
+            inSampleSize = generateSequence(1) { it * 2 }.first { longestEdge / it <= MAX_EDGE_PX }
+        }
+        val decoded = resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
+        decoded?.scaledToBound()
+    }.getOrNull()
+
+    private fun Bitmap.scaledToBound(): Bitmap {
+        val longestEdge = max(width, height)
+        if (longestEdge <= MAX_EDGE_PX) return this
+        val ratio = MAX_EDGE_PX.toFloat() / longestEdge
+        return scale(
+            width = (width * ratio).toInt().coerceAtLeast(1),
+            height = (height * ratio).toInt().coerceAtLeast(1),
+        )
+    }
+
+    private fun Bitmap.encodeWebp(): ByteArray =
+        ByteArrayOutputStream().use { stream ->
+            @Suppress("DEPRECATION")
+            val format = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                Bitmap.CompressFormat.WEBP_LOSSY
+            } else {
+                Bitmap.CompressFormat.WEBP
+            }
+            compress(format, WEBP_QUALITY, stream)
+            stream.toByteArray()
+        }
+
+    private companion object {
+        /**
+         * Forum images are read on a phone and, at most, on a laptop. 2048 covers a full-width image
+         * on a retina display; beyond that the extra bytes buy nothing anyone will see.
+         */
+        const val MAX_EDGE_PX = 2048
+        const val WEBP_QUALITY = 86
+        const val MIME_WEBP = "image/webp"
+        const val MIME_GIF = "image/gif"
+        const val MIME_OCTET = "application/octet-stream"
+    }
+}

--- a/app/src/main/java/io/github/nodyssey/platform/KeystoreSecretCipher.kt
+++ b/app/src/main/java/io/github/nodyssey/platform/KeystoreSecretCipher.kt
@@ -1,0 +1,70 @@
+package io.github.nodyssey.platform
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import io.github.nodyssey.data.security.SecretCipher
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * AES-GCM under a key held by the platform keystore, where the key material itself is never readable
+ * by this process and never leaves the device.
+ *
+ * That last part is the reason [decrypt] answers an unreadable value with an empty string rather than
+ * an exception: a restored backup carries the ciphertext to a phone whose keystore has no key for it,
+ * and so does a keystore the system reset. Both are ordinary events, and both mean the same thing to
+ * the user — the address and port are still there, the password has to be typed again.
+ */
+class KeystoreSecretCipher(private val alias: String = DEFAULT_ALIAS) : SecretCipher {
+    override fun encrypt(plaintext: String): String? {
+        if (plaintext.isEmpty()) return ""
+        return runCatching {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, key())
+            val ciphertext = cipher.doFinal(plaintext.toByteArray())
+            // The IV is generated per encryption by the cipher itself and is not a secret; prefixing it
+            // keeps a stored value self-describing, so decryption needs nothing but the key.
+            SecretCipher.MARKER + Base64.encodeToString(cipher.iv + ciphertext, Base64.NO_WRAP)
+        }.getOrNull()
+    }
+
+    override fun decrypt(stored: String): String {
+        if (!SecretCipher.isEncrypted(stored)) return ""
+        return runCatching {
+            val bytes = Base64.decode(stored.removePrefix(SecretCipher.MARKER), Base64.NO_WRAP)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, key(), GCMParameterSpec(TAG_BITS, bytes, 0, IV_BYTES))
+            String(cipher.doFinal(bytes, IV_BYTES, bytes.size - IV_BYTES))
+        }.getOrDefault("")
+    }
+
+    /** Created on first use and kept by the keystore from then on; nothing here holds it in a field. */
+    private fun key(): SecretKey {
+        val store = KeyStore.getInstance(PROVIDER).apply { load(null) }
+        (store.getEntry(alias, null) as? KeyStore.SecretKeyEntry)?.secretKey?.let { return it }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, PROVIDER)
+        generator.init(
+            KeyGenParameterSpec
+                .Builder(alias, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                // No user-authentication requirement: the forum's own requests run while the screen is
+                // off, and a proxy the app cannot reach without an unlock is a proxy that breaks
+                // background refreshes.
+                .build(),
+        )
+        return generator.generateKey()
+    }
+
+    private companion object {
+        const val PROVIDER = "AndroidKeyStore"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val DEFAULT_ALIAS = "nodyssey.secret.v1"
+        const val IV_BYTES = 12
+        const val TAG_BITS = 128
+    }
+}

--- a/app/src/main/java/io/github/nodyssey/platform/NodeSeekDatabaseFactory.kt
+++ b/app/src/main/java/io/github/nodyssey/platform/NodeSeekDatabaseFactory.kt
@@ -1,0 +1,24 @@
+package io.github.nodyssey.platform
+
+import android.content.Context
+import androidx.room.Room
+import io.github.nodyssey.data.local.NODESEEK_MIGRATIONS
+import io.github.nodyssey.data.local.NodeSeekDatabase
+
+/**
+ * Opens the app's database file.
+ *
+ * Separate from [NodeSeekDatabase] itself because opening it is where the `Context` is needed and
+ * where the file's name is decided — both facts about this platform — while the schema, the DAOs and
+ * the migrations are facts about the app.
+ *
+ * `nodeseek.db` is the file already on every installed device; the name is not a choice left open.
+ */
+fun createNodeSeekDatabase(context: Context): NodeSeekDatabase =
+    Room
+        .databaseBuilder(context, NodeSeekDatabase::class.java, "nodeseek.db")
+        // Known upgrades preserve local state explicitly. The fallback remains for unknown legacy
+        // versions whose downloaded content can be rebuilt; schemas stay checked in.
+        .addMigrations(*NODESEEK_MIGRATIONS)
+        .fallbackToDestructiveMigration(dropAllTables = true)
+        .build()

--- a/app/src/main/java/io/github/nodyssey/ui/settings/AboutAppViewModel.kt
+++ b/app/src/main/java/io/github/nodyssey/ui/settings/AboutAppViewModel.kt
@@ -1,17 +1,18 @@
 package io.github.nodyssey.ui.settings
 
 import android.content.Intent
-import android.content.pm.PackageInstaller
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import io.github.nodyssey.data.update.ApkInstaller
 import io.github.nodyssey.data.update.AppUpdateRepository
 import io.github.nodyssey.di.AppContainer
+import io.github.nodyssey.platform.ApkInstaller
 import io.github.plaza.core.AppVersion
 import io.github.plaza.core.update.AppUpdateState
+import io.github.plaza.core.update.InstallFailure
+import io.github.plaza.core.update.InstallOutcome
 import io.github.plaza.core.update.UpdateDownload
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -80,9 +81,9 @@ class AboutAppViewModel(
         needsInstallPermission.value = false
         viewModelScope.launch {
             val committed = installer.install(File(ready.apkPath))
-            // Nothing will arrive at the receiver if the session never got written, so the plain
-            // failure status stands in for it and the screen still says something.
-            if (!committed) updates.onInstallStatus(PackageInstaller.STATUS_FAILURE)
+            // Nothing will arrive at the receiver if the session never got written, so an unnamed
+            // failure stands in for it and the screen still says something.
+            if (!committed) updates.onInstallOutcome(InstallOutcome.Failed(InstallFailure.UNKNOWN))
         }
     }
 

--- a/app/src/test/java/io/github/nodyssey/core/NodeSeekSiteTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/NodeSeekSiteTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.net.URLEncoder
 
 class NodeSeekSiteTest {
     @Test
@@ -15,6 +16,36 @@ class NodeSeekSiteTest {
         )
         assertEquals("/member?q=%E8%8A%B1%E7%94%B0", NodeSeekSite.userSearchPath("花田"))
         assertEquals("/api/account/find/%E8%8A%B1%E7%94%B0", NodeSeekSite.userSearchApiPath("花田"))
+    }
+
+    /**
+     * The encoder these paths are built with, against the `java.net.URLEncoder` it replaced.
+     *
+     * Character for character rather than case by case, because the interesting characters are the
+     * ones nobody thinks to write a case for: `URLEncoder` leaves `*` alone and escapes `~`, which
+     * is the opposite of what `encodeURIComponent` does, and a search URL is what the site is asked
+     * for and what the app caches under.
+     */
+    @Test
+    fun `search paths encode exactly the way URLEncoder did`() {
+        val queries = listOf(
+            "花田",
+            "Android TV",
+            "a+b",
+            "~!*'()",
+            "-._",
+            "100%",
+            "a&b=c",
+            "\"quoted\"",
+            "🍜",
+            "",
+        )
+
+        queries.forEach { query ->
+            val expected = URLEncoder.encode(query, "UTF-8").replace("+", "%20")
+
+            assertEquals(query, "/member?q=$expected", NodeSeekSite.userSearchPath(query))
+        }
     }
 
     @Test

--- a/app/src/test/java/io/github/nodyssey/core/StardustReceiveMarkupTest.kt
+++ b/app/src/test/java/io/github/nodyssey/core/StardustReceiveMarkupTest.kt
@@ -135,6 +135,21 @@ class StardustReceiveMarkupTest {
     }
 
     /**
+     * A marker typed rather than generated can carry the character itself instead of its escape.
+     *
+     * `URLSearchParams` copies an unescaped character straight through, so an emoji — two `Char`s
+     * that only mean anything together — has to survive as one. Decoding it as bytes one `Char` at a
+     * time is the mistake this pins: that turns 🍜 into two replacement characters, and the reader
+     * sees a 备注 the writer never typed.
+     */
+    @Test
+    fun `keeps an unescaped character that takes two chars to write`() {
+        val code = StardustReceiveMarkup.parse("member_id=9&ref_id=1&diff=5&description=%E8%AF%B7 🍜")
+
+        assertEquals("请 🍜", code?.description)
+    }
+
+    /**
      * A stray `%` costs the site the whole card. Keeping the raw text instead loses nothing that was
      * ever readable and leaves a hand-written marker usable.
      */

--- a/app/src/test/java/io/github/nodyssey/data/AppCacheStoreTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/AppCacheStoreTest.kt
@@ -1,8 +1,5 @@
 package io.github.nodyssey.data
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
-import coil3.ImageLoader
 import coil3.disk.DiskCache
 import io.github.plaza.core.AppDispatchers
 import kotlinx.coroutines.Dispatchers
@@ -14,8 +11,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.io.File
 
 /**
@@ -26,7 +21,6 @@ import java.io.File
  * system settings. So the assertions are about the directory: what the number counts, and what is
  * actually gone afterwards.
  */
-@RunWith(RobolectricTestRunner::class)
 class AppCacheStoreTest {
     @get:Rule
     val temporaryFolder = TemporaryFolder()
@@ -34,24 +28,30 @@ class AppCacheStoreTest {
     private val dispatchers = AppDispatchers(io = Dispatchers.Unconfined, default = Dispatchers.Unconfined)
 
     private lateinit var cacheDirectory: File
-    private lateinit var imageLoader: ImageLoader
+    private lateinit var diskCache: DiskCache
 
     private fun store(): AppCacheStore {
         cacheDirectory = temporaryFolder.newFolder("cache")
-        imageLoader =
-            ImageLoader
-                .Builder(ApplicationProvider.getApplicationContext<Context>())
-                .diskCache {
-                    DiskCache
-                        .Builder()
-                        .directory(File(cacheDirectory, "coil3_disk_cache").toOkioPath())
-                        .build()
-                }.build()
-        return DefaultAppCacheStore(cacheDirectory, dispatchers) { imageLoader }
+        diskCache =
+            DiskCache
+                .Builder()
+                .directory(File(cacheDirectory, "coil3_disk_cache").toOkioPath())
+                .build()
+        return DefaultAppCacheStore(cacheDirectory, dispatchers) {
+            object : ImageCaches {
+                // Nothing here writes to a memory cache, and nothing asserts on one.
+                override fun clearMemory() = Unit
+
+                override fun clearDisk(): File {
+                    diskCache.clear()
+                    return File(diskCache.directory.toString())
+                }
+            }
+        }
     }
 
     private fun writeCachedImage(bytes: Int) {
-        val cache = requireNotNull(imageLoader.diskCache)
+        val cache = diskCache
         val editor = requireNotNull(cache.openEditor("https://www.nodeseek.com/avatar/1.png"))
         cache.fileSystem.write(editor.data) { write(ByteArray(bytes)) }
         editor.commit()
@@ -102,10 +102,9 @@ class AppCacheStoreTest {
 
             // Coil's journal is open in this process; the directory has to survive so the next
             // image can be cached without the loader having to notice anything happened.
-            val cache = requireNotNull(imageLoader.diskCache)
-            assertEquals(0L, cache.size)
+            assertEquals(0L, diskCache.size)
             writeCachedImage(512)
-            assertTrue(cache.size > 0L)
+            assertTrue(diskCache.size > 0L)
         }
 
     @Test

--- a/app/src/test/java/io/github/nodyssey/data/TestPreferenceStores.kt
+++ b/app/src/test/java/io/github/nodyssey/data/TestPreferenceStores.kt
@@ -1,0 +1,69 @@
+package io.github.nodyssey.data
+
+import androidx.datastore.core.DataMigration
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import org.junit.rules.ExternalResource
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * A real `DataStore` on a throwaway file, with no Android underneath it.
+ *
+ * The real store rather than an interface fake, for the same reason `inMemoryDatabase` uses real
+ * Room: what is worth testing about a settings class is its *encoding* — which key holds what, what
+ * a missing value falls back to, what a migration rewrites — and a fake would only prove the fake
+ * encodes correctly.
+ *
+ * No `Context` and therefore no Robolectric, which is the other half of the point.
+ * `preferencesDataStore` — the `Context` extension these stores used to be opened with — is also a
+ * *process singleton keyed by file name*, so every test in a class shared one file and each one had
+ * to write whatever it was about to read in case an earlier test had left something there. A fresh
+ * directory per test ends that: a test that reads before writing now reads an empty store, which is
+ * what it was always trying to say.
+ *
+ * A rule rather than a function because the store owns a collector that has to be cancelled, and a
+ * JUnit rule is the one thing that runs per test method without every test having to remember.
+ *
+ * @param name the file's name; it appears in the temporary directory and nowhere else, so it is for
+ * whoever is looking at a failure rather than for the code.
+ * @param migrations run on first read, exactly as the app's own store would run them.
+ */
+class PreferenceStoreScope(
+    private val name: String = "test",
+    private val migrations: List<DataMigration<Preferences>> = emptyList(),
+) : ExternalResource() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    val dataStore: DataStore<Preferences> by lazy {
+        val directory = Files.createTempDirectory("nodyssey-$name").toFile().apply { deleteOnExit() }
+        PreferenceDataStoreFactory.create(scope = scope, migrations = migrations) {
+            File(directory, "$name.preferences_pb")
+        }
+    }
+
+    override fun after() {
+        scope.cancel()
+    }
+}
+
+/**
+ * The same store as a plain value, for a test that already has a scope to hang it on.
+ *
+ * [scope] should be a test's `backgroundScope`, so the store's collector is cancelled with the test.
+ */
+internal fun testPreferenceStore(
+    scope: CoroutineScope,
+    name: String = "test",
+    migrations: List<DataMigration<Preferences>> = emptyList(),
+): DataStore<Preferences> {
+    val directory = Files.createTempDirectory("nodyssey-$name").toFile().apply { deleteOnExit() }
+    return PreferenceDataStoreFactory.create(scope = scope, migrations = migrations) {
+        File(directory, "$name.preferences_pb")
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/data/composer/CommentComposerRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/composer/CommentComposerRepositoryTest.kt
@@ -1,8 +1,7 @@
 package io.github.nodyssey.data.composer
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import io.github.nodyssey.core.NodeSeekSite
+import io.github.nodyssey.data.testPreferenceStore
 import io.github.plaza.core.AppClock
 import io.github.plaza.core.AppDispatchers
 import io.github.plaza.core.net.SiteError
@@ -25,17 +24,12 @@ import okio.Buffer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /**
  * Every response body here was copied from a live exchange with the sandbox thread (2026-07-28),
  * not invented — the point of the suite is that the app keeps matching a contract we do not own.
  */
-@RunWith(RobolectricTestRunner::class)
 class CommentComposerRepositoryTest {
-    private val context: Context = ApplicationProvider.getApplicationContext()
-
     @Test
     fun `publish sends the site's own new-comment payload`() = runTest {
         val recorder = RecordingCommentInterceptor(
@@ -156,7 +150,7 @@ class CommentComposerRepositoryTest {
     private fun TestScope.repository(interceptor: Interceptor) =
         StandardTestDispatcher(testScheduler).let { dispatcher ->
             DefaultCommentComposerRepository(
-                context = context,
+                dataStore = testPreferenceStore(backgroundScope, "comment-composer"),
                 okHttpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
                 dispatchers = AppDispatchers(dispatcher, dispatcher),
                 clock = AppClock { 0L },

--- a/app/src/test/java/io/github/nodyssey/data/composer/PostComposerRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/composer/PostComposerRepositoryTest.kt
@@ -1,8 +1,7 @@
 package io.github.nodyssey.data.composer
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import io.github.nodyssey.core.NodeSeekSite
+import io.github.nodyssey.data.testPreferenceStore
 import io.github.plaza.core.AppClock
 import io.github.plaza.core.AppDispatchers
 import io.github.plaza.core.net.SiteError
@@ -27,13 +26,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class PostComposerRepositoryTest {
-    private val context: Context = ApplicationProvider.getApplicationContext()
-
     @Test
     fun `publish uses current NodeSeek discussion contract`() =
         runTest {
@@ -41,7 +35,7 @@ class PostComposerRepositoryTest {
             val recorder = RecordingPublishInterceptor()
             val repository =
                 DefaultPostComposerRepository(
-                    context = context,
+                    dataStore = testPreferenceStore(backgroundScope, "post-composer"),
                     okHttpClient = OkHttpClient.Builder().addInterceptor(recorder).build(),
                     dispatchers = AppDispatchers(dispatcher, dispatcher),
                     clock = AppClock { 0L },
@@ -80,7 +74,7 @@ class PostComposerRepositoryTest {
             val recorder = SuccessWithoutIdInterceptor()
             val repository =
                 DefaultPostComposerRepository(
-                    context = context,
+                    dataStore = testPreferenceStore(backgroundScope, "post-composer"),
                     okHttpClient = OkHttpClient.Builder().addInterceptor(recorder).build(),
                     dispatchers = AppDispatchers(dispatcher, dispatcher),
                     clock = AppClock { 0L },
@@ -143,7 +137,7 @@ class PostComposerRepositoryTest {
             val requests = RequestCaptor()
             val repository =
                 DefaultPostComposerRepository(
-                    context = context,
+                    dataStore = testPreferenceStore(backgroundScope, "post-composer"),
                     okHttpClient =
                     OkHttpClient.Builder().addInterceptor(requests).addInterceptor(recorder).build(),
                     dispatchers = AppDispatchers(dispatcher, dispatcher),
@@ -180,7 +174,7 @@ class PostComposerRepositoryTest {
             val dispatcher = StandardTestDispatcher(testScheduler)
             val repository =
                 DefaultPostComposerRepository(
-                    context = context,
+                    dataStore = testPreferenceStore(backgroundScope, "post-composer"),
                     okHttpClient =
                     OkHttpClient.Builder()
                         .addInterceptor(
@@ -231,7 +225,7 @@ class PostComposerRepositoryTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val repository =
             DefaultPostComposerRepository(
-                context = context,
+                dataStore = testPreferenceStore(backgroundScope, "post-composer"),
                 okHttpClient = OkHttpClient.Builder().addInterceptor(interceptor).build(),
                 dispatchers = AppDispatchers(dispatcher, dispatcher),
                 clock = AppClock { 0L },

--- a/app/src/test/java/io/github/nodyssey/data/imagehost/ImageHostSettingsTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/imagehost/ImageHostSettingsTest.kt
@@ -1,10 +1,9 @@
 package io.github.nodyssey.data.imagehost
 
-import android.content.Context
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.mutablePreferencesOf
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.test.core.app.ApplicationProvider
+import io.github.nodyssey.data.PreferenceStoreScope
 import io.github.nodyssey.data.security.PlainCipher
 import io.github.nodyssey.data.security.ReversingCipher
 import io.github.nodyssey.data.security.SecretCipher
@@ -16,29 +15,27 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 private const val NODE_IMAGE_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 /**
  * The stored half of 图床设置.
  *
- * Every test writes what it needs before reading it: DataStore is a process singleton keyed by file
- * name, and Robolectric hands every test in this class the same application context, so anything
- * left by an earlier test is still there for the next one.
+ * Each test gets its own store file, so a test that reads before writing reads an empty store rather
+ * than whatever the test before it left behind.
  */
-@RunWith(RobolectricTestRunner::class)
 class ImageHostSettingsTest {
-    private val context: Context = ApplicationProvider.getApplicationContext()
+    @get:Rule
+    val store = PreferenceStoreScope("imagehost")
 
     /**
      * The real cipher is the platform keystore, which a JVM test does not have — it would fail every
      * call and store nothing, and every assertion below would be about that rather than about this
      * class. See `TestCiphers.kt` for what each stand-in pins down.
      */
-    private val settings = DataStoreImageHostSettings(context, ReversingCipher)
+    private val settings = DataStoreImageHostSettings(store.dataStore, ReversingCipher)
 
     @Test
     fun `each host's credentials are kept apart`() = runTest {
@@ -155,7 +152,7 @@ class ImageHostSettingsTest {
         )
 
         // Reading the same file back with a cipher that does nothing shows what actually landed on disk.
-        val onDisk = DataStoreImageHostSettings(context, PlainCipher).config(ImageHostProvider.LSKY_PRO).first()
+        val onDisk = DataStoreImageHostSettings(store.dataStore, PlainCipher).config(ImageHostProvider.LSKY_PRO).first()
         assertTrue("the token must be stored as ciphertext", SecretCipher.isEncrypted(onDisk.token))
         assertFalse("and must not contain the token", onDisk.token.contains("lskytoken"))
         assertEquals("https://img.example.com", onDisk.siteUrl)
@@ -181,7 +178,7 @@ class ImageHostSettingsTest {
             ),
         )
 
-        val onDisk = DataStoreImageHostSettings(context, PlainCipher).config(ImageHostProvider.CUSTOM).first()
+        val onDisk = DataStoreImageHostSettings(store.dataStore, PlainCipher).config(ImageHostProvider.CUSTOM).first()
         assertTrue(SecretCipher.isEncrypted(onDisk.custom.headerValue))
         assertTrue(SecretCipher.isEncrypted(onDisk.custom.formFields))
         assertEquals("X-Token", onDisk.custom.headerName)
@@ -201,7 +198,7 @@ class ImageHostSettingsTest {
     @Test
     fun `a plaintext token from an older version is still read as the token`() = runTest {
         // PlainCipher writes unmarked, which is exactly the shape those installs have on disk.
-        DataStoreImageHostSettings(context, PlainCipher)
+        DataStoreImageHostSettings(store.dataStore, PlainCipher)
             .save(ImageHostConfig(ImageHostProvider.SMMS, token = "plainsmmstoken"))
 
         assertEquals("plainsmmstoken", settings.config(ImageHostProvider.SMMS).first().token)
@@ -214,7 +211,7 @@ class ImageHostSettingsTest {
             ImageHostConfig(ImageHostProvider.EASY_IMAGE, siteUrl = "https://img.example.com", token = "gone"),
         )
 
-        val recovered = DataStoreImageHostSettings(context, UnreadableCipher)
+        val recovered = DataStoreImageHostSettings(store.dataStore, UnreadableCipher)
             .config(ImageHostProvider.EASY_IMAGE)
             .first()
         assertEquals("", recovered.token)
@@ -224,10 +221,10 @@ class ImageHostSettingsTest {
     /** Encryption failing is not a reason to fall back to plaintext. */
     @Test
     fun `a device that cannot encrypt stores no token at all`() = runTest {
-        DataStoreImageHostSettings(context, UnencryptableCipher)
+        DataStoreImageHostSettings(store.dataStore, UnencryptableCipher)
             .save(ImageHostConfig(ImageHostProvider.IMGBB, token = "neverstored"))
 
-        assertEquals("", DataStoreImageHostSettings(context, PlainCipher).config(ImageHostProvider.IMGBB).first().token)
+        assertEquals("", DataStoreImageHostSettings(store.dataStore, PlainCipher).config(ImageHostProvider.IMGBB).first().token)
     }
 
     /**

--- a/app/src/test/java/io/github/nodyssey/data/proxy/ProxySettingsTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/proxy/ProxySettingsTest.kt
@@ -1,7 +1,6 @@
 package io.github.nodyssey.data.proxy
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
+import io.github.nodyssey.data.PreferenceStoreScope
 import io.github.nodyssey.data.security.PlainCipher
 import io.github.nodyssey.data.security.ReversingCipher
 import io.github.nodyssey.data.security.SecretCipher
@@ -11,22 +10,23 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /**
  * The stored half of 代理设置, and in particular what the password looks like on disk.
  *
  * The real cipher is the platform keystore, which no JVM test has — so these drive the same code with
  * ciphers whose behaviour is stated rather than provisioned: one that transforms, one that cannot
- * encrypt, one that cannot decrypt. Every test writes what it needs before reading it: DataStore is a
- * process singleton keyed by file name, and Robolectric hands every test in this class the same
- * application context.
+ * encrypt, one that cannot decrypt. Where a test builds a second settings object, it is on the same
+ * store: reading a file back with a different cipher is how "what actually landed on disk" becomes
+ * something a test can assert on.
  */
-@RunWith(RobolectricTestRunner::class)
 class ProxySettingsTest {
-    private val context: Context = ApplicationProvider.getApplicationContext()
+    @get:Rule
+    val store = PreferenceStoreScope("proxy")
+
+    private val settings = { cipher: SecretCipher -> DataStoreProxySettings(store.dataStore, cipher) }
 
     private val saved = ProxyConfig(
         enabled = true,
@@ -37,21 +37,26 @@ class ProxySettingsTest {
         password = "hunter2",
     )
 
+    /** Nothing written is not the same as something written empty; this is what a fresh install reads. */
+    @Test
+    fun `a store nothing has written reads as the defaults`() = runTest {
+        assertEquals(ProxyConfig(), settings(ReversingCipher).config.first())
+    }
+
     @Test
     fun `the whole configuration survives a round trip`() = runTest {
-        val settings = DataStoreProxySettings(context, ReversingCipher)
-        settings.save(saved.copy(scope = ProxyScope.FORUM_ONLY))
+        settings(ReversingCipher).save(saved.copy(scope = ProxyScope.FORUM_ONLY))
 
-        assertEquals(saved.copy(scope = ProxyScope.FORUM_ONLY), settings.config.first())
+        assertEquals(saved.copy(scope = ProxyScope.FORUM_ONLY), settings(ReversingCipher).config.first())
     }
 
     /** The point of the cipher: what a backup or a file browser would find is not the password. */
     @Test
     fun `the password is stored encrypted and everything else is stored as typed`() = runTest {
-        DataStoreProxySettings(context, ReversingCipher).save(saved)
+        settings(ReversingCipher).save(saved)
 
         // Reading the same file back with a cipher that does nothing shows what actually landed on disk.
-        val onDisk = DataStoreProxySettings(context, PlainCipher).config.first()
+        val onDisk = settings(PlainCipher).config.first()
         assertTrue("the stored value must say it is ciphertext", SecretCipher.isEncrypted(onDisk.password))
         assertEquals(SecretCipher.MARKER + "2retnuh", onDisk.password)
         assertEquals("127.0.0.1", onDisk.host)
@@ -64,9 +69,9 @@ class ProxySettingsTest {
      */
     @Test
     fun `an unreadable password reads as no password, and the rest still loads`() = runTest {
-        DataStoreProxySettings(context, ReversingCipher).save(saved)
+        settings(ReversingCipher).save(saved)
 
-        val recovered = DataStoreProxySettings(context, UnreadableCipher).config.first()
+        val recovered = settings(UnreadableCipher).config.first()
         assertEquals("", recovered.password)
         assertEquals(saved.copy(password = ""), recovered)
     }
@@ -74,8 +79,8 @@ class ProxySettingsTest {
     /** Encryption failing is not a reason to fall back to plaintext. */
     @Test
     fun `a device that cannot encrypt stores no password at all`() = runTest {
-        DataStoreProxySettings(context, UnencryptableCipher).save(saved)
+        settings(UnencryptableCipher).save(saved)
 
-        assertEquals("", DataStoreProxySettings(context, PlainCipher).config.first().password)
+        assertEquals("", settings(PlainCipher).config.first().password)
     }
 }

--- a/app/src/test/java/io/github/nodyssey/data/session/FakeSessionCookieStore.kt
+++ b/app/src/test/java/io/github/nodyssey/data/session/FakeSessionCookieStore.kt
@@ -1,0 +1,38 @@
+package io.github.nodyssey.data.session
+
+import io.github.plaza.core.net.SessionCookieStore
+
+/**
+ * A cookie store that is a map, standing in for the WebView's.
+ *
+ * Everything these tests are about happens *above* the store: which names count as a session, which
+ * ones Cloudflare rotates, and what a change in either should cost. What the store itself has to get
+ * right for that is one rule — a cookie written twice keeps only the second value, which is how a
+ * sign-out (`session=`) replaces a session rather than adding one — and it is one line here.
+ *
+ * Single-host on purpose. Every caller reads and writes the same site, so a per-URL store would add
+ * a dimension no test varies and quietly hide it if one ever did.
+ */
+class FakeSessionCookieStore : SessionCookieStore {
+    private val cookies = LinkedHashMap<String, String>()
+
+    var flushes: Int = 0
+        private set
+
+    override fun cookieHeader(url: String): String? =
+        cookies.entries
+            .joinToString("; ") { (name, value) -> "$name=$value" }
+            .ifEmpty { null }
+
+    override fun setCookie(url: String, cookie: String) {
+        // Attributes are the store's business, and this one keeps none of them.
+        val pair = cookie.substringBefore(';')
+        cookies[pair.substringBefore('=').trim()] = pair.substringAfter('=', "").trim()
+    }
+
+    override fun removeAll() = cookies.clear()
+
+    override fun flush() {
+        flushes++
+    }
+}

--- a/app/src/test/java/io/github/nodyssey/data/session/SessionRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/session/SessionRepositoryTest.kt
@@ -1,16 +1,12 @@
 package io.github.nodyssey.data.session
 
-import android.webkit.CookieManager
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.plaza.core.net.WebViewCookieJar
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /**
  * The layer the login bug lived in.
@@ -19,23 +15,16 @@ import org.robolectric.RobolectricTestRunner
  * them back and noticed. These tests are about *noticing* — the generation counter the feed reloads
  * on, and the two name checks that used to be a `contains("session=")`.
  */
-@RunWith(RobolectricTestRunner::class)
 class SessionRepositoryTest {
-    private val cookieManager = CookieManager.getInstance()
+    private val cookies = FakeSessionCookieStore()
     private lateinit var repository: SessionRepository
 
     @Before
     fun setUp() {
-        cookieManager.removeAllCookies(null)
-        repository = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager))
+        repository = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies))
     }
 
-    @After
-    fun tearDown() {
-        cookieManager.removeAllCookies(null)
-    }
-
-    private fun setCookie(raw: String) = cookieManager.setCookie(NodeSeekSite.BASE_URL, raw)
+    private fun setCookie(raw: String) = cookies.setCookie(NodeSeekSite.BASE_URL, raw)
 
     @Test
     fun `starts signed out when the store is empty`() {

--- a/app/src/test/java/io/github/nodyssey/data/update/AppUpdateRepositoryTest.kt
+++ b/app/src/test/java/io/github/nodyssey/data/update/AppUpdateRepositoryTest.kt
@@ -1,11 +1,11 @@
 package io.github.nodyssey.data.update
 
-import android.content.pm.PackageInstaller
 import io.github.plaza.core.AppClock
 import io.github.plaza.core.AppDispatchers
 import io.github.plaza.core.update.AppRelease
 import io.github.plaza.core.update.AppUpdateException
 import io.github.plaza.core.update.InstallFailure
+import io.github.plaza.core.update.InstallOutcome
 import io.github.plaza.core.update.ReleaseNote
 import io.github.plaza.core.update.ReleaseSource
 import io.github.plaza.core.update.UpdateCheck
@@ -331,10 +331,10 @@ class AppUpdateRepositoryTest {
         runTest {
             val repository = repository(FakeReleaseSource(release("1.2.0")))
 
-            repository.onInstallStatus(PackageInstaller.STATUS_FAILURE_CONFLICT)
+            repository.onInstallOutcome(InstallOutcome.Failed(InstallFailure.CONFLICT))
             assertEquals(InstallFailure.CONFLICT, repository.state.value.installFailure)
 
-            repository.onInstallStatus(PackageInstaller.STATUS_FAILURE_ABORTED)
+            repository.onInstallOutcome(InstallOutcome.Abandoned)
             assertNull(repository.state.value.installFailure)
         }
 

--- a/app/src/test/java/io/github/nodyssey/platform/ApkInstallOutcomeTest.kt
+++ b/app/src/test/java/io/github/nodyssey/platform/ApkInstallOutcomeTest.kt
@@ -1,0 +1,47 @@
+package io.github.nodyssey.platform
+
+import android.content.pm.PackageInstaller
+import io.github.plaza.core.update.InstallFailure
+import io.github.plaza.core.update.InstallOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The one place `PackageInstaller`'s status integers are read.
+ *
+ * Worth its own test because the mapping is the sort of thing that looks obviously right and gets one
+ * line wrong: `STATUS_FAILURE_ABORTED` is the user saying no, and reading it as a failure would put
+ * an error on screen for their own decision. The constants are compile-time values, so this needs no
+ * device and no Robolectric.
+ */
+class ApkInstallOutcomeTest {
+    @Test
+    fun `success and the user backing out are told apart, and neither is a failure`() {
+        assertEquals(InstallOutcome.Installed, outcomeOf(PackageInstaller.STATUS_SUCCESS))
+        assertEquals(InstallOutcome.Abandoned, outcomeOf(PackageInstaller.STATUS_FAILURE_ABORTED))
+    }
+
+    @Test
+    fun `every refusal the system names keeps its own reason`() {
+        val expected = mapOf(
+            PackageInstaller.STATUS_FAILURE_BLOCKED to InstallFailure.BLOCKED,
+            PackageInstaller.STATUS_FAILURE_CONFLICT to InstallFailure.CONFLICT,
+            PackageInstaller.STATUS_FAILURE_INCOMPATIBLE to InstallFailure.INCOMPATIBLE,
+            PackageInstaller.STATUS_FAILURE_STORAGE to InstallFailure.STORAGE,
+            PackageInstaller.STATUS_FAILURE_INVALID to InstallFailure.INVALID,
+        )
+
+        expected.forEach { (status, failure) ->
+            assertEquals("status $status", InstallOutcome.Failed(failure), outcomeOf(status))
+        }
+    }
+
+    /** The list has grown before; a status this build has never seen must not be a crash. */
+    @Test
+    fun `a status this build does not know is an unnamed failure`() {
+        assertEquals(InstallOutcome.Failed(InstallFailure.UNKNOWN), outcomeOf(PackageInstaller.STATUS_FAILURE))
+        assertEquals(InstallOutcome.Failed(InstallFailure.UNKNOWN), outcomeOf(Int.MAX_VALUE))
+    }
+
+    private fun outcomeOf(status: Int): InstallOutcome = ApkInstallResultReceiver.outcomeOf(status)
+}

--- a/app/src/test/java/io/github/nodyssey/ui/messages/MessageThreadViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/messages/MessageThreadViewModelTest.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.ui.messages
 
-import android.webkit.CookieManager
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.net.JsonApi
@@ -9,6 +8,7 @@ import io.github.nodyssey.data.MessageRepository
 import io.github.nodyssey.data.MessageThread
 import io.github.nodyssey.data.NotificationRepository
 import io.github.nodyssey.data.composer.ImageUploader
+import io.github.nodyssey.data.session.FakeSessionCookieStore
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.plaza.core.AppClock
 import io.github.plaza.core.net.SiteError
@@ -33,18 +33,16 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class MessageThreadViewModelTest {
     private val dispatcher = StandardTestDispatcher()
-    private val cookieManager = CookieManager.getInstance()
+    private val cookies = FakeSessionCookieStore()
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
-        cookieManager.removeAllCookies(null)
-        cookieManager.setCookie(NodeSeekSite.BASE_URL, "session=test")
+        cookies.setCookie(NodeSeekSite.BASE_URL, "session=test")
     }
 
     @After
     fun tearDown() {
-        cookieManager.removeAllCookies(null)
         Dispatchers.resetMain()
     }
 
@@ -207,7 +205,7 @@ class MessageThreadViewModelTest {
     ) = MessageThreadViewModel(
         repository = repository,
         notifications = notifications,
-        session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+        session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
         clock = AppClock { NOW },
         uploader = ImageUploader { _, _ -> "https://cdn.nodeimage.com/i/x.webp" },
         uid = 4471,

--- a/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/notifications/NotificationsViewModelTest.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.ui.notifications
 
-import android.webkit.CookieManager
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.core.net.JsonApi
 import io.github.nodyssey.data.MessageConversation
@@ -9,6 +8,7 @@ import io.github.nodyssey.data.MessageThread
 import io.github.nodyssey.data.NotificationRepository
 import io.github.nodyssey.data.SearchRepository
 import io.github.nodyssey.data.UserSearchResult
+import io.github.nodyssey.data.session.FakeSessionCookieStore
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.plaza.core.AppClock
 import io.github.plaza.core.net.WebViewCookieJar
@@ -37,18 +37,16 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class NotificationsViewModelTest {
     private val dispatcher = StandardTestDispatcher()
-    private val cookieManager = CookieManager.getInstance()
+    private val cookies = FakeSessionCookieStore()
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
-        cookieManager.removeAllCookies(null)
-        cookieManager.setCookie(NodeSeekSite.BASE_URL, "session=test")
+        cookies.setCookie(NodeSeekSite.BASE_URL, "session=test")
     }
 
     @After
     fun tearDown() {
-        cookieManager.removeAllCookies(null)
         Dispatchers.resetMain()
     }
 
@@ -137,7 +135,7 @@ class NotificationsViewModelTest {
             repository = notifications,
             messages = NoMessages,
             search = NoSearch,
-            session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+            session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
             clock = clock,
         )
     }

--- a/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
+++ b/app/src/test/java/io/github/nodyssey/ui/profile/ProfileViewModelTest.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.ui.profile
 
-import android.webkit.CookieManager
 import androidx.paging.PagingData
 import io.github.nodyssey.core.NodeSeekSite
 import io.github.nodyssey.data.AssetsRepository
@@ -15,6 +14,7 @@ import io.github.nodyssey.data.PostRepository
 import io.github.nodyssey.data.ProfileRepository
 import io.github.nodyssey.data.ReadHistoryEntry
 import io.github.nodyssey.data.UserProfile
+import io.github.nodyssey.data.session.FakeSessionCookieStore
 import io.github.nodyssey.data.session.SessionRepository
 import io.github.nodyssey.model.FeedSort
 import io.github.nodyssey.model.ReactionAction
@@ -48,18 +48,16 @@ import java.time.LocalDate
 @RunWith(RobolectricTestRunner::class)
 class ProfileViewModelTest {
     private val dispatcher = StandardTestDispatcher()
-    private val cookieManager = CookieManager.getInstance()
+    private val cookies = FakeSessionCookieStore()
 
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
-        cookieManager.removeAllCookies(null)
-        cookieManager.setCookie(NodeSeekSite.BASE_URL, "session=test")
+        cookies.setCookie(NodeSeekSite.BASE_URL, "session=test")
     }
 
     @After
     fun tearDown() {
-        cookieManager.removeAllCookies(null)
         Dispatchers.resetMain()
     }
 
@@ -68,7 +66,7 @@ class ProfileViewModelTest {
         runTest(dispatcher) {
             val viewModel =
                 ProfileViewModel(
-                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
                     postRepository = NoOpPostRepository,
                     profileRepository =
                     FakeProfileRepository(
@@ -102,7 +100,7 @@ class ProfileViewModelTest {
         runTest(dispatcher) {
             val viewModel =
                 ProfileViewModel(
-                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
                     postRepository = NoOpPostRepository,
                     profileRepository =
                     FakeProfileRepository(
@@ -131,7 +129,7 @@ class ProfileViewModelTest {
             val fresh = cached.copy(name = "网络新名字", chickenCount = 305)
             val viewModel =
                 ProfileViewModel(
-                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
                     postRepository = NoOpPostRepository,
                     profileRepository =
                     FakeProfileRepository(
@@ -161,7 +159,7 @@ class ProfileViewModelTest {
         runTest(dispatcher) {
             val viewModel =
                 ProfileViewModel(
-                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
                     postRepository = NoOpPostRepository,
                     profileRepository =
                     FakeProfileRepository(
@@ -187,7 +185,7 @@ class ProfileViewModelTest {
             val assets = FakeAssetsRepository(gain = 7)
             val viewModel =
                 ProfileViewModel(
-                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
                     postRepository = NoOpPostRepository,
                     profileRepository =
                     FakeProfileRepository(
@@ -230,7 +228,7 @@ class ProfileViewModelTest {
                 )
             val viewModel =
                 ProfileViewModel(
-                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookieManager)),
+                    session = SessionRepository(WebViewCookieJar(NodeSeekSite.CONFIG, cookies)),
                     postRepository = NoOpPostRepository,
                     profileRepository =
                     FakeProfileRepository(

--- a/core/src/main/java/io/github/plaza/core/AndroidAppVersion.kt
+++ b/core/src/main/java/io/github/plaza/core/AndroidAppVersion.kt
@@ -1,0 +1,24 @@
+package io.github.plaza.core
+
+import android.content.Context
+import android.os.Build
+
+/**
+ * The installed build's own version, from the package manager.
+ *
+ * Read there rather than from `BuildConfig`: the release build type turns `buildConfig` off (see
+ * `app/build.gradle.kts`), and the package manager is the authority anyway — it reports what is
+ * installed, which is the number an update has to be compared against.
+ */
+fun readAppVersion(context: Context): AppVersion {
+    val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+    return AppVersion(
+        name = packageInfo.versionName.orEmpty(),
+        code = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageInfo.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            packageInfo.versionCode.toLong()
+        },
+    )
+}

--- a/core/src/main/java/io/github/plaza/core/AppVersion.kt
+++ b/core/src/main/java/io/github/plaza/core/AppVersion.kt
@@ -1,29 +1,12 @@
 package io.github.plaza.core
 
-import android.content.Context
-import android.os.Build
-
 /**
  * The installed build's own version.
  *
- * Read through `PackageManager` rather than `BuildConfig`: the release build type turns
- * `buildConfig` off (see `app/build.gradle.kts`), and the package manager is the authority anyway —
- * it reports what is installed, which is the number an update has to be compared against.
+ * Read through `PackageManager` rather than `BuildConfig` — see [readAppVersion], which is where
+ * that argument and the platform call both live.
  */
 data class AppVersion(
     val name: String,
     val code: Long,
 )
-
-fun readAppVersion(context: Context): AppVersion {
-    val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-    return AppVersion(
-        name = packageInfo.versionName.orEmpty(),
-        code = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            packageInfo.longVersionCode
-        } else {
-            @Suppress("DEPRECATION")
-            packageInfo.versionCode.toLong()
-        },
-    )
-}

--- a/core/src/main/java/io/github/plaza/core/TerminalColumns.kt
+++ b/core/src/main/java/io/github/plaza/core/TerminalColumns.kt
@@ -36,9 +36,9 @@ object TerminalColumns {
         var column = 0
         var index = 0
         while (index < charIndex && index < line.length) {
-            val codePoint = line.codePointAt(index)
+            val codePoint = codePointAt(line, index)
             column += cellsFor(codePoint)
-            index += Character.charCount(codePoint)
+            index += charCount(codePoint)
         }
         return column
     }
@@ -46,11 +46,31 @@ object TerminalColumns {
     private inline fun forEachCodePoint(text: String, action: (Int) -> Unit) {
         var index = 0
         while (index < text.length) {
-            val codePoint = text.codePointAt(index)
+            val codePoint = codePointAt(text, index)
             action(codePoint)
-            index += Character.charCount(codePoint)
+            index += charCount(codePoint)
         }
     }
+
+    /**
+     * The code point starting at [index], as `String.codePointAt` would report it.
+     *
+     * Spelled out rather than delegated because both of the ways the JVM offers this — `Character`
+     * and the `codePointAt` the Kotlin stdlib only publishes for JVM — are platform API, and the
+     * rule for decoding a surrogate pair is four lines. An unpaired surrogate reads as itself, which
+     * is what the JVM does too and what keeps a truncated string from throwing here.
+     */
+    private fun codePointAt(text: String, index: Int): Int {
+        val high = text[index]
+        if (high.isHighSurrogate() && index + 1 < text.length) {
+            val low = text[index + 1]
+            if (low.isLowSurrogate()) return 0x10000 + ((high.code - 0xD800) shl 10) + (low.code - 0xDC00)
+        }
+        return high.code
+    }
+
+    /** `Character.charCount`: how many `Char`s the code point occupied. */
+    private fun charCount(codePoint: Int): Int = if (codePoint >= 0x10000) 2 else 1
 
     private fun cellsFor(codePoint: Int): Int = if (isWide(codePoint)) 2 else 1
 

--- a/core/src/main/java/io/github/plaza/core/image/AndroidNetworkMetering.kt
+++ b/core/src/main/java/io/github/plaza/core/image/AndroidNetworkMetering.kt
@@ -1,0 +1,22 @@
+package io.github.plaza.core.image
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+/**
+ * Whether the connection in use right now is one 仅 Wi-Fi 加载图片 should allow.
+ *
+ * All three capabilities are required, and `NOT_METERED` is the one that surprises people: a VPN
+ * whose tunnel does not report it makes this false on Wi-Fi, so the switch skips images on what
+ * looks to the user like Wi-Fi. That is the platform's answer, not a bug here — but it is why the
+ * interceptor takes this as a function it is handed rather than asking the system itself.
+ */
+fun Context.hasValidatedUnmeteredNetwork(): Boolean {
+    val connectivityManager = getSystemService(ConnectivityManager::class.java)
+    val activeNetwork = connectivityManager.activeNetwork ?: return false
+    val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) &&
+        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+}

--- a/core/src/main/java/io/github/plaza/core/image/ImageNetworkPolicyInterceptor.kt
+++ b/core/src/main/java/io/github/plaza/core/image/ImageNetworkPolicyInterceptor.kt
@@ -1,8 +1,5 @@
 package io.github.plaza.core.image
 
-import android.content.Context
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import coil3.Extras
 import coil3.getExtra
 import coil3.intercept.Interceptor
@@ -35,15 +32,11 @@ fun ImageRequest.Builder.allowMeteredImage(allow: Boolean): ImageRequest.Builder
  * consulted per request; where that flow comes from — which DataStore key, under which name — is the
  * app's business, and the interceptor is deliberately not told.
  */
-class ImageNetworkPolicyInterceptor internal constructor(
+class ImageNetworkPolicyInterceptor(
     private val imagesOnWifiOnly: Flow<Boolean>,
+    /** See `hasValidatedUnmeteredNetwork` — what counts as unmetered is the platform's to answer. */
     private val hasUnmeteredNetwork: () -> Boolean,
 ) : Interceptor {
-    constructor(context: Context, imagesOnWifiOnly: Flow<Boolean>) : this(
-        imagesOnWifiOnly = imagesOnWifiOnly,
-        hasUnmeteredNetwork = context::hasValidatedUnmeteredNetwork,
-    )
-
     override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
         val deferred =
             shouldDeferImage(
@@ -96,12 +89,3 @@ internal fun shouldDeferImage(
  */
 internal fun ImageRequest.withoutNetwork(): ImageRequest =
     newBuilder().networkCachePolicy(CachePolicy.DISABLED).build()
-
-private fun Context.hasValidatedUnmeteredNetwork(): Boolean {
-    val connectivityManager = getSystemService(ConnectivityManager::class.java)
-    val activeNetwork = connectivityManager.activeNetwork ?: return false
-    val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
-    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
-        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) &&
-        capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
-}

--- a/core/src/main/java/io/github/plaza/core/net/AcceptLanguage.kt
+++ b/core/src/main/java/io/github/plaza/core/net/AcceptLanguage.kt
@@ -1,31 +1,6 @@
 package io.github.plaza.core.net
 
-import android.os.LocaleList
 import java.util.Locale
-
-/**
- * The `Accept-Language` a browser on this device would send.
- *
- * OkHttp sends no `Accept-Language` at all, and a request without one is a request no browser
- * makes. Cloudflare's bot scoring reads that: on an image host fronted by it, the app's request was
- * answered with a managed challenge and a 403 while every browser on the same connection was served
- * the picture. Measured against `img.legend.moe` on 2026-08-18 — with the same User-Agent, adding
- * this header alone turned three 403s into three 200s, and removing it turned them back:
- *
- * ```
- * UA + Accept-Encoding + Accept-Language  →  200 200 200
- * UA + Accept-Encoding                    →  403 403 403
- * UA +                   Accept-Language  →  403 403 403
- * ```
- *
- * (`Accept-Encoding` is OkHttp's own, added to every request that does not set one, so the app
- * already had that half.)
- *
- * Sent on page requests too, not just images: the WebView sends one on every navigation, and two
- * halves of the app that disagree about what the device reads is exactly the mismatch a bot score
- * is looking for. See [resolveUserAgent] for the same argument about `User-Agent`.
- */
-fun deviceAcceptLanguage(): String = acceptLanguage(LocaleList.getDefault().toLocales())
 
 /**
  * Builds the header value from [locales], most-preferred first.
@@ -75,5 +50,3 @@ private const val MAX_LANGUAGES = 6
 
 /** What a device with no usable locale gets. Sending nothing is the thing this file exists to avoid. */
 private const val FALLBACK = "en-US,en;q=0.9"
-
-private fun LocaleList.toLocales(): List<Locale> = (0 until size()).mapNotNull { get(it) }

--- a/core/src/main/java/io/github/plaza/core/net/DeviceAcceptLanguage.kt
+++ b/core/src/main/java/io/github/plaza/core/net/DeviceAcceptLanguage.kt
@@ -1,0 +1,30 @@
+package io.github.plaza.core.net
+
+import android.os.LocaleList
+import java.util.Locale
+
+/**
+ * The `Accept-Language` a browser on this device would send.
+ *
+ * OkHttp sends no `Accept-Language` at all, and a request without one is a request no browser
+ * makes. Cloudflare's bot scoring reads that: on an image host fronted by it, the app's request was
+ * answered with a managed challenge and a 403 while every browser on the same connection was served
+ * the picture. Measured against `img.legend.moe` on 2026-08-18 — with the same User-Agent, adding
+ * this header alone turned three 403s into three 200s, and removing it turned them back:
+ *
+ * ```
+ * UA + Accept-Encoding + Accept-Language  →  200 200 200
+ * UA + Accept-Encoding                    →  403 403 403
+ * UA +                   Accept-Language  →  403 403 403
+ * ```
+ *
+ * (`Accept-Encoding` is OkHttp's own, added to every request that does not set one, so the app
+ * already had that half.)
+ *
+ * Sent on page requests too, not just images: the WebView sends one on every navigation, and two
+ * halves of the app that disagree about what the device reads is exactly the mismatch a bot score
+ * is looking for. See [resolveUserAgent] for the same argument about `User-Agent`.
+ */
+fun deviceAcceptLanguage(): String = acceptLanguage(LocaleList.getDefault().toLocales())
+
+private fun LocaleList.toLocales(): List<Locale> = (0 until size()).mapNotNull { get(it) }

--- a/core/src/main/java/io/github/plaza/core/net/SessionCookieStore.kt
+++ b/core/src/main/java/io/github/plaza/core/net/SessionCookieStore.kt
@@ -1,0 +1,35 @@
+package io.github.plaza.core.net
+
+/**
+ * The one cookie store OkHttp and the sign-in browser both use.
+ *
+ * An interface rather than the platform's own type because *which* store it is — Android's
+ * `CookieManager`, `WKHTTPCookieStore`, a map in a test — is the only part of sharing cookies that
+ * is about the platform. Everything else, and in particular reading a signed-in state off the names
+ * a site issues, is about the site; that lives in [WebViewCookieJar] and now needs no device.
+ *
+ * The whole interface speaks in raw header strings for the same reason: `Set-Cookie` is what every
+ * one of those stores already takes and returns, so nothing has to be parsed to cross this line.
+ */
+interface SessionCookieStore {
+    /**
+     * The `Cookie` header this store would send to [url] — `a=1; b=2` — or null when it has none.
+     *
+     * Attributes are not included: a store returns what it would *send*, which is names and values.
+     */
+    fun cookieHeader(url: String): String?
+
+    /** [cookie] is one `Set-Cookie` value, attributes and all; the store decides what it keeps. */
+    fun setCookie(url: String, cookie: String)
+
+    fun removeAll()
+
+    /**
+     * Writes whatever is held in memory to wherever the store persists.
+     *
+     * Named here because it is not an implementation detail: the WebView batches its writes, and the
+     * cookie worth never losing — the session the site issues at login — arrives from an XHR rather
+     * than a page load, so there is no navigation to hang the write on.
+     */
+    fun flush()
+}

--- a/core/src/main/java/io/github/plaza/core/net/UserAgent.kt
+++ b/core/src/main/java/io/github/plaza/core/net/UserAgent.kt
@@ -1,10 +1,10 @@
 package io.github.plaza.core.net
 
-import android.content.Context
-import android.webkit.WebSettings
-
 /**
  * The one User-Agent both halves of the app send.
+ *
+ * Where it comes from is [resolveUserAgent]'s business, and lives beside it; this is the value and
+ * what a consumer has to know about it.
  *
  * @property value what OkHttp must put on every request.
  * @property isWebViewDefault true when [value] was read straight off the WebView, meaning the WebView
@@ -16,32 +16,3 @@ data class UserAgent(
     val value: String,
     val isWebViewDefault: Boolean,
 )
-
-/**
- * Asks the WebView what it is, rather than telling the site what we wish it were.
- *
- * This is the fix for the infinite Cloudflare checkbox. A managed challenge cross-checks the
- * `User-Agent` header against the JavaScript environment — `navigator.userAgentData` and the
- * `Sec-CH-UA` hints, which WebView derives from its *real* Chromium version and which
- * `setUserAgentString` does not touch. A header claiming "Chrome 126 on a Pixel 8" on a device
- * running something else is a contradiction, and a managed challenge answers a contradiction with
- * another challenge, forever.
- *
- * OkHttp then has to send the same string, because `cf_clearance` is issued against the UA that
- * solved the challenge and is rejected for any other. One source, both consumers.
- */
-fun resolveUserAgent(context: Context, config: SiteConfig): UserAgent {
-    // Throws on devices where the WebView provider is missing or mid-update. Not a suspend call, so
-    // `runCatching` is safe here — there is no cancellation to swallow.
-    val default =
-        runCatching { WebSettings.getDefaultUserAgent(context) }
-            .getOrNull()
-            ?.takeIf { it.isNotBlank() }
-
-    return if (default != null) {
-        UserAgent(value = default, isWebViewDefault = true)
-    } else {
-        // The WebView is unusable anyway; what matters is that both sides still agree.
-        UserAgent(value = config.fallbackUserAgent, isWebViewDefault = false)
-    }
-}

--- a/core/src/main/java/io/github/plaza/core/net/WebUrl.kt
+++ b/core/src/main/java/io/github/plaza/core/net/WebUrl.kt
@@ -1,0 +1,238 @@
+package io.github.plaza.core.net
+
+/**
+ * The parts of an absolute URL that deciding what to do with a link depends on.
+ *
+ * This exists because that decision — is this our own site, may the login WebView load it, does it
+ * open a screen or the browser — is a rule about the *site*, and it was reading it off
+ * `java.net.URI`, which is a fact about the JVM. `WebUrlTest` is a differential test against
+ * `java.net.URI` for exactly that reason: the replacement has to answer the way the class it
+ * replaced did, including for the URLs written to get past a host check.
+ *
+ * Deliberately not a URL builder and not a general parser. It reads; nothing here formats a URL, and
+ * the site's own path vocabulary stays where it is.
+ *
+ * @param scheme lower-cased on the way in. Everything else keeps its case, because a path and a
+ * query are case-sensitive and a host is compared with an explicit `lowercase` where it matters.
+ * @param userInfo the `user:password@` an attacker puts in front of the host they want you to read.
+ * Non-null is the signal; the value itself is of no interest.
+ * @param host null when the authority is not a hostname this can vouch for — absent, or carrying a
+ * character a hostname may not (`_`, a non-ASCII letter, an empty label), or followed by a port that
+ * is not a number. Callers read null as "not a host I know", which is the safe reading.
+ * @param port -1 when the URL named none, exactly as `URI.getPort` reports it.
+ * @param path percent-decoded, and null for a URL with no authority (`javascript:alert(1)`) — the
+ * one case where a null path is not an absent path but a URL with nothing path-shaped in it.
+ * @param rawQuery still encoded: `?to=https%3A%2F%2F…` has to be decoded per value, after the split
+ * on `&`, or a `%26` inside a value would end the field it belongs to.
+ * @param fragment percent-decoded. The site keeps whole routes in here (`#/message?mode=talk&to=5`),
+ * so it is read rather than skipped.
+ */
+data class WebUrl(
+    val scheme: String,
+    val userInfo: String?,
+    val host: String?,
+    val port: Int,
+    val path: String?,
+    val rawQuery: String?,
+    val fragment: String?,
+) {
+    /**
+     * The value `name` carries in [rawQuery], percent-decoded, or null when the query has no such
+     * field. An empty value reads as an empty string, which is what the site's own `/jump?to=` sends.
+     *
+     * `+` stays a plus sign. `java.net.URLDecoder`, which this replaced, would have made it a space —
+     * that is form encoding, and this is a URL. Nothing the site emits can tell the difference,
+     * because `encodeURIComponent` writes a literal plus as `%2B`; a hand-typed `/jump?to=` with one
+     * in it now survives instead of arriving at the browser with a space in the middle.
+     */
+    fun queryParameter(name: String): String? =
+        rawQuery
+            ?.split('&')
+            ?.firstOrNull { it.substringBefore('=') == name }
+            ?.substringAfter('=', missingDelimiterValue = "")
+            ?.let(::percentDecode)
+
+    companion object {
+        /**
+         * [value] as an absolute URL, or null when it is not one.
+         *
+         * Null covers everything `URI(value)` used to answer with an exception or with a relative
+         * URI: a missing scheme, a character no URL may carry unescaped, a `%` that begins no
+         * escape. Callers already treated all of those as "not a URL I can reason about".
+         */
+        fun parse(value: String): WebUrl? {
+            val text = value.trim()
+            if (!isWellFormed(text)) return null
+
+            val schemeEnd = schemeEnd(text) ?: return null
+            val scheme = text.substring(0, schemeEnd).lowercase()
+
+            val body = text.substring(schemeEnd + 1)
+            val hash = body.indexOf('#')
+            val fragment = if (hash < 0) null else percentDecode(body.substring(hash + 1))
+            val beforeFragment = if (hash < 0) body else body.substring(0, hash)
+            val question = beforeFragment.indexOf('?')
+            val rawQuery = if (question < 0) null else beforeFragment.substring(question + 1)
+            val hierarchical = if (question < 0) beforeFragment else beforeFragment.substring(0, question)
+
+            // No `//` means no authority: an opaque URL such as `mailto:` or `javascript:`, whose
+            // remainder is not a path and must not be read as one.
+            if (!hierarchical.startsWith("//")) {
+                return WebUrl(scheme, null, null, -1, null, rawQuery, fragment)
+            }
+
+            val afterSlashes = hierarchical.substring(2)
+            // An authority ends at the first `/`; what follows is the path, empty when there is none.
+            val authority = afterSlashes.substringBefore('/')
+            val path = afterSlashes.substring(authority.length)
+            // `https://` on its own named neither; `file:///tmp` named an empty authority and a path.
+            if (authority.isEmpty() && path.isEmpty()) return null
+
+            val at = authority.lastIndexOf('@')
+            val userInfo = if (at >= 0) authority.substring(0, at) else null
+            // A port that is not a number makes the whole authority unreadable, not just itself.
+            val (hostText, portText) = splitPort(authority.substring(at + 1)) ?: (null to null)
+            val port = if (portText.isNullOrEmpty()) -1 else portText.toPort() ?: NO_AUTHORITY
+            val host = hostText?.takeIf { port != NO_AUTHORITY && isHost(it) }
+
+            return WebUrl(
+                scheme = scheme,
+                userInfo = userInfo,
+                host = host,
+                port = if (host == null) -1 else port,
+                path = percentDecode(path),
+                rawQuery = rawQuery,
+                fragment = fragment,
+            )
+        }
+
+        /**
+         * Rejects what `URI(String)` threw on: a character no URL may carry unescaped, and a `%`
+         * that is not the start of a two-digit escape.
+         *
+         * The set is RFC 2396's, which is the one `java.net.URI` enforces — narrower than what a
+         * browser will swallow, and narrow on purpose: a space or a backslash inside a URL is how a
+         * link gets read one way by the check and another way by whatever opens it.
+         */
+        private fun isWellFormed(text: String): Boolean {
+            var index = 0
+            while (index < text.length) {
+                val char = text[index]
+                if (char == '%') {
+                    if (index + 3 > text.length) return false
+                    if (!text[index + 1].isHex() || !text[index + 2].isHex()) return false
+                    index += 3
+                    continue
+                }
+                if (!char.isAllowedInUrl()) return false
+                index++
+            }
+            return true
+        }
+
+        /** Where the `:` after a scheme sits, or null when the URL is relative. */
+        private fun schemeEnd(text: String): Int? {
+            val colon = text.indexOf(':')
+            if (colon <= 0 || !text[0].isAsciiLetter()) return null
+            for (index in 1 until colon) {
+                val char = text[index]
+                if (!char.isAsciiLetter() && !char.isAsciiDigit() && char != '+' && char != '-' && char != '.') {
+                    return null
+                }
+            }
+            return colon
+        }
+
+        /**
+         * Splits `host[:port]`, keeping an IPv6 literal's own colons inside its brackets. The second
+         * half is null when no `:` was written and `""` when one was written with nothing after it.
+         */
+        private fun splitPort(hostAndPort: String): Pair<String, String?>? {
+            if (hostAndPort.startsWith("[")) {
+                val close = hostAndPort.indexOf(']')
+                if (close < 0) return null
+                val host = hostAndPort.substring(0, close + 1)
+                val remainder = hostAndPort.substring(close + 1)
+                return when {
+                    remainder.isEmpty() -> host to null
+                    remainder.startsWith(":") -> host to remainder.substring(1)
+                    else -> null
+                }
+            }
+            val colon = hostAndPort.indexOf(':')
+            return if (colon < 0) {
+                hostAndPort to null
+            } else {
+                hostAndPort.substring(0, colon) to hostAndPort.substring(colon + 1)
+            }
+        }
+
+        /** Digits only, so `:-1` is a broken authority rather than a negative port. */
+        private fun String.toPort(): Int? = takeIf { it.isNotEmpty() && it.all { char -> char.isAsciiDigit() } }?.toIntOrNull()
+
+        /**
+         * A hostname or an IP literal, by RFC 2396's rules rather than a browser's.
+         *
+         * An underscore, a non-ASCII letter and an empty label all fail here and all failed before;
+         * a hostname this refuses is simply not one of ours, and the caller hands it to the browser,
+         * which has its own more forgiving parser.
+         */
+        private fun isHost(host: String): Boolean {
+            if (host.isEmpty()) return false
+            if (host.startsWith("[")) return host.endsWith("]") && host.length > 2
+            // A single trailing dot is the root label written out; `nodeseek.com.` is a hostname.
+            return host.removeSuffix(".").split('.').all { label ->
+                label.isNotEmpty() &&
+                    !label.startsWith('-') &&
+                    !label.endsWith('-') &&
+                    label.all { it.isAsciiLetter() || it.isAsciiDigit() || it == '-' }
+            }
+        }
+
+        /**
+         * `%XX` back to text, UTF-8 and all.
+         *
+         * A run of escapes is decoded together, so a character written as `%E4%B8%AD` comes back
+         * whole; characters that were never escaped are copied as they stand, which keeps a pair of
+         * surrogates from being taken apart.
+         */
+        private fun percentDecode(value: String): String = buildString(value.length) {
+            val escaped = ByteArray(value.length / 3 + 1)
+            var index = 0
+            while (index < value.length) {
+                if (value[index] != '%') {
+                    append(value[index++])
+                    continue
+                }
+                var count = 0
+                while (index + 3 <= value.length && value[index] == '%') {
+                    val octet = value.substring(index + 1, index + 3).toIntOrNull(radix = 16) ?: break
+                    escaped[count++] = octet.toByte()
+                    index += 3
+                }
+                if (count == 0) append(value[index++]) else append(escaped.decodeToString(endIndex = count))
+            }
+        }
+
+        private fun Char.isAsciiLetter(): Boolean = this in 'a'..'z' || this in 'A'..'Z'
+
+        private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'
+
+        private fun Char.isHex(): Boolean = isAsciiDigit() || this in 'a'..'f' || this in 'A'..'F'
+
+        /**
+         * A non-ASCII letter is allowed through here and refused by [isHost], which is what `URI`
+         * did: `https://例え.jp/` is a URL it parses and a host it will not vouch for. Rejecting it
+         * outright would read the same to every caller and be a worse answer to give a browser.
+         */
+        private fun Char.isAllowedInUrl(): Boolean =
+            isAsciiLetter() || isAsciiDigit() || this in OTHER_ALLOWED ||
+                (code > 0x7F && !isISOControl() && !isWhitespace())
+
+        /** RFC 2396's `mark` and `reserved` sets, plus the brackets RFC 2732 added for IPv6. */
+        private const val OTHER_ALLOWED = "-_.!~*'();/?:@&=+$,[]#"
+
+        /** Stands in for "this authority names no host at all"; no real port can collide with it. */
+        private const val NO_AUTHORITY = -2
+    }
+}

--- a/core/src/main/java/io/github/plaza/core/net/WebViewCookieJar.kt
+++ b/core/src/main/java/io/github/plaza/core/net/WebViewCookieJar.kt
@@ -1,28 +1,28 @@
 package io.github.plaza.core.net
 
-import android.webkit.CookieManager
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
 
 /**
- * Shares one cookie store between OkHttp and the WebView.
+ * Shares one cookie store between OkHttp and the sign-in browser, and reads a session out of it.
  *
  * Login and Cloudflare challenges can only be completed in a real WebView, and everything else in
- * the app is a plain OkHttp request. Rather than copying cookies back and forth, both sides read
- * and write Android's [CookieManager], which also persists them across launches for free.
+ * the app is a plain OkHttp request. Rather than copying cookies back and forth, both sides go
+ * through one [SessionCookieStore] — [WebViewCookieStore] in the app, which is Android's own
+ * `CookieManager` and is what makes the name of this class still true.
+ *
+ * Nothing below knows which store that is. What it does know is the site: which cookie names mean
+ * signed in, which ones Cloudflare churns on its own schedule, and what a change in them should
+ * cost. That is the half worth keeping off any one platform.
  */
 class WebViewCookieJar(
     private val config: SiteConfig,
-    private val cookieManager: CookieManager = CookieManager.getInstance(),
+    private val store: SessionCookieStore,
 ) : CookieJar {
 
-    init {
-        cookieManager.setAcceptCookie(true)
-    }
-
     override fun loadForRequest(url: HttpUrl): List<Cookie> {
-        val header = cookieManager.getCookie(url.toString()) ?: return emptyList()
+        val header = store.cookieHeader(url.toString()) ?: return emptyList()
         return header.split(';')
             .mapNotNull { Cookie.parse(url, it.trim()) }
     }
@@ -30,19 +30,13 @@ class WebViewCookieJar(
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
         if (cookies.isEmpty()) return
         val target = url.toString()
-        cookies.forEach { cookieManager.setCookie(target, it.toString()) }
-        cookieManager.flush()
+        cookies.forEach { store.setCookie(target, it.toString()) }
+        store.flush()
     }
 
-    /**
-     * Writes the in-memory cookie store to disk.
-     *
-     * The WebView batches its writes, and the one cookie worth never losing — the session the site
-     * issues at login — arrives from an XHR rather than a page load, so there is no navigation to
-     * hang the flush on.
-     */
+    /** See [SessionCookieStore.flush] for why this is worth calling by hand. */
     fun flush() {
-        cookieManager.flush()
+        store.flush()
     }
 
     /**
@@ -78,8 +72,8 @@ class WebViewCookieJar(
     fun cookieNames(): List<String> = cookiePairs().map { (name, _) -> name }
 
     fun clearSession() {
-        cookieManager.removeAllCookies(null)
-        cookieManager.flush()
+        store.removeAll()
+        store.flush()
     }
 
     /**
@@ -97,8 +91,8 @@ class WebViewCookieJar(
             (name.startsWith("__cf") || name.startsWith("_cf") || name.startsWith("cf_"))
 
     private fun cookiePairs(): List<Pair<String, String>> =
-        cookieManager
-            .getCookie(config.baseUrl)
+        store
+            .cookieHeader(config.baseUrl)
             .orEmpty()
             .split(';')
             .mapNotNull { raw ->

--- a/core/src/main/java/io/github/plaza/core/net/WebViewCookieStore.kt
+++ b/core/src/main/java/io/github/plaza/core/net/WebViewCookieStore.kt
@@ -1,0 +1,28 @@
+package io.github.plaza.core.net
+
+import android.webkit.CookieManager
+
+/**
+ * [SessionCookieStore] on Android's own `CookieManager`.
+ *
+ * The reason this is the app's cookie store and not an OkHttp jar of its own: login and Cloudflare
+ * challenges can only be completed in a real WebView, so the WebView's store is where those cookies
+ * land. Sharing it rather than copying out of it means there is no moment where one side has a
+ * cookie the other does not — and it persists across launches for free.
+ */
+class WebViewCookieStore(
+    private val cookieManager: CookieManager = CookieManager.getInstance(),
+) : SessionCookieStore {
+
+    init {
+        cookieManager.setAcceptCookie(true)
+    }
+
+    override fun cookieHeader(url: String): String? = cookieManager.getCookie(url)
+
+    override fun setCookie(url: String, cookie: String) = cookieManager.setCookie(url, cookie)
+
+    override fun removeAll() = cookieManager.removeAllCookies(null)
+
+    override fun flush() = cookieManager.flush()
+}

--- a/core/src/main/java/io/github/plaza/core/net/WebViewUserAgent.kt
+++ b/core/src/main/java/io/github/plaza/core/net/WebViewUserAgent.kt
@@ -1,0 +1,33 @@
+package io.github.plaza.core.net
+
+import android.content.Context
+import android.webkit.WebSettings
+
+/**
+ * Asks the WebView what it is, rather than telling the site what we wish it were.
+ *
+ * This is the fix for the infinite Cloudflare checkbox. A managed challenge cross-checks the
+ * `User-Agent` header against the JavaScript environment — `navigator.userAgentData` and the
+ * `Sec-CH-UA` hints, which WebView derives from its *real* Chromium version and which
+ * `setUserAgentString` does not touch. A header claiming "Chrome 126 on a Pixel 8" on a device
+ * running something else is a contradiction, and a managed challenge answers a contradiction with
+ * another challenge, forever.
+ *
+ * OkHttp then has to send the same string, because `cf_clearance` is issued against the UA that
+ * solved the challenge and is rejected for any other. One source, both consumers.
+ */
+fun resolveUserAgent(context: Context, config: SiteConfig): UserAgent {
+    // Throws on devices where the WebView provider is missing or mid-update. Not a suspend call, so
+    // `runCatching` is safe here — there is no cancellation to swallow.
+    val default =
+        runCatching { WebSettings.getDefaultUserAgent(context) }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+
+    return if (default != null) {
+        UserAgent(value = default, isWebViewDefault = true)
+    } else {
+        // The WebView is unusable anyway; what matters is that both sides still agree.
+        UserAgent(value = config.fallbackUserAgent, isWebViewDefault = false)
+    }
+}

--- a/core/src/main/java/io/github/plaza/core/update/AppUpdate.kt
+++ b/core/src/main/java/io/github/plaza/core/update/AppUpdate.kt
@@ -126,11 +126,28 @@ sealed interface UpdateDownload {
 }
 
 /**
- * Why the system installer refused the APK.
+ * How an install session ended, once the user has answered the system's confirmation.
  *
- * A user who backed out of the confirmation dialog is not in here: `STATUS_FAILURE_ABORTED` means
- * "no thanks", and showing an error for it would turn their own decision into a fault.
+ * The platform reports this as an integer from its own installer; naming the three outcomes here is
+ * what keeps the repository — which only decides what the screen says — from having to know which
+ * integer meant which. The translation belongs to whatever received the platform's answer.
  */
+sealed interface InstallOutcome {
+    /** The new build is in, and this process is about to be replaced by it. */
+    data object Installed : InstallOutcome
+
+    /**
+     * The user backed out of the confirmation dialog.
+     *
+     * Separate from [Failed] because it is an answer rather than a fault, and showing an error for it
+     * would turn their own decision into one.
+     */
+    data object Abandoned : InstallOutcome
+
+    data class Failed(val failure: InstallFailure) : InstallOutcome
+}
+
+/** Why the system installer refused the APK. */
 enum class InstallFailure {
     /** Blocked by the device — Play Protect, a device policy, or unknown sources still off. */
     BLOCKED,

--- a/core/src/test/java/io/github/plaza/core/net/WebUrlTest.kt
+++ b/core/src/test/java/io/github/plaza/core/net/WebUrlTest.kt
@@ -1,0 +1,163 @@
+package io.github.plaza.core.net
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * [WebUrl] against the `java.net.URI` it replaced, URL by URL.
+ *
+ * A differential test rather than a list of expectations, because what is being preserved is not a
+ * specification — it is the answers one particular parser gave, and those answers are what every
+ * host check in the app was written against. Anything asserted by hand here would be asserting what
+ * the author *believed* `URI` did; a link written to slip past a host check is exactly the case
+ * where that belief is wrong.
+ *
+ * `java.net.URI` is JVM API and this test runs on the JVM, which is the point: the test may keep the
+ * dependency the code being tested has just shed, and that is what makes the shedding checkable. If
+ * `:core` ever compiles for a non-JVM target, this file stays behind with the JVM one.
+ */
+class WebUrlTest {
+
+    /**
+     * Every shape that matters, mostly for the reason it matters rather than for coverage.
+     *
+     * The two that are load-bearing beyond parsing: `user@host` — where the host is the part after
+     * the `@`, which is the whole point of writing it — and every non-web scheme, where the answer
+     * has to be "no host" rather than a host lifted out of what follows the colon.
+     */
+    private val urls = listOf(
+        // The site, as it is actually linked.
+        "https://www.nodeseek.com/signIn.html",
+        "https://nodeseek.com/",
+        "http://www.nodeseek.com/post-832584-2",
+        "https://www.nodeseek.com",
+        "https://www.nodeseek.com/member?t=lcy0828",
+        "https://www.nodeseek.com/member?t=%E4%B8%AD%E6%96%87",
+        "https://www.nodeseek.com/jump?to=https%3A%2F%2Filatency.com%2Fcoverage",
+        "https://www.nodeseek.com/jump?to=",
+        "https://www.nodeseek.com/notification#/atMe",
+        "https://www.nodeseek.com/notification#/message?mode=talk&to=5230",
+        "https://nodeseek.com/notification/#/replyToMe",
+        "https://www.nodeseek.com/space/23042#/general",
+        // Hosts written to be mistaken for the site.
+        "https://www.nodeseek.com.evil.example/",
+        "https://www.nodeseek.com@evil.example/",
+        "https://user:pw@nodeseek.com/x",
+        "https://evil.example/?x=www.nodeseek.com",
+        "https://evil.example/#www.nodeseek.com",
+        // Schemes that are not the web.
+        "javascript:alert(1)",
+        "content://www.nodeseek.com/private",
+        "file:///data/data/io.github.nodyssey/file",
+        "mailto:someone@nodeseek.com",
+        "nsapp://stardust-receive?member_id=1&diff=2",
+        "intent://www.nodeseek.com/#Intent;scheme=https;end",
+        // Ports.
+        "https://www.nodeseek.com:443/x",
+        "https://www.nodeseek.com:8443/x",
+        "https://www.nodeseek.com:abc/x",
+        "https://www.nodeseek.com:/x",
+        "https://[::1]:8080/x",
+        "https://[::1]/x",
+        // Hostnames `java.net.URI` refuses to vouch for.
+        "https://foo_bar.example/",
+        "https://.nodeseek.com/x",
+        "https://nodeseek.com./x",
+        "https://-nodeseek.com/x",
+        "https://1.2.3.4/x",
+        "https://例え.jp/",
+        "https://www.nodeseek.com/%E4%B8%AD/中文?q=中文#中文",
+        // Case, which no comparison in the app may depend on.
+        "HTTPS://WWW.NODESEEK.COM/x",
+        "https://WWW.NodeSeek.COM/x",
+        // Escapes, in each of the three places one can appear.
+        "https://www.nodeseek.com/a%2Fb",
+        "https://www.nodeseek.com/x?q=a%26b",
+        "https://www.nodeseek.com/x#frag%20ment",
+        "https://www.nodeseek.com/%E4%B8%AD%E6%96%87",
+        // Trailing and empty parts.
+        "https://www.nodeseek.com/x?",
+        "https://www.nodeseek.com/x#",
+        "https://www.nodeseek.com/?#",
+    )
+
+    /** What `URI` threw on, [WebUrl.parse] answers null to — the callers treated both the same way. */
+    private val rejected = listOf(
+        "https://exa mple.com/",
+        "https://www.nodeseek.com/pa th",
+        "https://www.nodeseek.com/a%2",
+        "https://www.nodeseek.com/a%zz",
+        "https://www.nodeseek.com/a\\b",
+        "https://www.nodeseek.com/<script>",
+        "https://",
+        "//www.nodeseek.com/x",
+        "/post-123",
+        "",
+        "   ",
+        "not a url",
+    )
+
+    @Test
+    fun `reads every part the way java net URI read it`() {
+        urls.forEach { url ->
+            val expected = URI(url)
+            val actual = WebUrl.parse(url) ?: error("$url did not parse")
+
+            assertEquals("$url scheme", expected.scheme.lowercase(), actual.scheme)
+            assertEquals("$url userInfo", expected.userInfo, actual.userInfo)
+            assertEquals("$url host", expected.host, actual.host)
+            assertEquals("$url port", expected.port, actual.port)
+            assertEquals("$url path", expected.path, actual.path)
+            assertEquals("$url rawQuery", expected.rawQuery, actual.rawQuery)
+            assertEquals("$url fragment", expected.fragment, actual.fragment)
+        }
+    }
+
+    @Test
+    fun `refuses everything java net URI refused to parse as an absolute url`() {
+        rejected.forEach { url ->
+            val jvmRefused = try {
+                !URI(url.trim()).isAbsolute
+            } catch (exception: URISyntaxException) {
+                true
+            }
+
+            assertEquals("$url should be refused by java.net.URI too", true, jvmRefused)
+            assertNull(url, WebUrl.parse(url))
+        }
+    }
+
+    /**
+     * The one deliberate departure, and the reason it cannot reach anything the site wrote.
+     *
+     * `URLDecoder`, which read these values before, is a *form* decoder: it turns `+` into a space.
+     * `encodeURIComponent` — the only thing that writes the site's own `/jump?to=` and `?t=` values —
+     * escapes a literal plus as `%2B`, so no link the site generates contains a bare `+` to disagree
+     * about. A hand-typed one now reaches the browser as written instead of with a space in it.
+     */
+    @Test
+    fun `a plus in a query value stays a plus`() {
+        val url = WebUrl.parse("https://www.nodeseek.com/jump?to=https%3A%2F%2Fexample.com%2Fa+b")
+
+        assertEquals("https://example.com/a+b", url?.queryParameter("to"))
+    }
+
+    @Test
+    fun `an escape inside a query value survives the split on ampersand`() {
+        val url = WebUrl.parse("https://www.nodeseek.com/x?q=a%26b&r=2")
+
+        assertEquals("a&b", url?.queryParameter("q"))
+        assertEquals("2", url?.queryParameter("r"))
+    }
+
+    @Test
+    fun `a query field the url does not carry reads as null, and an empty one as empty`() {
+        val url = WebUrl.parse("https://www.nodeseek.com/jump?to=")
+
+        assertEquals("", url?.queryParameter("to"))
+        assertNull(url?.queryParameter("from"))
+    }
+}

--- a/docs/kmp-migration-plan.md
+++ b/docs/kmp-migration-plan.md
@@ -144,6 +144,10 @@ HTML structure / CSS selector / markup quirks / API quirks / Cloudflare behavior
 
 **全程不需要任何 KMP 基建，不新建模块，不动 frontend。**每一项都可独立合并。
 
+> **执行记录（2026-08-18）**：4.1 / 4.2 / 4.4 / 4.5 已完成，4.3 完成 7/19（12 个 Room 测试类
+> 在第一阶段做不到，见 4.3）。下面每一节里带 ✅ / ⚠️ 的段落是事后按实测补写的，未标注的部分
+> 是当初的计划原文。
+
 ### 4.1 让 core 不再认识 Android
 
 把这些从 `core` / `data` 往外推：
@@ -163,6 +167,26 @@ android.net.* / android.os.*
 `NodeSeekSite.kt` 需要拆：它用了 `resolveUserAgent`（要 `Context`）、`java.net.URI` /
 `URLEncoder`，还有一个只服务于 KDoc 链接的 `import ...designsys.component.UserAvatar`
 （删 import、把 `[UserAvatar]` 改成普通文字即可，不涉及架构）。
+
+**✅ 实际做法**：这 9 个分成两类，处理方式不同。
+
+| 类别 | 文件 | 做法 |
+|---|---|---|
+| 只为了拿 `DataStore` 才收 `Context` | `ProxySettings`、`ImageHostSettings`、`PostComposerRepository`、`CommentComposerRepository` | 改收 `DataStore<Preferences>`；`preferencesDataStore` 委托集中到 `di/PreferenceStores.kt` |
+| 本身就是平台外壳 | `KeystoreSecretCipher`、`DefaultImagePreparer`、`ApkInstaller` + `ApkInstallResultReceiver`、`NodeSeekDatabase.create` | 整个搬进新的 `app/.../platform/` 包，接口留在 `data` |
+
+`AppUpdateRepository` 是第三种：它没有平台外壳可搬，只是 `onInstallStatus(status: Int)` 收的是
+`PackageInstaller.STATUS_*`。改成 `onInstallOutcome(InstallOutcome)`，整数到语义的翻译放在广播
+到达的地方。
+
+`resolveUserAgent` 和 `UserAvatar` 两个 import 实测都没人用，只出现在 KDoc 散文里，直接删。
+
+**✅ `:core` 也做了同一件事**：`AppVersion` / `UserAgent` / `AcceptLanguage` /
+`ImageNetworkPolicyInterceptor` 四处形状一样——中性的值和逻辑，加边缘一个读设备的函数。把读取
+函数各自拆成独立文件（`AndroidAppVersion.kt`、`WebViewUserAgent.kt`、`DeviceAcceptLanguage.kt`、
+`AndroidNetworkMetering.kt`）。**拆开不是为了整洁**：KMP 里一个文件不能一半 `commonMain` 一半
+`androidMain`，拆过之后第二阶段就是移动文件而不是改写。`:core` 里 `import android.*` 的现在只剩
+5 个以平台命名的文件。
 
 ### 4.2 让 core 不再认识 JVM library 实现
 
@@ -187,6 +211,26 @@ java.io.* / java.net.*
 
 参考实现见 `nodyssey-kmp-spike/gate-b-parser/src/commonMain/`，已通过两端测试。
 
+**✅ 实际做法**：三处按 spike 走，但 spike 的 `percentDecode` 有一个 bug 没照抄——它对未转义
+字符逐 `Char` 转字节，会把一个 emoji 拆成两个替换字符。改成「未转义字符原样抄写」，并补了测试。
+
+`java.util.Base64` → `kotlin.io.encoding.Base64` 时 padding 设成 `PRESENT_OPTIONAL`：spike 的
+注释说两者「都要求正确 padding」，实测不对——Java 的 decoder 接受无 padding 的输入，Kotlin 默认
+不接受。
+
+**✅ 多出来的一项：`NodeSeekSite` 的 `java.net.URI`**。判断一个链接是不是本站、能不能进登录
+WebView、该开原生页还是浏览器，是关于站点的规则，之前却是从 `java.net.URI` 上读出来的。新增
+`:core` 的 `WebUrl` 承担这件事。
+
+`WebUrlTest` 是**对 `java.net.URI` 的差分测试**而不是手写断言：要保住的不是规范，是那一个解析器
+给出的答案，而 `https://www.nodeseek.com@evil.example/`、非 web scheme、下划线主机名、非数字端口
+这些绕过主机校验的写法，恰恰是手写期望最容易写错的地方。实测确认了几条反直觉行为：`URI` 对
+`https://例え.jp/` 是**解析成功、host 为 null**（不是抛异常），对 `foo_bar.example` 同样；对
+`:abc` 端口也是 host 为 null。
+
+一处有意的行为差异：查询参数里的 `+` 不再解成空格（`URLDecoder` 是表单解码器）。
+`encodeURIComponent` 把字面加号写成 `%2B`，站点自己生成的链接碰不到这个差异。
+
 ### 4.3 测试变纯
 
 **这一项无论 KMP 做不做都值，且它是后续一切的前提。**
@@ -201,6 +245,29 @@ java.io.* / java.net.*
 **例外**：`NodeSeekDatabaseMigrationTest` 测的就是 Android schema 升级，永远留在 Android 侧。
 
 即时收益：测试执行时间显著缩短，与 KMP 无关。
+
+#### ⚠️ 实测：这一项在第一阶段只能做到 7/19
+
+**已脱离 Robolectric（7 个）**：`ProxySettingsTest`、`ImageHostSettingsTest`、
+`PostComposerRepositoryTest`、`CommentComposerRepositoryTest`（随 4.1 的 DataStore 改造一起）、
+`SessionRepositoryTest`（随 `SessionCookieStore` 一起）、`AppCacheStoreTest`（把
+`DefaultAppCacheStore` 收的整个 `ImageLoader` 收窄成它真正用到的 `ImageCaches`）。另有三个
+`ui` 层测试（`MessageThreadViewModelTest`、`ProfileViewModelTest`、`NotificationsViewModelTest`）
+顺带换掉了 `CookieManager`。
+
+**做不到的 12 个**：全部靠 `inMemoryDatabase()`。`javap` 查过 `room-runtime-android` 2.8.4 的
+`androidx.room.Room`，四个 builder 重载**每一个都要 `android.content.Context`**，没有 common
+那套无 Context 的重载。所以「真 Room 跑在纯 JVM 单测」这条路在不新建 KMP 模块的前提下不存在，
+而不新建模块正是第一阶段的约束。
+
+**并且原来那条「即时收益」不成立**：实测整个 `:app` 单测 24.5s，其中 Robolectric 类占 23.1s，
+但这 12 个 Room 类只占 **2.6s**——剩下 20s 在 41 个 Compose 测试类里，而 4.6 明说不许碰
+frontend。Robolectric 的 sandbox 是按 SDK 缓存、跨类共享的，所以边际成本远比想象中小。
+
+**决定（2026-08-18）**：这 12 个继续用 Robolectric，等第二阶段 Room 进 KMP 模块（那边有
+`BundledSQLiteDriver` 和无 Context 的 builder）时一起解决。换 fake DAO 的选项被否掉了——
+`TestDoubles.kt` 里写明「Robolectric 而不是 fake DAO 是刻意的：要测的就是 SQL」，三表 join、
+upsert 不重排、级联删除这些覆盖丢了不划算。
 
 ### 4.4 把平台能力抽成很少几个 interface
 
@@ -218,6 +285,20 @@ interface SettingsStoreFactory
 
 继续用 constructor injection，不为 KMP 引入 DI framework。
 
+**✅ 落地情况**——六个里只有一个真的需要新写接口，其余要么已存在，要么一个函数就够：
+
+| 计划里的名字 | 实际 |
+|---|---|
+| `SiteTransport` | 已存在，叫 `HtmlSource`；`SiteHtmlClient` 是它的 OkHttp 实现 |
+| `SessionCookieStore` | **新写**。`WebViewCookieJar` 原来和 `android.webkit.CookieManager` 绑死，而它真正值钱的是站点知识（哪些 cookie 名算登录、哪些是 Cloudflare 噪声）。接口留 `:core`，`CookieManager` 实现是 `WebViewCookieStore` |
+| `SecretCipher` | 已存在；这次只是把 `KeystoreSecretCipher` 挪进 `platform/` |
+| `AppVersionProvider` | 不需要接口——`AppVersion` 本来就是中性 data class，拆出 `readAppVersion` 即可 |
+| `DatabaseFactory` | 不需要接口——一个 `createNodeSeekDatabase(context)` 函数 |
+| `SettingsStoreFactory` | 不需要接口——`di/PreferenceStores.kt` 里一组 `Context` 扩展 |
+
+按「不要过度抽象」这条，后三个都没做成接口。另外顺手收窄了一个不在计划里的依赖：
+`DefaultAppCacheStore` 原来收整个 `ImageLoader`，实际只用两个缓存，改成 `ImageCaches`。
+
 ### 4.5 拆掉 data → designsys 反向依赖
 
 [`SettingsRepository.kt:18`](../app/src/main/java/io/github/nodyssey/data/settings/SettingsRepository.kt)
@@ -225,6 +306,10 @@ interface SettingsStoreFactory
 
 把需要持久化的部分下沉成 `EditorActionId`，`:designsys` 负责映射回 UI action。
 这是 `data` 层唯一一处反向依赖，**单独一个 PR**。
+
+**✅ 实测比这简单得多**：存进 DataStore 的本来就是 `List<String>`，`setComposerToolbar` 收的也是
+`List<String>`——那个 import 只出现在 KDoc 散文里，没有一行代码用它。不需要 `EditorActionId`，
+删掉 import 就断了。`NodeSeekSite` 的 `UserAvatar` 是同一种情况。
 
 ### 4.6 不碰 frontend
 
@@ -240,12 +325,22 @@ Compose
 ### 第一阶段验收
 
 ```bash
-./gradlew :app:testDebugUnitTest :app:assembleDebug
+./gradlew testDebugUnitTest :app:assembleDebug spotlessCheck :app:lintDebug
 ```
 
 - `data` / `core` 的公开 API 不出现 `android.*`、`okhttp3.*`、`org.jsoup.*`、`java.*`
-- `data` 包下不再出现 `RobolectricTestRunner`（迁移测试除外）
+- ~~`data` 包下不再出现 `RobolectricTestRunner`（迁移测试除外）~~ →
+  **改为**：`data` 包下 `RobolectricTestRunner` 只剩靠 `inMemoryDatabase()` 的 12 个类，
+  加上迁移测试。理由见 4.3；这一条移交第二阶段
 - 测试总数不减，Android 行为不变
+
+**✅ 2026-08-18 全绿**。`import android.*` 在 `app/.../data`、`app/.../core`、`app/.../model`
+下为 0；`:core` 只剩 5 个以平台命名的文件（`AndroidAppVersion`、`DeviceAcceptLanguage`、
+`WebViewUserAgent`、`WebViewCookieStore`、`AndroidNetworkMetering`）。jsoup 类型只出现在 parser
+的**参数**上，没有一个出现在返回值上——第一阶段这条要求达成，换 Ksoup 留给第二阶段。
+
+测试总数 1,269 → 1,280（`WebUrlTest` 5 个差分测试、`urlEncode` 的差分测试、
+`ApkInstallOutcomeTest` 3 个、`percentDecode` 的代理对测试、`ProxySettings` 的空 store 默认值）。
 
 ---
 


### PR DESCRIPTION
按 [`docs/kmp-migration-plan.md`](docs/kmp-migration-plan.md) 做第一阶段。目标不是跨平台化，是把
业务核心整理成不认识 Android、不认识 JVM 库实现的 Kotlin —— 每一项单独看都是 Android 架构改善，
即使最终不做 KMP 也是净收益。

**不动 frontend**：`app/ui`、`:designsys`、Navigation 3、Compose 一个字没改。

## 计划项落地情况

| 计划项 | 结果 |
|---|---|
| 4.1 让 data 不再认识 Android | 9 个文件清零；`:core` 同样处理 |
| 4.2 让 core 不再认识 JVM library | 三处按 spike 走 + 一处计划外的 `java.net.URI` |
| 4.3 测试变纯 | 7/19，剩下 12 个在第一阶段做不到（见下） |
| 4.4 平台能力抽 interface | 六个候选里只有一个真的需要新写 |
| 4.5 拆 data → designsys 反向依赖 | 比计划简单得多 |

## 提交逐条

1. **data 层不再 import designsys** — `SettingsRepository` 存的本来就是 `List<String>`，
   `EditorAction` 只出现在 KDoc 散文里。不需要计划里的 `EditorActionId`，删 import 就断了。
2. **TerminalColumns / 收款码 / `__config__` 不再依赖 JVM 实现** — 自写 UTF-16 代理对处理、
   自写 percent-decode（保留 `+`→空格 的表单语义）、`kotlin.io.encoding.Base64`。
3. **链接判定改用自写的 `WebUrl`** — 见下。
4. **四个 DataStore 仓库改收 `DataStore`，不再收 `Context`** — 开文件是 Android 的事，
   文件里存什么是 App 的事；前者集中到 `di/PreferenceStores.kt`。
5. **平台外壳搬出 data** — 新建 `platform/` 包：`KeystoreSecretCipher`、`DefaultImagePreparer`、
   `ApkInstaller` + `ApkInstallResultReceiver`、`createNodeSeekDatabase`。接口留在 `data`。
6. **cookie 存储抽成 `SessionCookieStore`** — `WebViewCookieJar` 里值钱的是站点知识，
   之前和 `android.webkit.CookieManager` 绑死。
7. **`:core` 的 Android 读取器各自独立成文件** — KMP 里一个文件不能一半 `commonMain`
   一半 `androidMain`，拆过之后第二阶段是移动文件而不是改写。
8. **`AppCacheStore` 只收它真正用到的两个图片缓存**。
9. **把实测结论写回计划文档**。

## 三处值得 reviewer 注意的

### `WebUrl` 的测试是对 `java.net.URI` 的差分测试

判断一个链接是不是本站、能不能进登录 WebView、该开原生页还是浏览器，是关于站点的规则，
之前却是从 `java.net.URI` 上读出来的。

`WebUrlTest` 不是手写断言：**要保住的不是规范，是那一个解析器给出的答案**，而
`https://www.nodeseek.com@evil.example/`、非 web scheme、下划线主机名、非数字端口这些绕过主机
校验的写法，恰恰是手写期望最容易写错的地方。实测确认了几条反直觉行为 —— `URI` 对
`https://例え.jp/` 是**解析成功、host 为 null**（不是抛异常），下划线主机名和 `:abc` 端口同理。

**一处有意的行为差异**：查询参数里的 `+` 不再解成空格。`URLDecoder` 是表单解码器，而这是 URL；
`encodeURIComponent` 把字面加号写成 `%2B`，站点自己生成的 `/jump?to=` 和 `?t=` 碰不到这个差异。
`urlEncode` 那一侧则**逐字节保持不变**（unreserved 集合仍是 `URLEncoder` 的，和
`encodeURIComponent` 在 `~!'()` 上不同），同样加了差分测试。

### spike 里有两处照抄会出错

- `nodyssey-kmp-spike` 的 `percentDecode` 对未转义字符逐 `Char` 转字节，会把一个 emoji 拆成
  两个替换字符。改成「未转义字符原样抄写」，补了测试。
- 它的注释说 `java.util.Base64` 和 Kotlin 的「都要求正确 padding」，实测不对：Java 的 decoder
  接受无 padding 输入，Kotlin 默认不接受。已设 `PaddingOption.PRESENT_OPTIONAL`。

### 4.3 剩下 12 个 Room 测试类做不到，且原计划的收益前提不成立

`javap` 查过 `room-runtime-android` 2.8.4 的 `androidx.room.Room`，四个 builder 重载
**每一个都要 `android.content.Context`**，没有 common 那套无 Context 的重载 —— 所以「真 Room 跑在
纯 JVM 单测」在不新建 KMP 模块的前提下不存在，而不新建模块正是第一阶段的约束。

并且原计划写的「即时收益：测试执行时间显著缩短」不成立：`:app` 单测 24.5s 里 Robolectric 类占
23.1s，但这 12 个 Room 类只占 **2.6s** —— 剩下 20s 在 41 个 Compose 测试类里，而 4.6 明说不许碰
frontend。Robolectric 的 sandbox 按 SDK 缓存、跨类共享，边际成本比想象中小。

换 fake DAO 的选项被否掉了：`TestDoubles.kt` 里写明「Robolectric 而不是 fake DAO 是刻意的：
要测的就是 SQL」，三表 join、upsert 不重排、级联删除这些覆盖丢了不划算。这一条移交第二阶段
（那边有 `BundledSQLiteDriver` 和无 Context 的 builder）。

## 验收

```
./gradlew testDebugUnitTest :app:assembleDebug spotlessCheck :app:lintDebug
```

全绿。

- `import android.*` 在 `app/.../data`、`app/.../core`、`app/.../model` 下为 0；`:core` 只剩 5 个
  以平台命名的文件（`AndroidAppVersion`、`DeviceAcceptLanguage`、`WebViewUserAgent`、
  `WebViewCookieStore`、`AndroidNetworkMetering`）。
- jsoup 类型只出现在 parser 的**参数**上，没有一个出现在返回值上 —— 第一阶段这条达成，
  换 Ksoup 留给第二阶段。
- 测试总数 **1,269 → 1,280**，0 失败。新增的都是差分测试和之前没覆盖的路径 —— 比如
  `PackageInstaller` 状态映射原来只有 `CONFLICT` 一条被间接覆盖到，`STATUS_FAILURE_ABORTED`
  读错就会把用户自己的「取消」显示成错误。

## 数据兼容

没有改表名、列名、`@SerialName`、DataStore 文件名或 preference key。`AndroidManifest.xml` 里
receiver 的组件名随类一起从 `.data.update.ApkInstallResultReceiver` 改成
`.platform.ApkInstallResultReceiver`（那个 `PendingIntent` 是安装时现建现用，不跨版本存活）。

## 顺带发现，本次未处理

计划第 6 节提到的 `SiteConfig.sessionCookieNames = listOf("session", "token")` —— 站点实际下发的
JWT 风格 cookie 名是 `pjwt`，`token` 可能已是死代码。不属于第一阶段所以没动，但
`SessionCookieStore` 抽出来之后，验证它只需要一个 fake，不用真机。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
