### PR TITLE
缓存策略测试不再跟着真实日期一起过期

### DIFF
--- a/designsys/src/androidHostTest/kotlin/io/github/plaza/designsys/image/LongLivedImageCacheStrategyTest.kt
+++ b/designsys/src/androidHostTest/kotlin/io/github/plaza/designsys/image/LongLivedImageCacheStrategyTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
 
 /**
  * Asked against the real [CacheControlCacheStrategy] rather than a stand-in, because the claim being
@@ -28,9 +29,16 @@ class LongLivedImageCacheStrategyTest {
     private val context: PlatformContext = ApplicationProvider.getApplicationContext()
     private val options = Options(context)
 
+    /**
+     * The delegate reads a clock to decide freshness, and is handed one stopped at [NOW] rather than
+     * the machine's. Otherwise a fixture written as an absolute instant is fresh until the real date
+     * catches up with it and stale on every run after that.
+     */
+    private fun cacheControl() = CacheControlCacheStrategy(now = { Instant.fromEpochMilliseconds(NOW) })
+
     private val strategy =
         LongLivedImageCacheStrategy(
-            delegate = CacheControlCacheStrategy(),
+            delegate = cacheControl(),
             isLongLived = { url -> url.startsWith("$SITE/avatar/") },
         )
 
@@ -74,7 +82,7 @@ class LongLivedImageCacheStrategyTest {
         runTest {
             val asServed = served(NOW - 5.hours.inWholeMilliseconds)
 
-            val baseline = CacheControlCacheStrategy().read(asServed, NetworkRequest(AVATAR), options)
+            val baseline = cacheControl().read(asServed, NetworkRequest(AVATAR), options)
             assertNull("the site's own answer sends this one back to the server", baseline.response)
 
             val stored = requireNotNull(strategy.write(null, NetworkRequest(AVATAR), asServed, options).response)
@@ -99,7 +107,10 @@ class LongLivedImageCacheStrategyTest {
         const val AVATAR = "$SITE/avatar/52425.png"
         const val ATTACHMENT = "https://img.example.test/photo.png"
 
-        /** Fixed rather than read off the clock: the arithmetic under test is about elapsed time. */
+        /**
+         * Fixed rather than read off the clock: the arithmetic under test is about elapsed time. Only
+         * safe to fix because [cacheControl] is told to read the same instant back.
+         */
         const val NOW = 1_787_000_000_000L
     }
 }


### PR DESCRIPTION
## 问题

`LongLivedImageCacheStrategyTest` 里的 `NOW` 是个写死的绝对时刻（`1_787_000_000_000`，2026-08-17 20:53 UTC），而 `CacheControlCacheStrategy` 判新鲜与否读的是机器上的**真时钟**。于是「五小时前存下的头像」这个 fixture 的七天 `max-age=604800` 是从写死那一刻起算的，2026-08-24 15:53 UTC 一到就自己过期。

从那天起，`a five hour old avatar is served from disk instead of asked about` 在**每台机器上每次运行**都挂——不是 flaky，是真过期。`testAndroidHostTest` 是 `.github/workflows/ci.yml` 的一道门，所以整条 CI 从那天起就是红的。

## 改法

把时钟交给测试，而不是让测试去追时钟。Coil 的 `CacheControlCacheStrategy` 本来就收一个公开的 `now: () -> Instant`（3.5.0 的 aar 里确认过），让它读回 `NOW` 即可：

```kotlin
private fun cacheControl() = CacheControlCacheStrategy(now = { Instant.fromEpochMilliseconds(NOW) })
```

`strategy` 的 delegate 和第三个测试里那个 baseline 都走这个工厂方法。

`NOW` 保持字面量不动。被测的算术本来就是「过了多久」，换成 `System.currentTimeMillis()` 也能修，但那只是让 fixture 跟着墙上时钟漂；停表才是让这个类彻底不关心哪天跑。

**生产代码一行没动**，`NodysseyApp.kt` 和 `IosImageLoader.kt` 照旧用无参构造。

## Reviewer 需要知道的

同一个类里的 `a five hour old attachment still goes back to the server` 之前是**因为断言方向刚好相反**才绿着——不一起修的话，它会开始为错误的理由通过。现在它是因为五小时确实超过了站点自己的 `max-age=14400` 才通过。

## 验证

- `./gradlew :designsys:testAndroidHostTest spotlessCheck` 绿，`tests="4" failures="0"`。
- **确认原文件今天确实在挂**：`git checkout` 回原版跑，那条 FAILED（跑测试时机器是 16:27 UTC，过线 34 分钟）。绿不是改出来的错觉。
- **确认时钟真接进去了**：把冻结点挪到发出响应那一刻（age 0）重跑，头像那条和 attachment 那条**两个一起翻红**——说明这两条断言是被时钟驱动的，不是空跑绿。另外两条只断言 write 阶段的 header，与时钟无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)