### PR TITLE
二轮体检修复：补齐 58 个漏译键并加守卫，冷启动不再闪设备语言

### DIFF
--- a/designsys/src/commonMain/composeResources/values-en/strings.xml
+++ b/designsys/src/commonMain/composeResources/values-en/strings.xml
@@ -45,6 +45,7 @@
     <string name="richtext_action_copy">Copy</string>
     <string name="richtext_quote_reply">@%1$s %2$s</string>
     <string name="richtext_sticker_description">Sticker</string>
+    <string name="richtext_sticker_fallback">[Sticker]</string>
     <string name="richtext_image_skipped_title">Load images on Wi-Fi only is on, and this is not Wi-Fi</string>
     <string name="richtext_image_skipped_action">Tap to load this image</string>
     <string name="richtext_poll_title">Poll</string>

--- a/ui/src/androidHostTest/kotlin/io/github/nodyssey/guard/StringCatalogParityTest.kt
+++ b/ui/src/androidHostTest/kotlin/io/github/nodyssey/guard/StringCatalogParityTest.kt
@@ -1,0 +1,203 @@
+package io.github.nodyssey.guard
+
+import org.junit.Assert.fail
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * That every locale catalog carries a translation for every key — or a written reason not to.
+ *
+ * `values/strings.xml` is the Simplified Chinese original, and a key absent from a locale silently
+ * falls back to it. The header of `values-en` promises that every absence is deliberate: a string
+ * that reads the same in every language — a format that is only punctuation, a proper noun, the
+ * app's own name. Nothing enforced that promise, and the first pair of parallel branches broke it:
+ * 网络自检 merged first, the translation pass merged second, and the whole screen shipped in
+ * Chinese to a reader who had chosen English. This test is that header sentence made checkable.
+ *
+ * The lists below are exact, in both directions, for the reason the literal ratchet's counts are:
+ * a key missing a translation must either get one or be added here as a deliberate act, and a
+ * listed key that later gains a translation (or leaves the default catalog) must be struck off, so
+ * the list never accretes room for a regression to hide in.
+ *
+ * The placeholder check rides along because it is the other way a catalog lies: a translation that
+ * drops or renumbers a `%1$s` compiles fine and breaks at render time, in one language only.
+ */
+class StringCatalogParityTest {
+    @Test
+    fun `every key is translated in every locale, minus the declared identical ones`() {
+        val root = repositoryRoot()
+        val problems = buildString {
+            for ((module, locales) in CATALOGS) {
+                val values = File(root, "$module/src/commonMain/composeResources")
+                val base = parseCatalog(File(values, "values/strings.xml"))
+                check(base.isNotEmpty()) { "no strings parsed from $module/values — the guard is checking nothing" }
+                for ((locale, allowedAbsent) in locales) {
+                    val translated = parseCatalog(File(values, "$locale/strings.xml"))
+                    val orphans = translated.keys - base.keys
+                    if (orphans.isNotEmpty()) {
+                        appendLine("$module/$locale has keys the default catalog does not: ${orphans.sorted()}")
+                    }
+                    val missing = base.keys - translated.keys
+                    val untranslated = missing - allowedAbsent
+                    if (untranslated.isNotEmpty()) {
+                        appendLine("$module/$locale is missing translations (translate them, or declare them identical here):")
+                        untranslated.sorted().forEach { appendLine("  $it = ${base[it]}") }
+                    }
+                    val stale = allowedAbsent - missing
+                    if (stale.isNotEmpty()) {
+                        appendLine("$module/$locale allowlist entries that are translated or gone — strike them off: ${stale.sorted()}")
+                    }
+                }
+            }
+        }
+        if (problems.isNotEmpty()) fail(problems)
+    }
+
+    @Test
+    fun `translations keep the placeholders of the original`() {
+        val root = repositoryRoot()
+        val problems = buildString {
+            for ((module, locales) in CATALOGS) {
+                val values = File(root, "$module/src/commonMain/composeResources")
+                val base = parseCatalog(File(values, "values/strings.xml"))
+                for ((locale, _) in locales) {
+                    val translated = parseCatalog(File(values, "$locale/strings.xml"))
+                    for ((key, text) in translated) {
+                        val expected = placeholders(base[key] ?: continue)
+                        val actual = placeholders(text)
+                        if (expected != actual) {
+                            appendLine("$module/$locale/$key: placeholders $actual, but the original has $expected")
+                        }
+                    }
+                }
+            }
+        }
+        if (problems.isNotEmpty()) fail(problems)
+    }
+
+    private fun parseCatalog(file: File): Map<String, String> {
+        val strings = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file).getElementsByTagName("string")
+        return buildMap {
+            for (i in 0 until strings.length) {
+                val element = strings.item(i) as Element
+                put(element.getAttribute("name"), element.textContent)
+            }
+        }
+    }
+
+    private fun placeholders(text: String): List<String> =
+        PLACEHOLDER.findAll(text).map { it.value }.sorted().toList()
+
+    private companion object {
+        val PLACEHOLDER = Regex("""%\d+\$[a-z]""")
+
+        /**
+         * Keys that read the same in every language, so a translation would only be a copy to
+         * drift: formats that are all punctuation, unit strings, brand and proper nouns, URL and
+         * config placeholders. The three language names are here for the opposite reason — each is
+         * deliberately in its own language, the way every language picker names its entries.
+         */
+        val SAME_IN_EVERY_LANGUAGE = setOf(
+            "about_deepflood",
+            "account_bio",
+            "account_readme",
+            "account_telegram_section",
+            "account_value_unknown",
+            "app_name",
+            "assets_board_gain",
+            "assets_level",
+            "assets_quota_value",
+            "assets_quota_value_unknown",
+            "composer_app_menu",
+            "composer_emoji_group_fluent",
+            "composer_image_failed_reason",
+            "composer_permission_level",
+            "composer_title_count",
+            "credit_level",
+            "doh_provider_cloudflare",
+            "doh_provider_dnspod",
+            "doh_provider_google",
+            "doh_url_placeholder",
+            "imagehost_api_token_label",
+            "imagehost_custom_file_field_placeholder",
+            "imagehost_custom_form_fields_placeholder",
+            "imagehost_custom_header_name_placeholder",
+            "imagehost_custom_header_value_placeholder",
+            "imagehost_custom_url_path_placeholder",
+            "imagehost_custom_url_prefix_placeholder",
+            "imagehost_key_label",
+            "imagehost_site_placeholder",
+            "imagehost_upload_url_placeholder",
+            "ledger_amount_gain",
+            "ledger_amount_spend",
+            "message_markdown_label",
+            "message_thread_subtitle",
+            "message_thread_subtitle_level",
+            "network_check_download_value",
+            "network_check_pending",
+            "network_check_status_code",
+            "network_check_transport_wifi",
+            "network_check_vpn",
+            "notification_time_pair",
+            "offline_state_percent",
+            "page_jump_of_total",
+            "post_badge_more",
+            "post_quote_prefix",
+            "post_quote_reply",
+            "profile_level_unknown",
+            "profile_member_uid",
+            "proxy_port_placeholder",
+            "proxy_type_http",
+            "proxy_type_socks",
+            "ruling_action_none",
+            "ruling_meta_no_moderator",
+            "settings_body_size_value",
+            "settings_language_en",
+            "settings_language_zh_hans",
+            "settings_language_zh_hant",
+            "settings_sticker_size_value",
+            "settings_version",
+            "sign_in_mark",
+            "sign_in_verify_brand",
+            "space_bio",
+            "space_readme",
+            "space_uid",
+            "space_uid_bio",
+            "stardust_compose_ref",
+            "stardust_entry_peer",
+            "stardust_entry_ref",
+            "stardust_receive_confirm_ref_label",
+            "transfer_balance_change",
+            "transfer_ref",
+            "unread_count_capped",
+            "viewer_page",
+            "vote_percent",
+        )
+
+        /**
+         * Keys whose Simplified original is already Traditional-correct — grammar glue whose
+         * characters do not differ between the scripts, and one proper noun — so `values-zh-rTW`
+         * alone may fall back to it.
+         */
+        val SAME_IN_TRADITIONAL = setOf(
+            "composer_emoji_group_acn",
+            "doh_test_result",
+            "ruling_reason",
+            "ruling_target_kind",
+        )
+
+        /** module → (locale directory → keys allowed to be absent from it). */
+        val CATALOGS = mapOf(
+            "ui" to mapOf(
+                "values-en" to SAME_IN_EVERY_LANGUAGE,
+                "values-zh-rTW" to SAME_IN_EVERY_LANGUAGE + SAME_IN_TRADITIONAL,
+            ),
+            "designsys" to mapOf(
+                "values-en" to emptySet(),
+                "values-zh-rTW" to setOf("richtext_sticker_fallback"),
+            ),
+        )
+    }
+}

