### PR TITLE
D4：iOS 用 BGTaskScheduler 接上离线下载调度

### DIFF
--- a/app/src/main/java/io/github/nodyssey/data/offline/OfflineWorkers.kt
+++ b/app/src/main/java/io/github/nodyssey/data/offline/OfflineWorkers.kt
@@ -4,9 +4,6 @@ import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import io.github.nodyssey.NodysseyApp
-import io.github.plaza.core.net.SiteError
-import io.github.plaza.core.net.SiteException
-import kotlinx.coroutines.flow.first
 
 /**
  * Works the download queue until it is empty.
@@ -35,14 +32,9 @@ class OfflineDownloadWorker(
 /**
  * The daily housekeeping: 离线内容保留, and 自动补新回复 when it is switched on.
  *
- * Both live in one worker because both are the same errand — a look over what is stored, once a
- * day, on a device nobody may have opened 收藏 on — and because the sweep must run whether or not
- * the sync does.
- *
- * The sync is deliberately not a re-download of everything. It asks the collection list what the
- * site says each thread's reply count is now, hands those numbers to the library, and queues only
- * the threads that have actually moved; the download engine then re-fetches from each one's last
- * stored page rather than from the top.
+ * The errand itself is [runOfflineMaintenance] in `commonMain`, because it is the same on iOS, where
+ * `BGTaskScheduler` runs it. All this worker adds is WorkManager's vocabulary: an emptied sweep is a
+ * success, a sync the site could not be reached for is a retry.
  */
 class OfflineMaintenanceWorker(
     context: Context,
@@ -53,37 +45,11 @@ class OfflineMaintenanceWorker(
         val library = container.offlineLibrary
         val downloads = library as? OfflineDownloads ?: return Result.success()
 
-        downloads.sweepExpired()
-
-        if (!library.settings.first().autoSyncReplies) return Result.success()
-        // Collections are the signed-in account's own list; asking for them signed out is a request
-        // that can only be refused, and a periodic one at that.
-        if (!container.sessionRepository.peek().isSignedIn) return Result.success()
-
-        val counts = mutableMapOf<Long, Int>()
-        var page = 1
-        while (page <= MAX_COLLECTION_PAGES) {
-            val result =
-                try {
-                    container.userSpaceRepository.collections(page)
-                } catch (e: SiteException) {
-                    // Same rule as 通知轮询: only a transport failure is worth retrying. A challenge
-                    // page answered with more background requests is what the challenge is for.
-                    return if (e.error is SiteError.Network) Result.retry() else Result.success()
-                }
-            result.items.forEach { post -> post.commentCount?.let { counts[post.postId] = it } }
-            if (!result.hasNextPage || result.items.isEmpty()) break
-            page++
+        return when (
+            runOfflineMaintenance(library, downloads, container.sessionRepository, container.userSpaceRepository)
+        ) {
+            MaintenanceOutcome.COMPLETED -> Result.success()
+            MaintenanceOutcome.NETWORK_FAILED -> Result.retry()
         }
-        library.noteReplyCounts(counts)
-
-        val stale = downloads.staleIds()
-        if (stale.isNotEmpty()) library.download(stale)
-        return Result.success()
-    }
-
-    private companion object {
-        /** The same bound 收藏 walks the list under, and for the same reason: it exists. */
-        const val MAX_COLLECTION_PAGES = 20
     }
 }

--- a/iosapp/Nodyssey/App.swift
+++ b/iosapp/Nodyssey/App.swift
@@ -3,12 +3,22 @@ import NodysseyShell
 
 /// The whole of the Swift in this app.
 ///
-/// `MainActivity` is the Android counterpart and it is 76 lines; this is thirty, and the difference
-/// is not that iOS does less — it is that everything `MainActivity` does beyond installing a
-/// composition is about intents, and nothing here has any yet. When notifications and Universal Links
-/// arrive (step D4 and after), this is where they land.
+/// `MainActivity` is the Android counterpart and it is 76 lines; this is short, and the difference is
+/// not that iOS does less — it is that everything `MainActivity` does beyond installing a composition
+/// is about the platform's own hooks, and this app has one so far: the offline downloader's
+/// background tasks. `registerBackgroundTasks` installs their `BGTaskScheduler` handlers, which
+/// **must** happen before launch finishes, so it goes here rather than in the scene. When
+/// notifications and Universal Links arrive, this is where they land too.
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        NodysseyApp.shared.registerBackgroundTasks()
+        return true
+    }
+
     func application(
         _ application: UIApplication,
         configurationForConnecting session: UISceneSession,

--- a/iosapp/Nodyssey/Info.plist
+++ b/iosapp/Nodyssey/Info.plist
@@ -68,5 +68,17 @@
 	     uses runs out of process precisely so that it does not. -->
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>把看到的图片存进相册。</string>
+	<!-- The offline downloader's `BGTaskScheduler` work — see `BgTaskOfflineScheduler`. `processing`
+	     is what a `BGProcessingTaskRequest` runs under; the two identifiers must match the ones the
+	     scheduler submits, or `submit` throws. This is step D4's Android→iOS map of WorkManager. -->
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>processing</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>io.github.nodyssey.offline.drain</string>
+		<string>io.github.nodyssey.offline.maintenance</string>
+	</array>
 </dict>
 </plist>

--- a/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/BgTaskOfflineScheduler.kt
+++ b/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/BgTaskOfflineScheduler.kt
@@ -1,0 +1,236 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package io.github.nodyssey.ios
+
+import io.github.nodyssey.data.offline.DrainOutcome
+import io.github.nodyssey.data.offline.MaintenanceOutcome
+import io.github.nodyssey.data.offline.OfflineDownloads
+import io.github.nodyssey.data.offline.OfflineWorkScheduler
+import io.github.nodyssey.data.offline.runOfflineMaintenance
+import io.github.nodyssey.di.AppContainer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.BackgroundTasks.BGProcessingTask
+import platform.BackgroundTasks.BGProcessingTaskRequest
+import platform.BackgroundTasks.BGTask
+import platform.BackgroundTasks.BGTaskScheduler
+import platform.Foundation.NSDate
+import platform.Foundation.dateWithTimeIntervalSinceNow
+import platform.Network.nw_interface_type_wifi
+import platform.Network.nw_path_monitor_cancel
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_uses_interface_type
+import platform.darwin.dispatch_queue_create
+import kotlin.coroutines.resume
+
+/**
+ * [OfflineWorkScheduler] on `BGTaskScheduler` — the iOS counterpart of `WorkManagerOfflineScheduler`.
+ *
+ * This is step D4. Until it, `NoOfflineWorkScheduler` did nothing, and because the drain is only ever
+ * triggered *through* the scheduler (the engine says "there is work", never "run now"), an iOS build
+ * queued downloads that nothing ever worked off. So this class does two jobs WorkManager rolls into
+ * one, and the difference from Android is worth naming:
+ *
+ * - **The foreground drain.** WorkManager runs its one-time work almost immediately while the app is
+ *   on screen; the closest iOS has is doing it ourselves, so [startDrain] launches the drain on
+ *   [scope] there and then. This is what actually moves bytes in the common case — and the only path
+ *   that runs at all on the Simulator, where `BGTaskScheduler` is unavailable.
+ * - **The background continuation.** [startDrain] and [ensureMaintenance] also submit
+ *   `BGProcessingTaskRequest`s, so the system relaunches the app to finish a queue too large for one
+ *   foreground session, or to run the daily sweep on a device 收藏 has not been opened on for a
+ *   fortnight. [register] must have installed the handlers first — see its note on launch timing.
+ *
+ * **仅 Wi-Fi 下载 cannot be a request constraint here.** WorkManager has `NetworkType.UNMETERED`;
+ * `BGProcessingTaskRequest` has only `requiresNetworkConnectivity`, which is "any network". So the
+ * Wi-Fi rule is enforced where the download actually happens instead — [networkAllows] checks the
+ * live path before every drain, foreground or background, and a run that finds itself on cellular
+ * with the setting on simply does nothing and lets a later one try, which is the same waiting
+ * WorkManager does, moved one layer in.
+ *
+ * @param scope the app's process-lifetime scope, dispatched to the main thread. The drain itself
+ *   switches to IO inside `RoomOfflineLibrary`; this scope only ever holds the coroutine's shell and
+ *   serialises access to [foregroundDrain].
+ * @param container resolves the graph, building it if a background launch got here before any scene.
+ *   Suspends because that build waits on WebKit for the user agent — see `NodysseyApp`.
+ */
+class BgTaskOfflineScheduler(
+    private val scope: CoroutineScope,
+    private val container: suspend () -> AppContainer?,
+) : OfflineWorkScheduler {
+    private var registered = false
+    private var foregroundDrain: Job? = null
+
+    /**
+     * Installs the two launch handlers. **Must run before the app finishes launching** — iOS traps
+     * if a handler is registered afterwards — so `AppDelegate` calls this from
+     * `didFinishLaunchingWithOptions`, before any container exists. The handlers close over
+     * [container] and resolve it only when a task actually fires, which is much later.
+     */
+    fun register() {
+        if (registered) return
+        registered = true
+        val scheduler = BGTaskScheduler.sharedScheduler
+        scheduler.registerForTaskWithIdentifier(DRAIN_TASK_ID, null) { task -> onDrainTask(task as? BGProcessingTask) }
+        scheduler.registerForTaskWithIdentifier(MAINTENANCE_TASK_ID, null) { task ->
+            onMaintenanceTask(task as? BGProcessingTask)
+        }
+    }
+
+    /**
+     * Called once the app is on screen — the iOS counterpart of what the Android `NodysseyApp` does
+     * in `onCreate`: schedule the daily sweep, and pick up a queue left behind by a past run, since
+     * iOS keeps no persisted one-time work the way WorkManager does.
+     */
+    fun onLaunch() {
+        ensureMaintenance()
+        scope.launch {
+            val library = container()?.offlineLibrary ?: return@launch
+            val downloads = library as? OfflineDownloads ?: return@launch
+            if (downloads.hasQueuedWork()) startDrain(library.settings.first().wifiOnly)
+        }
+    }
+
+    override fun startDrain(
+        wifiOnly: Boolean,
+        restart: Boolean,
+    ) {
+        scope.launch {
+            if (restart) {
+                foregroundDrain?.cancel()
+                foregroundDrain = null
+            }
+            if (foregroundDrain?.isActive != true) {
+                foregroundDrain =
+                    scope.launch {
+                        if (networkAllows(wifiOnly)) {
+                            (container()?.offlineLibrary as? OfflineDownloads)?.drainQueue()
+                        }
+                    }
+            }
+        }
+        // A background continuation in case the foreground run is cut off by the app leaving the
+        // screen. requiresNetworkConnectivity only; the Wi-Fi rule is re-checked in the handler.
+        submit(BGProcessingTaskRequest(DRAIN_TASK_ID).apply { requiresNetworkConnectivity = true })
+    }
+
+    override fun ensureMaintenance() {
+        submit(
+            BGProcessingTaskRequest(MAINTENANCE_TASK_ID).apply {
+                requiresNetworkConnectivity = true
+                earliestBeginDate = NSDate.dateWithTimeIntervalSinceNow(MAINTENANCE_INTERVAL_SECONDS)
+            },
+        )
+    }
+
+    // --- background handlers ---------------------------------------------------------------------
+
+    private fun onDrainTask(task: BGProcessingTask?) {
+        task ?: return
+        // Chain the next run before working: a queue bigger than one window's budget then continues
+        // rather than stalling until the app is next opened.
+        submit(BGProcessingTaskRequest(DRAIN_TASK_ID).apply { requiresNetworkConnectivity = true })
+        runBackgroundTask(task) {
+            val library = container()?.offlineLibrary ?: return@runBackgroundTask true
+            val downloads = library as? OfflineDownloads ?: return@runBackgroundTask true
+            // On cellular with 仅 Wi-Fi 下载 on: nothing to do now, and reporting success keeps the
+            // system's opinion of this task healthy. The chained request above tries again later.
+            if (!networkAllows(library.settings.first().wifiOnly)) {
+                true
+            } else {
+                downloads.drainQueue() == DrainOutcome.DRAINED
+            }
+        }
+    }
+
+    private fun onMaintenanceTask(task: BGProcessingTask?) {
+        task ?: return
+        ensureMaintenance() // reschedule tomorrow's sweep
+        runBackgroundTask(task) {
+            val graph = container() ?: return@runBackgroundTask true
+            val library = graph.offlineLibrary
+            val downloads = library as? OfflineDownloads ?: return@runBackgroundTask true
+            runOfflineMaintenance(
+                library,
+                downloads,
+                graph.sessionRepository,
+                graph.userSpaceRepository,
+            ) == MaintenanceOutcome.COMPLETED
+        }
+    }
+
+    /**
+     * Runs one background task's work and closes it out exactly once.
+     *
+     * `invokeOnCompletion` rather than a call at the end of the coroutine because the expiration
+     * handler can cancel the job mid-drain: routing both the normal finish and the cancellation
+     * through completion means `setTaskCompletedWithSuccess` is called once either way, with `false`
+     * when the system pulled the budget out from under it.
+     */
+    private fun runBackgroundTask(
+        task: BGTask,
+        work: suspend () -> Boolean,
+    ) {
+        var success = false
+        val job = scope.launch { success = work() }
+        job.invokeOnCompletion { cause -> task.setTaskCompletedWithSuccess(cause == null && success) }
+        task.expirationHandler = { job.cancel() }
+    }
+
+    private fun submit(request: BGProcessingTaskRequest) {
+        request.requiresExternalPower = false
+        // `error = null` drops the reason: submit fails on the Simulator (BGTaskScheduler is
+        // unavailable there) and when the system declines to queue more, and neither is worth
+        // surfacing — the foreground drain is what moves bytes, this only asks iOS to keep going off
+        // screen. The `try` guards the ObjC exception the call can still raise for a bad identifier.
+        try {
+            BGTaskScheduler.sharedScheduler.submitTaskRequest(request, error = null)
+        } catch (t: Throwable) {
+            // See above: a refused background request never blocks the reader.
+        }
+    }
+
+    // --- the Wi-Fi gate --------------------------------------------------------------------------
+
+    private suspend fun networkAllows(wifiOnly: Boolean): Boolean = !wifiOnly || onWifi()
+
+    /**
+     * Whether the current default path runs over Wi-Fi.
+     *
+     * `NWPathMonitor` fires its update handler once with the current path as soon as it starts, so a
+     * one-shot read is a matter of taking that first callback and cancelling. Off Wi-Fi — cellular,
+     * or no network at all — this is false, and a Wi-Fi-only drain then waits, which for a device
+     * with nothing downloadable to reach is also the right answer.
+     */
+    private suspend fun onWifi(): Boolean =
+        suspendCancellableCoroutine { continuation ->
+            val monitor =
+                nw_path_monitor_create() ?: run {
+                    continuation.resume(false)
+                    return@suspendCancellableCoroutine
+                }
+            nw_path_monitor_set_update_handler(monitor) { path ->
+                val wifi = path != null && nw_path_uses_interface_type(path, nw_interface_type_wifi)
+                nw_path_monitor_cancel(monitor)
+                if (continuation.isActive) continuation.resume(wifi)
+            }
+            nw_path_monitor_set_queue(monitor, dispatch_queue_create("io.github.nodyssey.offline.path", null))
+            continuation.invokeOnCancellation { nw_path_monitor_cancel(monitor) }
+            nw_path_monitor_start(monitor)
+        }
+
+    private companion object {
+        /** Both must appear in `Info.plist`'s `BGTaskSchedulerPermittedIdentifiers`, or submit throws. */
+        const val DRAIN_TASK_ID = "io.github.nodyssey.offline.drain"
+        const val MAINTENANCE_TASK_ID = "io.github.nodyssey.offline.maintenance"
+
+        /** A day, like the Android periodic sweep. iOS treats it as "no earlier than", not "exactly". */
+        const val MAINTENANCE_INTERVAL_SECONDS = 24.0 * 60.0 * 60.0
+    }
+}

--- a/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/IosAppContainer.kt
+++ b/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/IosAppContainer.kt
@@ -62,6 +62,7 @@ import io.github.nodyssey.data.imagehost.DefaultImageHostRepository
 import io.github.nodyssey.data.imagehost.ImageHostRepository
 import io.github.nodyssey.data.local.createNodeSeekDatabase
 import io.github.nodyssey.data.offline.OfflineSettingsStore
+import io.github.nodyssey.data.offline.OfflineWorkScheduler
 import io.github.nodyssey.data.offline.RoomOfflineLibrary
 import io.github.nodyssey.data.offline.UrlSessionOfflineImageSource
 import io.github.nodyssey.data.proxy.DataStoreProxySettings
@@ -121,9 +122,14 @@ import platform.Foundation.NSURLSession
  *
  * @param userAgent resolved before the graph is built — see [NodysseyApp] and `resolveWebKitUserAgent`
  *   for why it cannot be read synchronously and must not be guessed at.
+ * @param offlineScheduler passed in rather than built here because it is registered with
+ *   `BGTaskScheduler` before this graph exists — see [NodysseyApp.registerBackgroundTasks]. Its own
+ *   handlers close back over the container through the same lazy resolver, so one instance serves
+ *   both the engine that queues work and the tasks that drain it.
  */
 class IosAppContainer(
     override val userAgent: UserAgent,
+    private val offlineScheduler: OfflineWorkScheduler,
     override val dispatchers: AppDispatchers = AppDispatchers(),
     override val clock: AppClock = AppClock.System,
 ) : AppContainer {
@@ -335,7 +341,7 @@ class IosAppContainer(
             images = UrlSessionOfflineImageSource { urlSession },
             collectedMeta = collectedPostMetaStore,
             settingsStore = OfflineSettingsStore(createPreferenceDataStore("offline")),
-            scheduler = NoOfflineWorkScheduler,
+            scheduler = offlineScheduler,
             clock = clock,
             dispatchers = dispatchers,
         )

--- a/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/NodysseyApp.kt
+++ b/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/NodysseyApp.kt
@@ -47,8 +47,31 @@ import platform.UIKit.UIViewController
 object NodysseyApp {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
+    /**
+     * The graph, and the one thing every path here shares. Split from [root] because a background
+     * task can need it without any window: `BGTaskScheduler` may relaunch this app straight into the
+     * background, where no scene connects and so [start] is never called, yet the drain still has to
+     * find a container. [ensureContainer] builds it for whichever gets here first.
+     */
+    private var container: IosAppContainer? = null
+    private var containerBuild: Deferred<IosAppContainer>? = null
+
     private var root: UIViewController? = null
-    private var building: Deferred<UIViewController>? = null
+    private var controllerBuild: Deferred<UIViewController>? = null
+
+    /**
+     * Owned here, not in the container, because [register] has to run before the graph exists —
+     * `BGTaskScheduler` launch handlers must be installed before the app finishes launching. Its
+     * resolver closes back over [ensureContainer], so the one instance both queues work (through the
+     * container) and drains it (through its handlers).
+     */
+    private val offlineScheduler = BgTaskOfflineScheduler(scope) { ensureContainer() }
+
+    /**
+     * Called from `AppDelegate.application(_:didFinishLaunchingWithOptions:)`, and it must be: iOS
+     * traps if a `BGTaskScheduler` handler is registered after launch completes.
+     */
+    fun registerBackgroundTasks() = offlineScheduler.register()
 
     fun start(onReady: (UIViewController) -> Unit) {
         root?.let {
@@ -56,34 +79,56 @@ object NodysseyApp {
             return
         }
         // The build, not a flag saying one is under way. Re-checking `root` inside the coroutine was
-        // not enough and could not be: [resolveWebKitUserAgent] suspends, and two `willConnectTo`
+        // not enough and could not be: [ensureContainer] suspends on WebKit, and two `willConnectTo`
         // calls before the first answer arrives both get past *any* check made before that point.
-        // The second one would then build a second container over the same Room database and the same
-        // six DataStore files — the corruption this object's KDoc is about — and hand the window a
-        // second controller with an empty back stack. Awaiting one `Deferred` is what makes the
-        // second caller a listener rather than a builder.
+        // Awaiting one `Deferred` is what makes the second caller a listener rather than a builder.
         //
         // No lock, and none needed: `start` is called from `scene(_:willConnectTo:)`, which is the
         // main thread, and this scope dispatches to the main thread — so the read and the write below
-        // cannot interleave with another call's.
-        val pending = building ?: scope.async { build() }.also { building = it }
+        // cannot interleave with another call's. The same holds for [ensureContainer]'s own guard.
+        val pending = controllerBuild ?: scope.async { buildController() }.also { controllerBuild = it }
         scope.launch { onReady(pending.await()) }
     }
 
-    private suspend fun build(): UIViewController {
-        val graph = IosAppContainer(userAgent = resolveWebKitUserAgent(NodeSeekSite.CONFIG))
+    /**
+     * The graph, built once per process and shared by the UI and the background tasks.
+     *
+     * A second instance over the same Room database and six DataStore files is not a duplicate, it is
+     * a corruption — DataStore raises `IllegalStateException` the moment two serve one file — so this
+     * awaits a single `Deferred` exactly as [start] does, and for the same reason.
+     */
+    suspend fun ensureContainer(): IosAppContainer {
+        container?.let { return it }
+        val pending = containerBuild ?: scope.async { buildContainer() }.also { containerBuild = it }
+        return pending.await()
+    }
 
+    private suspend fun buildContainer(): IosAppContainer {
+        // The `User-Agent` has to be the one WebKit sends, or a `cf_clearance` earned in the sign-in
+        // browser is rejected on the next API call, and WebKit will only say so asynchronously — so
+        // the graph is built after that answer rather than around a guess. See `resolveWebKitUserAgent`.
+        val graph =
+            IosAppContainer(
+                userAgent = resolveWebKitUserAgent(NodeSeekSite.CONFIG),
+                offlineScheduler = offlineScheduler,
+            )
         // Set before the first composition asks for an image, and once: `setSafe` is a no-op if
         // something already installed a loader, which is what makes a second call harmless.
         SingletonImageLoader.setSafe { context -> imageLoader(context, graph) }
+        container = graph
+        containerBuild = null
+        return graph
+    }
 
+    private suspend fun buildController(): UIViewController {
+        val graph = ensureContainer()
         val controller =
             ComposeUIViewController {
                 NodysseyRoot(
                     container = graph,
                     // No notification extra and no deep link to read yet: both arrive through
-                    // `UIApplicationDelegate`, and neither has an iOS half — the poll worker is
-                    // step D4 and Universal Links have no association file. See
+                    // `UIApplicationDelegate`, and neither has an iOS half — the poll worker has no
+                    // iOS counterpart and Universal Links have no association file. See
                     // `AppLinkHandling.ios.kt`.
                     initialTab = TopLevelDestination.HOME,
                     launchRequest = null,
@@ -92,7 +137,10 @@ object NodysseyApp {
             }
         root = controller
         // Nothing left to await; the fast path above answers from here on.
-        building = null
+        controllerBuild = null
+        // On screen now: schedule the daily sweep and resume any queue a past run left behind — the
+        // iOS counterpart of what the Android `NodysseyApp` does in `onCreate`.
+        offlineScheduler.onLaunch()
         return controller
     }
 

--- a/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/Unavailable.kt
+++ b/iosapp/src/iosMain/kotlin/io/github/nodyssey/ios/Unavailable.kt
@@ -1,6 +1,5 @@
 package io.github.nodyssey.ios
 
-import io.github.nodyssey.data.offline.OfflineWorkScheduler
 import io.github.nodyssey.data.update.AppUpdateRepository
 import io.github.plaza.core.update.ApkInstaller
 import io.github.plaza.core.update.AppRelease
@@ -14,18 +13,14 @@ import kotlinx.coroutines.flow.StateFlow
  * What this shell declines to do, gathered in one file so the list reads as a list.
  *
  * Every one of these is a member of `AppContainer`: a screen names it, so something has to be there
- * for the graph to assemble at all. They fall into two groups, and the difference matters when
- * reading this as a to-do list, because only one of the two is one.
+ * for the graph to assemble at all. What is left here is not a gap — sideloading an APK and checking
+ * GitHub for a newer build are Android's answer to a question this platform answers differently:
+ * software arrives from the App Store. There is nothing here to implement later.
  *
- *   - **Not a gap.** Sideloading an APK and checking GitHub for a newer build are Android's answer to
- *     a question this platform answers differently: software arrives from the App Store. There is
- *     nothing here to implement later.
- *   - **A gap, and it is named.** Background download scheduling is step D4's `BGTaskScheduler`, and
- *     it is recorded in `docs/kmp-migration-plan.md`.
- *
- * There were four of these when this shell first ran. The image-host upload was the third, and it is
- * gone: step D3c moved the six clients into `commonMain` and gave `HttpTransport` the upload-progress
- * callback that had kept them out. `IosAppContainer` builds the real repository now.
+ * The list has only shrunk. The image-host upload went in step D3c, which moved the six clients into
+ * `commonMain` and gave `HttpTransport` the upload-progress callback that had kept them out; the
+ * background download scheduler went in step D4 — see `BgTaskOfflineScheduler`, the `BGTaskScheduler`
+ * that WorkManager was mapped to. `IosAppContainer` builds both for real now.
  *
  * Nothing here throws where a button leads to it. A `TODO()` would be a crash waiting for the first
  * person to press one, and what is behind these is *nothing* rather than something broken.
@@ -67,17 +62,4 @@ internal object NoAppUpdates : AppUpdateRepository {
     override suspend fun releaseNotes(force: Boolean): List<ReleaseNote> = emptyList()
 
     override fun onInstallOutcome(outcome: InstallOutcome) = Unit
-}
-
-/**
- * Background downloads are step D4's — `WorkManager` → `BGTaskScheduler`.
- *
- * Declining here does not turn 离线阅读 off: `RoomOfflineLibrary` drains its own queue while the app is
- * running and only asks the scheduler to keep going once it is not. What is missing is the keeping
- * going, which is what D4 is.
- */
-internal object NoOfflineWorkScheduler : OfflineWorkScheduler {
-    override fun startDrain(wifiOnly: Boolean, restart: Boolean) = Unit
-
-    override fun ensureMaintenance() = Unit
 }

--- a/shared/src/commonMain/kotlin/io/github/nodyssey/data/offline/OfflineDownloads.kt
+++ b/shared/src/commonMain/kotlin/io/github/nodyssey/data/offline/OfflineDownloads.kt
@@ -4,9 +4,10 @@ package io.github.nodyssey.data.offline
  * The half of the offline library its background workers drive.
  *
  * Apart from `OfflineLibrary` because the two have different callers: that one is what 收藏 manages
- * downloads through, this is what WorkManager calls and nothing on any screen ever does. A worker
- * looks for it with a cast — the library that ships when offline reading is unavailable does not
- * implement it, and a worker that finds nothing to drive simply finishes.
+ * downloads through, this is what the background scheduler calls — WorkManager on Android,
+ * `BGTaskScheduler` on iOS — and nothing on any screen ever does. A worker looks for it with a cast:
+ * the library that ships when offline reading is unavailable does not implement it, and a worker that
+ * finds nothing to drive simply finishes.
  */
 interface OfflineDownloads {
     /** True when something is queued — what tells a woken worker whether it has a job at all. */
@@ -35,11 +36,26 @@ enum class DrainOutcome {
 }
 
 /**
- * When downloads run. Implemented over WorkManager; an interface so the engine stays testable.
+ * Whether the daily sweep should be tried again — [runOfflineMaintenance]'s answer.
+ *
+ * The same distinction [DrainOutcome] draws, for the same reason: a run the site could not be reached
+ * for is a retry, everything else is done. Each platform maps this to its own scheduler's vocabulary
+ * — `Result.retry()` on Android, `setTaskCompleted(success: false)` on iOS.
+ */
+enum class MaintenanceOutcome {
+    COMPLETED,
+    NETWORK_FAILED,
+}
+
+/**
+ * When downloads run. Implemented over WorkManager on Android and `BGTaskScheduler` on iOS; an
+ * interface so the engine stays testable and platform-blind.
  *
  * The engine says *that* there is work, never *when* to do it: 仅 Wi-Fi 下载 is a constraint the
  * platform enforces, and a queue that waited on its own timer would be a second, worse scheduler
- * running beside the one the system already has.
+ * running beside the one the system already has. (Where the platform has no unmetered constraint —
+ * iOS — the implementation enforces the Wi-Fi rule itself; that stays the scheduler's problem, not
+ * the engine's.)
  */
 interface OfflineWorkScheduler {
     /**

--- a/shared/src/commonMain/kotlin/io/github/nodyssey/data/offline/OfflineMaintenance.kt
+++ b/shared/src/commonMain/kotlin/io/github/nodyssey/data/offline/OfflineMaintenance.kt
@@ -1,0 +1,57 @@
+package io.github.nodyssey.data.offline
+
+import io.github.nodyssey.data.OfflineLibrary
+import io.github.nodyssey.data.UserSpaceRepository
+import io.github.nodyssey.data.session.SessionRepository
+import io.github.plaza.core.net.SiteError
+import io.github.plaza.core.net.SiteException
+import kotlinx.coroutines.flow.first
+
+/**
+ * The daily housekeeping, once — 离线内容保留 and 自动补新回复 — with nothing platform-specific in it.
+ *
+ * It lived in `:app`'s `OfflineMaintenanceWorker` while iOS had no scheduler at all. It is here now
+ * because the errand is the same on both platforms and only the trigger differs: WorkManager runs it
+ * once a day on Android, `BGTaskScheduler` does on iOS, and both call this. Duplicating it would be
+ * two copies of the same 20-page walk, the same signed-out short-circuit and the same
+ * network-vs-anything-else retry rule — a place for the two to drift.
+ *
+ * The sweep runs unconditionally; the sync is skipped unless 自动补新回复 is on and someone is signed
+ * in, because collections are the account's own list and asking for them signed out is a request that
+ * can only be refused.
+ */
+suspend fun runOfflineMaintenance(
+    library: OfflineLibrary,
+    downloads: OfflineDownloads,
+    sessionRepository: SessionRepository,
+    userSpaceRepository: UserSpaceRepository,
+): MaintenanceOutcome {
+    downloads.sweepExpired()
+
+    if (!library.settings.first().autoSyncReplies) return MaintenanceOutcome.COMPLETED
+    if (!sessionRepository.peek().isSignedIn) return MaintenanceOutcome.COMPLETED
+
+    val counts = mutableMapOf<Long, Int>()
+    var page = 1
+    while (page <= MAX_COLLECTION_PAGES) {
+        val result =
+            try {
+                userSpaceRepository.collections(page)
+            } catch (e: SiteException) {
+                // Same rule as the drain and 通知轮询: only a transport failure is worth another run.
+                // A challenge page answered with more background requests is what the challenge is for.
+                return if (e.error is SiteError.Network) MaintenanceOutcome.NETWORK_FAILED else MaintenanceOutcome.COMPLETED
+            }
+        result.items.forEach { post -> post.commentCount?.let { counts[post.postId] = it } }
+        if (!result.hasNextPage || result.items.isEmpty()) break
+        page++
+    }
+    library.noteReplyCounts(counts)
+
+    val stale = downloads.staleIds()
+    if (stale.isNotEmpty()) library.download(stale)
+    return MaintenanceOutcome.COMPLETED
+}
+
+/** The same bound 收藏 walks the list under, and for the same reason: it exists. */
+private const val MAX_COLLECTION_PAGES = 20


### PR DESCRIPTION
KMP 迁移计划 D4 —— WorkManager → `BGTaskScheduler` 的 iOS 落地。

## 背景
iOS 侧 `OfflineWorkScheduler` 一直是空壳（`NoOfflineWorkScheduler`），而离线队列**只经调度器触发下载**。所以现状不是文档说的「前台能抽干、只差后台续跑」——iOS 上前台也从来没抽干过队列。计划里那句「`RoomOfflineLibrary` 在前台自己抽干」其实是 Android 上 WorkManager 的功劳。D4 在 iOS 补齐整套：前台抽干 + 后台续跑 + 每日维护。

## 改了什么
- **`BgTaskOfflineScheduler`（新）**：`startDrain` 立刻在前台起 drain 协程，同时提交 `BGProcessingTaskRequest` 让系统在应用离屏后继续；`ensureMaintenance` 提交每日维护；`register()` 装 handler；`onLaunch()` 对齐 Android 启动时的排期与「有残留队列就续跑」。
- **`runOfflineMaintenance`（新，commonMain）**：把每日维护（保留期清理 + 自动补新回复的 20 页遍历）从 Android worker 提到共享层，两端共用，避免逻辑各写一遍漂移。Android `OfflineMaintenanceWorker` 改成调它。
- **container 单例化**（`NodysseyApp`）：拆出 `ensureContainer()`，后台冷启动（无 scene 连接）也能拿到同一个图，避免第二个实例撞同一 Room / 六个 DataStore 文件。
- **接线**：`IosAppContainer` 注入真调度器、删掉 `NoOfflineWorkScheduler`；`App.swift` 在 `didFinishLaunching` 注册 handler（必须在启动完成前，否则 iOS trap）；`Info.plist` 声明两个 task id + `processing` 后台模式。

## 两处平台差异（iOS 固有，非取舍）
- **「仅 Wi-Fi 下载」不能当请求约束**：`BGProcessingTaskRequest` 只有 `requiresNetworkConnectivity`（有网即可），没有 WorkManager 的 `UNMETERED`。改在 drain 里用 `NWPathMonitor` 现查，蜂窝上且开关开着就不跑、等下次——等价于 WorkManager 的「等 Wi-Fi」。
- **模拟器上 `BGTaskScheduler` 不可用**：`submit` 静默失败，前台 drain 仍工作（模拟器上真正搬字节的就是它），后台续跑只在真机生效。

## 验证
- Android：`:app` 全量单测 + `assembleDebug` + `lintDebug` 全绿
- iOS：`iosArm64` / `iosSimulatorArm64` 均编过
- `spotlessCheck` 绿
- 后台任务本身需真机 + 系统调度，无法单测，留待真机验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)