--- a/ui/src/androidHostTest/kotlin/io/github/nodyssey/ui/settings/AppLanguageRecompositionTest.kt
+++ b/ui/src/androidHostTest/kotlin/io/github/nodyssey/ui/settings/AppLanguageRecompositionTest.kt
@@ -1,5 +1,6 @@
 package io.github.nodyssey.ui.settings
 
+import android.os.LocaleList
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
@@ -16,6 +17,7 @@ import io.github.nodyssey.data.settings.AppLanguage
 import io.github.nodyssey.ui.resources.Res
 import io.github.nodyssey.ui.resources.settings_language
 import org.jetbrains.compose.resources.stringResource
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -53,6 +55,26 @@ class AppLanguageRecompositionTest {
         composeRule.onNodeWithText("语言").assertIsDisplayed()
         composeRule.onNodeWithText(SWITCH).performClick()
         composeRule.onNodeWithText("Language").assertIsDisplayed()
+    }
+
+    /**
+     * The cold-start frames, where the settings store has not answered yet and the language on
+     * screen is whatever `attachBaseContext` already applied. Null must change nothing: not the
+     * strings, and not the process default that `Accept-Language` and the number formats read —
+     * substituting SYSTEM here is exactly the wrong-language flash the nullable exists to prevent.
+     */
+    @Test
+    fun `an unanswered store leaves the applied language alone`() {
+        val stored = LocaleList.forLanguageTags("en")
+        LocaleList.setDefault(stored)
+        composeRule.setContent {
+            ProvideAppLanguage(null) {
+                Text(stringResource(Res.string.settings_language))
+            }
+        }
+
+        composeRule.onNodeWithText("Language").assertIsDisplayed()
+        assertEquals(stored, LocaleList.getDefault())
     }
 
     private companion object {

--- a/ui/src/androidMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.android.kt
+++ b/ui/src/androidMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.android.kt
@@ -29,7 +29,7 @@ import io.github.nodyssey.data.settings.AppLanguage
  */
 @Composable
 actual fun ProvideAppLanguage(
-    language: AppLanguage,
+    language: AppLanguage?,
     content: @Composable () -> Unit,
 ) {
     // Derived from the configuration in force rather than from `context.resources.configuration`,
@@ -38,12 +38,20 @@ actual fun ProvideAppLanguage(
     // stale window size for as long as the language stayed put.
     val base = LocalConfiguration.current
     val configuration =
-        remember(language, base) {
-            val locales = AndroidAppLanguage.localesFor(language)
-            // In composition rather than an effect: an effect runs after the tree below has already
-            // resolved its strings, which would leave the first frame in the old language.
-            LocaleList.setDefault(locales)
-            Configuration(base).apply { setLocales(locales) }
+        if (language == null) {
+            // The store has not answered. `base` already carries the stored choice — `wrap` put it
+            // there before this composition existed — so passing it through untouched is what keeps
+            // the first frames in the right language. See the note on the expect.
+            base
+        } else {
+            remember(language, base) {
+                val locales = AndroidAppLanguage.localesFor(language)
+                // In composition rather than an effect: an effect runs after the tree below has
+                // already resolved its strings, which would leave the first frame in the old
+                // language.
+                LocaleList.setDefault(locales)
+                Configuration(base).apply { setLocales(locales) }
+            }
         }
     CompositionLocalProvider(LocalConfiguration provides configuration, content = content)
 }

--- a/ui/src/commonMain/composeResources/values-en/strings.xml
+++ b/ui/src/commonMain/composeResources/values-en/strings.xml
@@ -8,7 +8,8 @@
 
   A key absent here is not missing: it falls back to the Simplified entry, which is the right outcome
   for the handful that are the same in every language — a format string that is only punctuation, a
-  proper noun, the app's own name.
+  proper noun, the app's own name. `StringCatalogParityTest` holds this paragraph to its word: an
+  absence has to be declared there, or the build fails.
 
   No backslash escapes beyond \n, \t and \uXXXX: Compose Resources unescapes only those, so a `\'`
   would reach the screen with the backslash still on it. Apostrophes are written plainly.
@@ -18,6 +19,7 @@
   languages still has to recognise what they are looking at on the web version.
 -->
 <resources>
+    <string name="loading_indicator_label">Loading</string>
     <string name="action_back">Back</string>
     <string name="action_close">Close</string>
     <string name="action_expand">Expand</string>
@@ -183,6 +185,9 @@
     <string name="search_history_scope">Posts · all boards</string>
     <string name="search_user_history_scope">Users</string>
     <string name="search_history_board_scope">Posts · %1$s</string>
+    <string name="search_user_topics">%1$d topics</string>
+    <string name="search_user_comments">%1$d comments</string>
+    <string name="search_user_joined">Joined %1$s</string>
     <string name="search_board_range">Board scope</string>
     <string name="search_board_range_hint">One board at a time — the site search itself takes only one; the ones you use most sit at the top</string>
     <string name="search_recent_boards">Recently used</string>
@@ -225,6 +230,7 @@
     <string name="message_copied">Message copied</string>
 
     <string name="profile_session_active">Signed in to NodeSeek</string>
+    <string name="profile_member_since">Joined %1$d/%2$d · UID %3$d</string>
     <string name="profile_edit">Edit your space</string>
     <string name="profile_chicken">Drumsticks</string>
     <string name="profile_stars">Stardust</string>
@@ -308,6 +314,7 @@
     <string name="settings_sticker_uniform">One size for every sticker</string>
     <string name="settings_sticker_uniform_hint">On, every sticker is drawn at the same adjustable size; off, each keeps the size it was made at</string>
     <string name="settings_sticker_size">Sticker size</string>
+    <string name="settings_sticker_preview_caption">Stickers are this big</string>
     <string name="settings_text_preview">Preview: what a long passage reads like at this size.</string>
     <string name="settings_content">Content</string>
     <string name="settings_app_links">Site links</string>
@@ -389,6 +396,53 @@
     <string name="doh_limits_hint">A hijacked or poisoned hostname connects again once DoH resolves it. But when the address itself is blocked, the handshake is cut on its SNI, or the connection is reset, no DNS helps and only a proxy will.</string>
     <string name="doh_proxy_hint">While a proxy is on, hostnames are resolved at the proxy and nothing here applies to those requests.</string>
     <string name="doh_webview_hint">Signing in uses the system WebView, which has its own networking and the system private DNS, untouched by this.</string>
+    <string name="settings_network_check_entry">Network check</string>
+    <string name="settings_network_check_entry_hint">Runs one real request and lists the proxy, VPN, DNS and measured speed; the screen to screenshot when reporting that the app is slow</string>
+    <string name="network_check_title">Network check</string>
+    <string name="network_check_rerun">Run again</string>
+    <string name="network_check_running">Checking…</string>
+    <string name="network_check_copy">Copy the report</string>
+    <string name="network_check_copied">Copied</string>
+    <string name="network_check_section_environment">Environment</string>
+    <string name="network_check_device">Device</string>
+    <string name="network_check_os">OS version</string>
+    <string name="network_check_app_version">App version</string>
+    <string name="network_check_transport">Network type</string>
+    <string name="network_check_transport_cellular">Cellular</string>
+    <string name="network_check_transport_ethernet">Ethernet</string>
+    <string name="network_check_transport_other">Other</string>
+    <string name="network_check_transport_none">No connection</string>
+    <string name="network_check_vpn_on">Connected</string>
+    <string name="network_check_vpn_off">Not connected</string>
+    <string name="network_check_metered">Metered</string>
+    <string name="network_check_proxy">Proxy</string>
+    <string name="network_check_proxy_off">Off</string>
+    <string name="network_check_proxy_local">%1$s · localhost %2$d</string>
+    <string name="network_check_proxy_remote">%1$s · remote host %2$d</string>
+    <string name="network_check_proxy_forum_only"> (forum only)</string>
+    <string name="network_check_doh">Encrypted DNS</string>
+    <string name="network_check_doh_off">Off</string>
+    <string name="network_check_custom_tab_app">Links open with</string>
+    <string name="network_check_default_browser">Default browser</string>
+    <string name="network_check_app_none">None</string>
+    <string name="network_check_yes">Yes</string>
+    <string name="network_check_no">No</string>
+    <string name="network_check_section_forum">Forum</string>
+    <string name="network_check_section_updates">Update source</string>
+    <string name="network_check_status">Result</string>
+    <string name="network_check_dns">DNS lookup</string>
+    <string name="network_check_connect">Connect</string>
+    <string name="network_check_tls">TLS handshake</string>
+    <string name="network_check_first_byte">First byte</string>
+    <string name="network_check_download">Download</string>
+    <string name="network_check_rate">Speed</string>
+    <string name="network_check_rate_immeasurable">Too fast to measure</string>
+    <string name="network_check_reused">Connection reused — not measured</string>
+    <string name="network_check_failed">Failed (%1$s)</string>
+    <string name="network_check_hint_title">How to read this report</string>
+    <string name="network_check_hint_layers">Large DNS, connect and first-byte numbers next to a fast download mean waiting; all three small with a slow download means the bandwidth is capped. A progress bar crawling along is the latter.</string>
+    <string name="network_check_hint_custom_tab">Links in posts are handed to the app named above, and the traffic counts as that app’s, not Nodyssey’s. When it is not the same app as the default browser, that gap is usually the whole story behind “slow in the app, fast in the browser” — a VPN’s per-app rules go by app.</string>
+    <string name="network_check_hint_scope">The forum and the update source are probed separately: one side slow means that route is the problem; both slow means this device’s connection.</string>
 
     <string name="about_title">About Nodyssey</string>
     <string name="about_community_title">About · community</string>
@@ -454,6 +508,9 @@
     <string name="about_email">Email us</string>
     <string name="about_deepflood_hint">Sister site · deepflood.com</string>
     <string name="about_licenses_hint">This app’s licence and the third-party libraries it uses</string>
+    <string name="about_crash_export">Export the crash log</string>
+    <string name="about_crash_export_hint">Last crash: %1$s · v%2$s. The log stays on this device; whether it goes to the developer is your call</string>
+    <string name="about_crash_clear">Clear the crash record</string>
     <string name="about_unofficial_notice">Nodyssey is an unofficial, open-source client for the NodeSeek forum and has no affiliation with the people who run the site; posts and comments remain the copyright of the forum and their authors.</string>
 
     <string name="privacy_title">Privacy policy</string>
@@ -1101,6 +1158,8 @@
     <string name="offline_failed_space">Download failed · the images do not fit in the space left</string>
     <string name="offline_failed_network">Download failed · the network dropped</string>
     <string name="offline_failed_unavailable">Download failed · the post is no longer visible</string>
+    <string name="offline_failed_challenge">Download failed · the site is asking for a human check</string>
+    <string name="offline_failed_rate_limited">Download failed · rate limited by the site, try again later</string>
 
     <string name="offline_sheet_title">Offline reading</string>
     <string name="offline_sheet_body">Downloads the body and replies of bookmarked posts to read without a network</string>

--- a/ui/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/ui/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -14,6 +14,7 @@
   proper noun the site itself does not translate.
 -->
 <resources>
+    <string name="loading_indicator_label">載入中</string>
     <string name="action_back">返回</string>
     <string name="action_close">關閉</string>
     <string name="action_expand">展開</string>
@@ -178,6 +179,9 @@
     <string name="search_history_scope">文章 · 全部版塊</string>
     <string name="search_user_history_scope">使用者</string>
     <string name="search_history_board_scope">文章 · %1$s</string>
+    <string name="search_user_topics">主題 %1$d</string>
+    <string name="search_user_comments">評論 %1$d</string>
+    <string name="search_user_joined">加入 %1$s</string>
     <string name="search_board_range">版塊範圍</string>
     <string name="search_board_range_hint">只能選一個版塊，站台搜尋介面本身只支援單版塊；最近使用會置頂</string>
     <string name="search_recent_boards">最近使用</string>
@@ -220,6 +224,7 @@
     <string name="message_copied">訊息已複製</string>
 
     <string name="profile_session_active">NodeSeek 登入工作階段有效</string>
+    <string name="profile_member_since">%1$d年%2$d月 註冊 · UID %3$d</string>
     <string name="profile_edit">編輯個人主頁</string>
     <string name="profile_chicken">雞腿</string>
     <string name="profile_stars">星辰</string>
@@ -303,6 +308,7 @@
     <string name="settings_sticker_uniform">表情統一縮限</string>
     <string name="settings_sticker_uniform_hint">開啟後所有表情一樣大，可調；關閉則各按表情原本的大小顯示</string>
     <string name="settings_sticker_size">表情大小</string>
+    <string name="settings_sticker_preview_caption">表情就這麼大</string>
     <string name="settings_text_preview">預覽：中文長文的閱讀體驗。</string>
     <string name="settings_content">內容</string>
     <string name="settings_app_links">站內連結</string>
@@ -384,6 +390,53 @@
     <string name="doh_limits_hint">網域被劫持、被汙染，換成 DoH 解析就能直連。但如果目標 IP 本身被封、交握時按 SNI 阻斷或者被回 RST，換什麼 DNS 都沒用，那種情況還得掛代理。</string>
     <string name="doh_proxy_hint">開著代理的時候，網域交給代理那邊解析，這裡的設定對走代理的請求不起作用。</string>
     <string name="doh_webview_hint">登入用的是系統 WebView，它走自己的網路和系統的私人 DNS，不受這裡影響。</string>
+    <string name="settings_network_check_entry">網路自檢</string>
+    <string name="settings_network_check_entry_hint">測一次連線，把代理、VPN、DNS 和實際速度列出來；回報「很慢」的時候截這張圖</string>
+    <string name="network_check_title">網路自檢</string>
+    <string name="network_check_rerun">重新檢測</string>
+    <string name="network_check_running">檢測中…</string>
+    <string name="network_check_copy">複製結果</string>
+    <string name="network_check_copied">已複製</string>
+    <string name="network_check_section_environment">環境</string>
+    <string name="network_check_device">機型</string>
+    <string name="network_check_os">系統版本</string>
+    <string name="network_check_app_version">App 版本</string>
+    <string name="network_check_transport">網路類型</string>
+    <string name="network_check_transport_cellular">行動數據</string>
+    <string name="network_check_transport_ethernet">乙太網路</string>
+    <string name="network_check_transport_other">其他</string>
+    <string name="network_check_transport_none">沒有連線</string>
+    <string name="network_check_vpn_on">已連線</string>
+    <string name="network_check_vpn_off">未連線</string>
+    <string name="network_check_metered">按流量計費</string>
+    <string name="network_check_proxy">代理</string>
+    <string name="network_check_proxy_off">關閉</string>
+    <string name="network_check_proxy_local">%1$s · 本機 %2$d</string>
+    <string name="network_check_proxy_remote">%1$s · 遠端主機 %2$d</string>
+    <string name="network_check_proxy_forum_only">（僅論壇）</string>
+    <string name="network_check_doh">加密 DNS</string>
+    <string name="network_check_doh_off">關閉</string>
+    <string name="network_check_custom_tab_app">連結開啟方式</string>
+    <string name="network_check_default_browser">預設瀏覽器</string>
+    <string name="network_check_app_none">沒有</string>
+    <string name="network_check_yes">是</string>
+    <string name="network_check_no">否</string>
+    <string name="network_check_section_forum">論壇</string>
+    <string name="network_check_section_updates">更新來源</string>
+    <string name="network_check_status">結果</string>
+    <string name="network_check_dns">DNS 解析</string>
+    <string name="network_check_connect">建立連線</string>
+    <string name="network_check_tls">TLS 交握</string>
+    <string name="network_check_first_byte">首位元組</string>
+    <string name="network_check_download">下載</string>
+    <string name="network_check_rate">速率</string>
+    <string name="network_check_rate_immeasurable">太快，測不出</string>
+    <string name="network_check_reused">連線重用，沒測到</string>
+    <string name="network_check_failed">失敗（%1$s）</string>
+    <string name="network_check_hint_title">這份報告說明什麼</string>
+    <string name="network_check_hint_layers">DNS、連線、首位元組三項大而下載快，是在等；三項都小而下載慢，才是頻寬被限。進度條一點點爬屬於後者。</string>
+    <string name="network_check_hint_custom_tab">貼文裡的連結是交給上面那個 App 開啟的，流量算它的，不算 Nodyssey 的。它和預設瀏覽器不是同一個的時候，「App 裡慢、瀏覽器裡快」多半就是這個原因——VPN 的分應用代理是按 App 算的。</string>
+    <string name="network_check_hint_scope">論壇和更新來源分開測：只有一邊慢，是那條線路的問題；兩邊都慢，是這台裝置的連線。</string>
 
     <string name="about_title">關於 Nodyssey</string>
     <string name="about_community_title">關於 · 社群</string>
@@ -449,6 +502,9 @@
     <string name="about_email">聯絡我們</string>
     <string name="about_deepflood_hint">姊妹站 · deepflood.com</string>
     <string name="about_licenses_hint">本應用程式授權與第三方函式庫清單</string>
+    <string name="about_crash_export">匯出當機日誌</string>
+    <string name="about_crash_export_hint">上次當機：%1$s · v%2$s。日誌只存在本機，要不要傳給開發者由你決定</string>
+    <string name="about_crash_clear">清除當機記錄</string>
     <string name="about_unofficial_notice">本應用程式是 NodeSeek 論壇的非官方開源用戶端，與站台營運方無隸屬關係；文章與評論內容的著作權歸論壇及原作者所有。</string>
 
     <string name="privacy_title">隱私協議</string>
@@ -1094,6 +1150,8 @@
     <string name="offline_failed_space">下載失敗 · 圖片超出剩餘空間</string>
     <string name="offline_failed_network">下載失敗 · 網路中斷</string>
     <string name="offline_failed_unavailable">下載失敗 · 文章已不可見</string>
+    <string name="offline_failed_challenge">下載失敗 · 需要人機驗證</string>
+    <string name="offline_failed_rate_limited">下載失敗 · 站點限流，稍後再試</string>
 
     <string name="offline_sheet_title">離線閱讀</string>
     <string name="offline_sheet_body">下載收藏文章的內文與回覆，斷網時照常看</string>

--- a/ui/src/commonMain/kotlin/io/github/nodyssey/NodysseyRoot.kt
+++ b/ui/src/commonMain/kotlin/io/github/nodyssey/NodysseyRoot.kt
@@ -76,7 +76,11 @@ fun NodysseyRoot(
     // Outside the theme, because the strings its own screens read resolve against this and because
     // a language is not a colour. Changing it recomposes the tree underneath in the new language —
     // no restart, no black frame, and the scroll position and back stack stay where they were.
-    ProvideAppLanguage(settings.appLanguage) {
+    // The nullable read, not the defaulted `settings`: handing the placeholder's SYSTEM to a frame
+    // the store has not answered yet would reset the language `attachBaseContext` already applied,
+    // and flash the device's language on every cold start — the same reason `ApplyAppLanguage`
+    // above takes the nullable.
+    ProvideAppLanguage(storedSettings?.appLanguage) {
         PlazaTheme(
             darkTheme = darkTheme,
             // The three sources differ only in where the seed came from; 动态取色 is the one that can

--- a/ui/src/commonMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.kt
+++ b/ui/src/commonMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.kt
@@ -16,10 +16,19 @@ import io.github.nodyssey.data.settings.AppLanguage
  *
  * Android has a lever anyway, and the Android actual explains it. iOS and the desktop JVM do not,
  * which is what [appLanguageAppliesOnRestart] says out loud.
+ *
+ * Null means the settings store has not answered yet, and the honest move is to change nothing:
+ * on Android the shell's `attachBaseContext` has already put the *stored* choice into the
+ * configuration this composition starts from, so the first frames are right as they stand.
+ * Substituting [AppLanguage.SYSTEM] for "no answer yet" — which is what a placeholder
+ * `UserSettings()` would do — reset that to the device's language for a frame or two on every
+ * cold start, and a reader whose chosen language differs from the device's watched the whole
+ * screen flash through the wrong one. The same null-guard `ApplyAppLanguage` documents, for the
+ * same reason.
  */
 @Composable
 expect fun ProvideAppLanguage(
-    language: AppLanguage,
+    language: AppLanguage?,
     content: @Composable () -> Unit,
 )
 

--- a/ui/src/iosMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.ios.kt
+++ b/ui/src/iosMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.ios.kt
@@ -13,7 +13,7 @@ import io.github.nodyssey.data.settings.AppLanguage
  */
 @Composable
 actual fun ProvideAppLanguage(
-    language: AppLanguage,
+    language: AppLanguage?,
     content: @Composable () -> Unit,
 ) = content()
 

--- a/ui/src/jvmMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.jvm.kt
+++ b/ui/src/jvmMain/kotlin/io/github/nodyssey/ui/settings/AppLanguageEnvironment.jvm.kt
@@ -13,7 +13,7 @@ import io.github.nodyssey.data.settings.AppLanguage
  */
 @Composable
 actual fun ProvideAppLanguage(
-    language: AppLanguage,
+    language: AppLanguage?,
     content: @Composable () -> Unit,
 ) = content()
 


### PR DESCRIPTION
## 背景

第二轮 MAD 体检（基线 1.2.13-dev.1）的修复。上轮三个 P1 复核全部在位；本轮无新 P0/P1，发现集中在网络自检（#121）与三语 i18n（#120）两个并行分支的接缝处。

## 改了什么

**补译 + 守卫（F-19，de8e8844）**

- 58 个只有简中的键补齐 en / zh-rTW：`network_check_*` 整族（约 45 键，整个网络自检屏）、`about_crash_*` 三键、`loading_indicator_label`（TalkBack 加载名）、`offline_failed_challenge`/`offline_failed_rate_limited`、`profile_member_since`、`search_user_*`、`settings_sticker_preview_caption`；designsys 另补 `richtext_sticker_fallback` 的 en。
- 新增 `StringCatalogParityTest`（guard 家族）：三份 strings.xml 逐键核对，缺席必须在显式 allowlist 里声明（74 个「各语言相同」+ 4 个「繁中可回落」）。清单双向精确——漏译报错，已译却还在清单上也报错。附带占位符一致性检查（译文丢了或改号 `%1$s` 只在渲染时炸，现在编译期就拦）。

**冷启动语言闪帧（F-20，c5ac369f）**

- `ProvideAppLanguage` 改收 `AppLanguage?`：settings store 未回答时透传 `attachBaseContext` 已设好的 configuration，不再拿兜底 `UserSettings()` 的 SYSTEM 把进程 locale 重置一遍。此前选了非设备语言的用户每次冷启动先画一帧设备语言、store 回答后整树翻转。`ApplyAppLanguage` 那半早有同款 null 守卫，此处补齐。
- 三平台 actual 同步签名；`AppLanguageRecompositionTest` 新增 null 分支断言（不换字符串、不动进程默认 locale）。

## 审阅要点

- 译文词汇对齐既有两份语言文件：tw 用 連線/連接埠/預設/TLS 交握/逾時，en 沿用弯引号文风。
- allowlist 的取舍：三个语言名（简体中文/繁體中文/English）各用自己的语言写，属刻意不译；繁中另外 4 键（`ruling_reason` 等语法胶水、`AC娘`）简繁同形，回落无损。
- Android null 分支与非空分支共用同一 `CompositionLocalProvider` 结构，store 回答瞬间不产生子树重建。

## 验证

- `:ui` / `:designsys` 全量 `testAndroidHostTest` 通过（含三个 guard 与语言测试）。
- Android / JVM / iosSimulatorArm64 三目标编译通过；`spotlessApply` 干净。

体检未修项（有意留出）：1.2.13 发版前重录 Baseline Profile；Renovate App 待安装。

🤖 Generated with [Claude Code](https://claude.com/claude-code)